### PR TITLE
palloc: defer bitmap updates until allocation succeeds

### DIFF
--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -227,7 +227,7 @@ void* palloc(void)
 static uint64 malloc_core(page_t page, uint64 blocks)
 {
         int i, j, mask;
-        uint64 count = 0, start;
+        uint64 count = 0, start = 0, k;
 
         if(!page)
                 return -1;
@@ -236,12 +236,14 @@ static uint64 malloc_core(page_t page, uint64 blocks)
                 mask = 0x80;
                 for(j = 0; j < 8; j++) {
                         if((page->bitmap[i] & mask) == 0) {
-                                page->bitmap[i] |= mask;
                                 if(count == 0) {
                                         start = i * 8 + j;
                                 }
                                 count++;
                                 if(count == blocks) {
+                                        for(k = start; k < start + blocks; k++) {
+                                                page->bitmap[k / 8] |= (0x80 >> (k % 8));
+                                        }
                                         page->used += blocks;
                                         // printf("malloc_core: %d->%d\n", start, start + blocks);
                                         return start + PAGE_BLOCK;


### PR DESCRIPTION
Summary

Fixes bitmap corruption when contiguous allocation fails in `malloc_core()`.

### Problem

`malloc_core()` previously marked each free bitmap bit as allocated while scanning for a contiguous range. If the scan later encountered an allocated bit, or failed to find enough contiguous blocks, those tentative bitmap updates were not rolled back.

This could leave blocks marked as used even though the allocation did not succeed. As a result, the bitmap could become inconsistent with `page->used`, causing free blocks to be lost from future allocations.

### Solution

- Track the start and length of a candidate contiguous range while scanning.
- Defer bitmap updates until a range with the requested number of blocks has been found.
- Mark the selected range in the bitmap only after allocation success, then update `page->used`.