### PR TITLE
spinlock: balance failed trylock critical sections

### DIFF
--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -96,6 +96,8 @@ int spinlock_trylock(spinlock_t lock)
 
 	if (!ret)
 		lock->cpu = cur_cpu();
+	else
+		exit_critical();
 
 	return ret;
 }
@@ -127,6 +129,5 @@ void spinlock_release(spinlock_t lock)
         __sync_lock_release(&lock->locked);
         exit_critical();
 }
-
 
 


### PR DESCRIPTION
### Summary

Fixes a critical section depth imbalance in `spinlock_trylock()`.

### Problem

When `spinlock_trylock()` is called, it enters a critical section at the start. However, if lock acquisition fails, it previously returned without calling `exit_critical()`. This leaks a critical section entry (e.g., leaving preemption or interrupts disabled), which can corrupt system scheduling state and cause lockups or unexpected behavior later.

### Solution

- Add `exit_critical()` call to the failure path of `spinlock_trylock()` to ensure `enter_critical()` and `exit_critical()` remain balanced regardless of whether the lock was successfully acquired.
