### PR TITLE
sched: replace polling with runnable queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: Caffeinix CI
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: qemu-runtime-logs
-          path: output/tests/*.log
+          path: |
+            output/tests/*.log
+            output/tests/scheduler-benchmark.json

--- a/arch/riscv/include/riscv.h
+++ b/arch/riscv/include/riscv.h
@@ -72,6 +72,12 @@ static inline void sie_w(uint64 v)
         asm volatile("csrw sie, %0" : : "r"(v));
 }
 
+#define SIP_SSIP (1L << 1)
+static inline void sip_clear_ssip(void)
+{
+	asm volatile("csrc sip, %0" : : "r"(SIP_SSIP) : "memory");
+}
+
 #define SSTATUS_SPP (1L << 8)  // Previous mode, 1=Supervisor, 0=User
 #define SSTATUS_SPIE (1L << 5) // Supervisor Previous Interrupt Enable
 #define SSTATUS_FS_MASK (3L << 13)

--- a/arch/riscv/include/riscv.h
+++ b/arch/riscv/include/riscv.h
@@ -166,6 +166,11 @@ static inline uint64 time_r(void)
 	return value;
 }
 
+static inline void wait_for_interrupt(void)
+{
+	asm volatile("wfi" : : : "memory");
+}
+
 #endif
 
 #endif

--- a/arch/riscv/include/sbi.h
+++ b/arch/riscv/include/sbi.h
@@ -12,5 +12,6 @@ int64 sbi_set_timer(uint64 deadline);
 int64 sbi_hart_start(uint64 hart_id, uint64 start_address,
 		     uint64 opaque);
 int64 sbi_hart_get_status(uint64 hart_id, uint64 *status);
+int64 sbi_send_ipi(uint64 hart_id);
 
 #endif

--- a/arch/riscv/sbi.c
+++ b/arch/riscv/sbi.c
@@ -5,6 +5,7 @@
 #define SBI_EXT_BASE 0x10
 #define SBI_EXT_TIME 0x54494d45
 #define SBI_EXT_HSM 0x48534d
+#define SBI_EXT_IPI 0x735049
 
 #define SBI_BASE_GET_SPEC_VERSION 0
 #define SBI_BASE_GET_IMPL_ID 1
@@ -14,6 +15,7 @@
 #define SBI_TIME_SET_TIMER 0
 #define SBI_HSM_HART_START 0
 #define SBI_HSM_HART_GET_STATUS 2
+#define SBI_IPI_SEND_IPI 0
 
 #define SBI_SUCCESS 0
 
@@ -88,6 +90,8 @@ void sbi_init(int requested_cpus)
 		PANIC("SBI TIME extension required");
 	if (requested_cpus > 1 && !sbi_extension_available(SBI_EXT_HSM))
 		PANIC("SBI HSM extension required");
+	if (requested_cpus > 1 && !sbi_extension_available(SBI_EXT_IPI))
+		PANIC("SBI IPI extension required");
 }
 
 void sbi_report(void)
@@ -127,5 +131,15 @@ int64 sbi_hart_get_status(uint64 hart_id, uint64 *status)
 	                   0, 0, 0, 0, 0);
 	if (!result.error)
 		*status = result.value;
+	return result.error;
+}
+
+int64 sbi_send_ipi(uint64 hart_id)
+{
+	struct sbi_return result;
+
+	/* A one-bit mask based at hart_id also handles sparse hart IDs. */
+	result = sbi_ecall(SBI_EXT_IPI, SBI_IPI_SEND_IPI, 1, hart_id,
+	                   0, 0, 0, 0);
 	return result.error;
 }

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -76,8 +76,10 @@ void kernel_trap(void)
                 PANIC("kerneltrap");
         }
 
-        if(which_dev == 2 && cur_thread() &&
-           cur_thread()->state == THREAD_RUNNING)
+	if(which_dev == 2 || which_dev == 3)
+                scheduler_request_resched();
+
+        if(scheduler_should_resched())
                 yield();
 
         sepc_w(sepc);
@@ -119,7 +121,10 @@ void user_trap_entry(void)
         if(killed(p))
                 exit(-1);
 
-        if(which_dev == 2)
+	if(which_dev == 2 || which_dev == 3)
+                scheduler_request_resched();
+
+        if(scheduler_should_resched())
                 yield();
 
         user_trap_ret();

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -74,7 +74,8 @@ void kernel_trap(void)
                 PANIC("kerneltrap");
         }
 
-        if(which_dev == 2 && cur_proc() != 0 && cur_proc()->state == RUNNING)
+        if(which_dev == 2 && cur_thread() &&
+           cur_thread()->state == THREAD_RUNNING)
                 yield();
 
         sepc_w(sepc);
@@ -94,21 +95,21 @@ void user_trap_entry(void)
 
         stvec_w((uint64)kernel_vec);
 
-        p->cur_thread->trapframe->epc = sepc_r();
+        cur_thread()->trapframe->epc = sepc_r();
 
         if(cause == 8) {
                 if(killed(p))
                         exit(-1);
 
                 /* System call */
-                p->cur_thread->trapframe->epc += 4;
+                cur_thread()->trapframe->epc += 4;
                 intr_on();
                 syscall();
         } else {
                 if((which_dev = dev_intr(cause)) == 0) {
                         printf("scause %p\n", cause);
                         printf("sepc=%p stval=%p\n",
-                               p->cur_thread->trapframe->epc, stval_r());
+                               cur_thread()->trapframe->epc, stval_r());
                         PANIC("user_trap_entry");
                 }
         }
@@ -137,11 +138,11 @@ void user_trap_ret(void)
         trampoline_uservec = TRAMPOLINE + (user_vec - trampoline);
         stvec_w(trampoline_uservec);
 
-        p->cur_thread->trapframe->kernel_satp = satp_r();
-	p->cur_thread->trapframe->kernel_sp =
-		p->cur_thread->kstack + KSTACK_SIZE;
-        p->cur_thread->trapframe->kernel_hartid = tp_r();
-        p->cur_thread->trapframe->kernel_trap = (uint64)user_trap_entry;
+        cur_thread()->trapframe->kernel_satp = satp_r();
+	cur_thread()->trapframe->kernel_sp =
+		cur_thread()->kstack + KSTACK_SIZE;
+        cur_thread()->trapframe->kernel_hartid = tp_r();
+        cur_thread()->trapframe->kernel_trap = (uint64)user_trap_entry;
 
         sstatus = sstatus_r();
         /* Set the interrupt is from user mode */
@@ -153,7 +154,7 @@ void user_trap_ret(void)
         sstatus_w(sstatus);
 
         /* Write the epc. It will be set to 0 if the process is first started */
-        sepc_w(p->cur_thread->trapframe->epc);
+        sepc_w(cur_thread()->trapframe->epc);
 
         satp = MAKE_SATP(p->pagetable);
 

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -32,9 +32,15 @@ static void tick_intr(void)
 static int dev_intr(uint64 scause)
 {
         int irq = 0;
-        /* This is a supervisor external interrupt via PLIC */
+
         if((scause & 0x8000000000000000L) &&
-           (scause & 0xff) == 9) {
+           (scause & 0xff) == 1) {
+                sip_clear_ssip();
+                return 3;
+        }
+        /* This is a supervisor external interrupt via PLIC */
+        else if((scause & 0x8000000000000000L) &&
+                (scause & 0xff) == 9) {
                 /* Get interrupt number from PLIC */
                 irq = plic_claim();
 		if (irq && irq_dispatch(irq) != IRQ_HANDLED)
@@ -173,5 +179,5 @@ void trap_init_lock(void)
 void trap_init(void)
 {
         stvec_w((uint64)kernel_vec);
-	sie_w(sie_r() | SIE_SEIE);
+	sie_w(sie_r() | SIE_SEIE | SIE_SSIE);
 }

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -22,10 +22,6 @@ static void tick_intr(void)
         spinlock_acquire(&tick_lock);
 
         tick_count ++;
-        if(tick_count % 10 == 0) {
-                // printf("timer interrupt\n");
-        }
-        wakeup((void*)&tick_count);
         spinlock_release(&tick_lock);
 }
 

--- a/drivers/tty/serial/uart.c
+++ b/drivers/tty/serial/uart.c
@@ -3,7 +3,6 @@
 #include <device_model.h>
 #include <irq.h>
 #include <mystring.h>
-#include <process.h>
 #include <spinlock.h>
 #include <tty.h>
 #include <uart.h>
@@ -18,7 +17,7 @@ static void uart_start_transmit_locked(struct uart_port *port)
 
 		port->operations->put_char(port, character);
 		port->transmit_tail++;
-		wakeup_(&port->transmit_tail);
+		wait_queue_wake_all(&port->transmit_wait);
 	}
 	port->operations->enable_tx_irq(
 		port, port->transmit_tail != port->transmit_head);
@@ -36,7 +35,7 @@ static int64 uart_tty_write(struct tty *tty, const char *buffer,
 	while (written < count) {
 		while (port->transmit_head - port->transmit_tail ==
 		       UART_TX_BUFFER_SIZE)
-			sleep_(&port->transmit_tail, &port->lock);
+			wait_queue_sleep(&port->transmit_wait, &port->lock);
 		port->transmit[port->transmit_head % UART_TX_BUFFER_SIZE] =
 			buffer[written++];
 		port->transmit_head++;
@@ -109,6 +108,7 @@ int uart_add_one_port(struct uart_port *port)
 	    !port->operations->enable_tx_irq)
 		return DRIVER_ERR_INVAL;
 	spinlock_init(&port->lock, "UART port");
+	wait_queue_init(&port->transmit_wait, "UART transmit");
 	port->transmit_head = 0;
 	port->transmit_tail = 0;
 	status = port->operations->startup(port);

--- a/drivers/tty/serial/uart.c
+++ b/drivers/tty/serial/uart.c
@@ -1,5 +1,6 @@
 #include <console.h>
 #include <char_device.h>
+#include <debug.h>
 #include <device_model.h>
 #include <irq.h>
 #include <mystring.h>
@@ -150,6 +151,10 @@ void uart_remove_one_port(struct uart_port *port)
 {
 	if (!port || !port->registered)
 		return;
+	spinlock_acquire(&port->lock);
+	if (!wait_queue_empty(&port->transmit_wait))
+		PANIC("remove UART with waiters");
+	spinlock_release(&port->lock);
 	console_unregister(&port->console);
 	port->operations->enable_rx_irq(port, 0);
 	port->operations->enable_tx_irq(port, 0);

--- a/drivers/tty/tty.c
+++ b/drivers/tty/tty.c
@@ -76,7 +76,7 @@ static int64 tty_read(struct tty *tty, int user_destination,
 				spinlock_release(&tty->lock);
 				return total;
 			}
-			sleep_(&tty->read_position, &tty->lock);
+			wait_queue_sleep(&tty->read_wait, &tty->lock);
 		}
 		if (tty->read_position == tty->commit_position &&
 		    tty->eof_pending) {
@@ -241,7 +241,7 @@ void tty_receive_char(struct tty *tty, int character)
 	if (canonical && character == tty->termios.control[LINUX_VEOF]) {
 		tty->commit_position = tty->edit_position;
 		tty->eof_pending = 1;
-		wakeup_(&tty->read_position);
+		wait_queue_wake_all(&tty->read_wait);
 		spinlock_release(&tty->lock);
 		return;
 	}
@@ -255,7 +255,7 @@ void tty_receive_char(struct tty *tty, int character)
 	if (!canonical || character == '\n' ||
 	    tty->edit_position - tty->read_position == TTY_INPUT_SIZE) {
 		tty->commit_position = tty->edit_position;
-		wakeup_(&tty->read_position);
+		wait_queue_wake_all(&tty->read_wait);
 	}
 	spinlock_release(&tty->lock);
 }
@@ -305,6 +305,7 @@ int tty_register(struct tty *tty, const char *prefix, int line,
 	tty->driver_data = driver_data;
 	tty_default_termios(tty);
 	spinlock_init(&tty->lock, tty->name);
+	wait_queue_init(&tty->read_wait, tty->name);
 	tty->registered = 1;
 	tty_core.devices[selected] = tty;
 	if (!tty_core.console)

--- a/drivers/tty/tty.c
+++ b/drivers/tty/tty.c
@@ -331,6 +331,12 @@ int tty_unregister(struct tty *tty)
 
 	if (!tty || !tty->registered)
 		return VFS_ERR_NOENT;
+	spinlock_acquire(&tty->lock);
+	if (!wait_queue_empty(&tty->read_wait)) {
+		spinlock_release(&tty->lock);
+		return VFS_ERR_BUSY;
+	}
+	spinlock_release(&tty->lock);
 	status = char_device_node_unregister(tty->name);
 	if (status < 0)
 		return status;

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -3,7 +3,7 @@ EXTRA_LDFLAGS := -T ./kernel.ld
 CFLAGS_file.o := 
 
 
-obj-y += string.o palloc.o spinlock.o thread.o \
+obj-y += string.o palloc.o spinlock.o thread.o wait.o \
 sleeplock.o switchto.o trampoline.o process.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o main.o

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -201,13 +201,13 @@ int exec_linux(char *path, char **argv, char **envp)
 	p->brk = sz;
 	p->brk_start = sz;
 	p->mmap_top = USER_MMAP_TOP;
-	p->cur_thread->trapframe->a0 = argc;
-	p->cur_thread->trapframe->a1 = sp + sizeof(uint64);
-	p->cur_thread->trapframe->sp = sp;
-	p->cur_thread->trapframe->epc = elf.entry;
-	memset(p->cur_thread->trapframe->f, 0,
-	       sizeof(p->cur_thread->trapframe->f));
-	p->cur_thread->trapframe->fcsr = 0;
+	cur_thread()->trapframe->a0 = argc;
+	cur_thread()->trapframe->a1 = sp + sizeof(uint64);
+	cur_thread()->trapframe->sp = sp;
+	cur_thread()->trapframe->epc = elf.entry;
+	memset(cur_thread()->trapframe->f, 0,
+	       sizeof(cur_thread()->trapframe->f));
+	cur_thread()->trapframe->fcsr = 0;
 
 	for (name = path_p = path; *path_p; path_p++) {
 		if (*path_p == '/')

--- a/kernel/fs/lwext4/caffeinix.c
+++ b/kernel/fs/lwext4/caffeinix.c
@@ -190,7 +190,7 @@ static int ext4fs_block_close(struct ext4_blockdev *blockdev)
 
 static void ext4fs_lock_mount(void)
 {
-	thread_t current = cur_proc()->cur_thread;
+	thread_t current = cur_thread();
 
 	if (ext4fs_lock_owner == current) {
 		ext4fs_lock_depth++;
@@ -203,7 +203,7 @@ static void ext4fs_lock_mount(void)
 
 static void ext4fs_unlock_mount(void)
 {
-	if (ext4fs_lock_owner != cur_proc()->cur_thread ||
+	if (ext4fs_lock_owner != cur_thread() ||
 	    !ext4fs_lock_depth)
 		PANIC("ext4 lock owner");
 	if (--ext4fs_lock_depth)

--- a/kernel/fs/virtio_disk.c
+++ b/kernel/fs/virtio_disk.c
@@ -296,6 +296,8 @@ static int virtio_submit(struct virtio_disk *disk, uint32 type,
 	result = request.result;
 	disk->info[indices[0]].request = 0;
 	free_chain(disk, indices[0]);
+	if (!wait_queue_empty(&request.completion))
+		PANIC("virtio completion waiters");
 	spinlock_release(&disk->lock);
 	return result;
 }

--- a/kernel/fs/virtio_disk.c
+++ b/kernel/fs/virtio_disk.c
@@ -4,9 +4,9 @@
 #include <mystring.h>
 #include <palloc.h>
 #include <irq.h>
-#include <process.h>
 #include <spinlock.h>
 #include <virtio_disk.h>
+#include <wait.h>
 
 #define NUM VIRTIO_DES_NUM
 #define VIRTIO_SECTOR_SIZE 512
@@ -17,6 +17,7 @@
 struct virtio_request {
 	volatile uint8 pending;
 	int result;
+	struct wait_queue completion;
 };
 
 struct virtio_disk {
@@ -37,6 +38,7 @@ struct virtio_disk {
 	} info[VIRTIO_DES_NUM];
 	struct virtio_blk_req requests[VIRTIO_DES_NUM];
 	struct spinlock lock;
+	struct wait_queue descriptor_wait;
 };
 
 static struct virtio_disk disks[VIRTIO_MMIO_SLOTS];
@@ -110,6 +112,7 @@ static int virtio_disk_init_one(struct virtio_disk *disk, int index)
 	    *R(disk, VIRTIO_MMIO_VENDOR_ID) != 0x554d4551)
 		return 0;
 	spinlock_init(&disk->lock, "virtio disk");
+	wait_queue_init(&disk->descriptor_wait, "virtio descriptors");
 
 	*R(disk, VIRTIO_MMIO_STATUS) = status;
 	status |= VIRTIO_CONFIG_S_ACKNOWLEDGE;
@@ -208,7 +211,6 @@ static void free_desc(struct virtio_disk *disk, int index)
 	disk->desc[index].flags = 0;
 	disk->desc[index].next = 0;
 	disk->free[index] = 1;
-	wakeup(&disk->free[0]);
 }
 
 static void free_chain(struct virtio_disk *disk, int index)
@@ -223,6 +225,7 @@ static void free_chain(struct virtio_disk *disk, int index)
 			break;
 		index = next;
 	}
+	wait_queue_wake_all(&disk->descriptor_wait);
 }
 
 static int alloc_descs(struct virtio_disk *disk, int *indices, int count)
@@ -250,9 +253,10 @@ static int virtio_submit(struct virtio_disk *disk, uint32 type,
 
 	request.pending = 1;
 	request.result = -1;
+	wait_queue_init(&request.completion, "virtio completion");
 	spinlock_acquire(&disk->lock);
 	while (alloc_descs(disk, indices, descriptor_count))
-		sleep(&disk->free[0], &disk->lock);
+		wait_queue_sleep(&disk->descriptor_wait, &disk->lock);
 
 	header = &disk->requests[indices[0]];
 	header->type = type;
@@ -288,7 +292,7 @@ static int virtio_submit(struct virtio_disk *disk, uint32 type,
 	*R(disk, VIRTIO_MMIO_QUEUE_NOTIFY) = 0;
 
 	while (request.pending)
-		sleep(&request, &disk->lock);
+		wait_queue_sleep(&request.completion, &disk->lock);
 	result = request.result;
 	disk->info[indices[0]].request = 0;
 	free_chain(disk, indices[0]);
@@ -321,7 +325,7 @@ void virtio_disk_intr(int irq)
 			PANIC("virtio disk completion");
 		request->result = disk->info[id].status ? -1 : 0;
 		request->pending = 0;
-		wakeup(request);
+		wait_queue_wake_one(&request->completion);
 		disk->used_idx++;
 	}
 	spinlock_release(&disk->lock);

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -15,6 +15,7 @@
 #include <spinlock.h>
 #include <riscv.h>
 #include <file.h>
+#include <wait.h>
 
 /* TODO:Delete this macro */
 // #define PROCESS_NO_SCHED                1
@@ -58,6 +59,7 @@ typedef struct process{
 	uint64 signal_mask;
 	struct process_signal_action signal_actions[64];
         struct process *parent;
+        struct wait_queue child_wait;
         trapframe_info_t tinfo;
         int tnums;
         thread_t thread[PROC_MAXTHREAD];

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -17,9 +17,6 @@
 #include <file.h>
 #include <wait.h>
 
-/* TODO:Delete this macro */
-// #define PROCESS_NO_SCHED                1
-
 typedef enum process_state{
         PROCESS_LIVE,
         PROCESS_ZOMBIE,
@@ -75,10 +72,6 @@ int process_fork(uint64 child_stack);
 int process_wait(int target, uint64 status_address, int nohang);
 
 int killed(process_t p);
-void sleep(void* chan, spinlock_t lk);
-void wakeup(void* chan);
-void sleep_(void* chan, spinlock_t lk);
-void wakeup_(void* chan);
 int either_copyout(int user_dst, uint64 dst, void* src, uint64 len);
 int either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 /* User init for first process */

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -20,12 +20,8 @@
 // #define PROCESS_NO_SCHED                1
 
 typedef enum process_state{
-        UNUSED,
-        ALLOCED,
-        RUNNABLE,
-        RUNNING,
-        SLEEPING,
-        ZOMBIE,
+        PROCESS_LIVE,
+        PROCESS_ZOMBIE,
 }process_state_t;
 
 typedef struct trapframe_info {
@@ -56,8 +52,6 @@ typedef struct process{
 	uint32 umask;
         file_t ofile[NOFILE];
 	uint8 fd_flags[NOFILE];
-        void *sleep_chan;
-
         int exit_state;
         int killed;
 	uint64 clear_child_tid;
@@ -67,7 +61,6 @@ typedef struct process{
         trapframe_info_t tinfo;
         int tnums;
         thread_t thread[PROC_MAXTHREAD];
-        thread_t cur_thread;
         
         struct list all_tag;
 }*process_t;

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -28,6 +28,7 @@ void scheduler_init(void);
 void scheduler(void);
 void yield(void);
 void sched(void);
+void scheduler_exit(void);
 void scheduler_make_runnable(thread_t thread);
 void scheduler_request_resched(void);
 int scheduler_should_resched(void);

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -17,6 +17,7 @@ typedef struct cpu {
 	struct device_node *of_node;
 	volatile uint8 online;
 	uint8 idle;
+	uint8 need_resched;
 }*cpu_t;
 
 uint8 cpuid(void);
@@ -28,5 +29,7 @@ void scheduler(void);
 void yield(void);
 void sched(void);
 void scheduler_make_runnable(thread_t thread);
+void scheduler_request_resched(void);
+int scheduler_should_resched(void);
 
 #endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -22,9 +22,11 @@ uint8 cpuid(void);
 cpu_t cur_cpu(void);
 thread_t cur_thread(void);
 process_t cur_proc(void);
+void scheduler_init(void);
 void scheduler(void);
 void yield(void);
 void sched(void);
+void scheduler_make_runnable(thread_t thread);
 void scheduler_wake(thread_t thread);
 
 #endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -8,8 +8,7 @@ struct device_node;
 
 typedef struct cpu {
         struct context context;
-        // thread_t thread;
-        process_t proc;
+        thread_t current;
         /* Nesting Depth */
         uint8 lock_nest_depth;
         /* Is the interrupt enabled before locking */
@@ -21,10 +20,11 @@ typedef struct cpu {
 
 uint8 cpuid(void);
 cpu_t cur_cpu(void);
-// thread_t cur_thread();
-process_t cur_proc();
+thread_t cur_thread(void);
+process_t cur_proc(void);
 void scheduler(void);
 void yield(void);
 void sched(void);
+void scheduler_wake(thread_t thread);
 
 #endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -29,6 +29,7 @@ void scheduler(void);
 void yield(void);
 void sched(void);
 void scheduler_exit(void);
+void scheduler_exit_locked(void);
 void scheduler_make_runnable(thread_t thread);
 void scheduler_request_resched(void);
 int scheduler_should_resched(void);

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -28,6 +28,5 @@ void scheduler(void);
 void yield(void);
 void sched(void);
 void scheduler_make_runnable(thread_t thread);
-void scheduler_wake(thread_t thread);
 
 #endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -16,6 +16,7 @@ typedef struct cpu {
 	uint64 hart_id;
 	struct device_node *of_node;
 	volatile uint8 online;
+	uint8 idle;
 }*cpu_t;
 
 uint8 cpuid(void);

--- a/kernel/include/sleeplock.h
+++ b/kernel/include/sleeplock.h
@@ -2,14 +2,17 @@
 #define __CAFFEINIX_KERNEL_SLEEP_LOCK_H
 
 #include <spinlock.h>
+#include <wait.h>
+
+struct thread;
 
 typedef struct sleeplock{
         uint8 locked;
         struct spinlock lk;
+        struct wait_queue waiters;
 
         const char* name;
-        /* Point a process that held this lock */
-        void* p;
+        struct thread *owner;
 }*sleeplock_t;
 
 void sleeplock_init(sleeplock_t lk, const char* name);

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -107,7 +107,6 @@ typedef struct thread {
         trapframe_t trapframe;
         struct context context;
 
-        void *sleep_chan;
         process_t home;
         struct list run_node;
         uint8 on_runqueue;

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -18,6 +18,7 @@
 #include <riscv.h>
 
 typedef struct process *process_t;
+struct wait_queue;
 
 typedef enum thread_state {
         THREAD_UNUSED,
@@ -110,6 +111,9 @@ typedef struct thread {
         process_t home;
         struct list run_node;
         uint8 on_runqueue;
+        struct wait_queue *waiting_on;
+        struct list wait_node;
+        uint8 on_waitqueue;
 }*thread_t;
 
 extern struct thread thread[NTHREAD];

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -108,7 +108,8 @@ typedef struct thread {
 
         void *sleep_chan;
         process_t home;
-        struct list all_tag;
+        struct list run_node;
+        uint8 on_runqueue;
 }*thread_t;
 
 extern struct thread thread[NTHREAD];

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -20,12 +20,12 @@
 typedef struct process *process_t;
 
 typedef enum thread_state {
-        NUSED,
-        NREADY,
-        READY,
-        RESETING,
-        ACTIVE,
-        DIED,
+        THREAD_UNUSED,
+        THREAD_ALLOCATED,
+        THREAD_RUNNABLE,
+        THREAD_RUNNING,
+        THREAD_SLEEPING,
+        THREAD_EXITED,
 }thread_state_t;
 
 typedef struct context {

--- a/kernel/include/tty.h
+++ b/kernel/include/tty.h
@@ -5,6 +5,7 @@
 #include <linux_uapi.h>
 #include <spinlock.h>
 #include <typedefs.h>
+#include <wait.h>
 
 #define TTY_MAX_DEVICES 8
 #define TTY_INPUT_SIZE 256
@@ -18,6 +19,7 @@ struct tty_operations {
 
 struct tty {
 	struct spinlock lock;
+	struct wait_queue read_wait;
 	int registered;
 	int line;
 	char name[CHAR_DEVICE_NAME_MAX + 1];

--- a/kernel/include/uart.h
+++ b/kernel/include/uart.h
@@ -23,6 +23,7 @@ struct uart_operations {
 
 struct uart_port {
 	struct spinlock lock;
+	struct wait_queue transmit_wait;
 	void *membase;
 	uint64 mapbase;
 	uint64 mapsize;

--- a/kernel/include/wait.h
+++ b/kernel/include/wait.h
@@ -1,0 +1,22 @@
+#ifndef __CAFFEINIX_KERNEL_WAIT_H
+#define __CAFFEINIX_KERNEL_WAIT_H
+
+#include <list.h>
+#include <spinlock.h>
+
+struct thread;
+
+typedef struct wait_queue {
+	struct spinlock lock;
+	struct list waiters;
+	const char *name;
+} *wait_queue_t;
+
+void wait_queue_init(wait_queue_t queue, const char *name);
+void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock);
+int wait_queue_wake_one(wait_queue_t queue);
+int wait_queue_wake_all(wait_queue_t queue);
+int wait_queue_wake_thread(struct thread *thread);
+int wait_queue_empty(wait_queue_t queue);
+
+#endif

--- a/kernel/include/wait.h
+++ b/kernel/include/wait.h
@@ -12,6 +12,10 @@ typedef struct wait_queue {
 	const char *name;
 } *wait_queue_t;
 
+/*
+ * The owner must prevent new sleepers and verify that the queue is empty
+ * before reclaiming or reinitializing the storage containing it.
+ */
 void wait_queue_init(wait_queue_t queue, const char *name);
 void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock);
 int wait_queue_wake_one(wait_queue_t queue);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -69,6 +69,7 @@ void main(void)
 			PANIC("map early console");
                 kvm_init();
                 thread_setup();
+                scheduler_init();
                 trap_init_lock();
                 trap_init();
 		timer_init_hart();

--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -12,6 +12,7 @@
 #include <mem_layout.h>
 #include <mystring.h>
 #include <of.h>
+#include <spinlock.h>
 
 #define MAGIC_NUMBER                            (0x20030528)
 #define MIN_SIZE                                (1)
@@ -52,6 +53,8 @@ typedef struct pool {
 
 static pmem_free_list_t head = 0;
 static struct pool pool;
+static struct spinlock page_lock;
+static struct spinlock heap_lock;
 
 #define PALLOC_MEMORY_RANGE_MAX 8
 #define PALLOC_RESERVED_RANGE_MAX 32
@@ -168,6 +171,8 @@ void palloc_init(void)
 	uint64 address;
 	int i, pages = 0;
 
+	spinlock_init(&page_lock, "physical pages");
+	spinlock_init(&heap_lock, "kernel heap");
 	palloc_discover_memory();
 	for (i = 0; i < memory_range_count; i++) {
 		for (address = memory_ranges[i].start;
@@ -193,6 +198,7 @@ void pfree(void* p)
         
         /* Clear the memory */
         memset(p, 1, PGSIZE);
+	spinlock_acquire(&page_lock);
 
         /* 
                 Convert the 'p' into 'list'Set the byte before <reg width> 
@@ -201,12 +207,15 @@ void pfree(void* p)
         pmem_node = (struct pmem_free_list*)p;
         pmem_node->next = head;
         head = pmem_node;
+	spinlock_release(&page_lock);
 }
 
 /* Alloc the physical memory */
 void* palloc(void)
 {
         char* p = 0;
+
+	spinlock_acquire(&page_lock);
         /* If the head is not NULL */
         if(head) {
                 p = (char*)head;
@@ -214,6 +223,7 @@ void* palloc(void)
         } else {
                 PANIC("palloc");
         }
+	spinlock_release(&page_lock);
         
         return p;
 }
@@ -341,6 +351,7 @@ void* malloc(uint64 size)
         if(size == 0)
                 return 0;
 
+	spinlock_acquire(&heap_lock);
         use_blocks = USE_BLOCK(size);
 
         page = pool.list;
@@ -352,8 +363,10 @@ re:
                 goto re;
         }
 
-        if(ret == -1)
+        if(ret == -1) {
+		spinlock_release(&heap_lock);
                 return 0;
+	}
                 
         
         /* Get the memory that the caller uses */
@@ -368,6 +381,7 @@ re:
         info->addr = p;
         info->parent = page;
 
+	spinlock_release(&heap_lock);
         return p;
 }
 
@@ -397,6 +411,7 @@ void free(void* p)
 
 	if (!p)
 		return;
+	spinlock_acquire(&heap_lock);
 	info = (block_info_t)((uint64)p - (INFO_BLOCK * MIN_SIZE));
         page = info->parent;
 
@@ -406,8 +421,10 @@ void free(void* p)
            info->magic != MAGIC_NUMBER) {
                 /* Illegal address */
                 printf("free: Illegal address\n");
+		spinlock_release(&heap_lock);
                 return;
         }
 
         free_core(page, (char*)info, INFO_BLOCK + info->used);
+	spinlock_release(&heap_lock);
 }

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -575,6 +575,7 @@ int kill(int pid)
         process_t p;
         list_t l;
 
+        spinlock_acquire(&wait_lock);
         for(l = proc.next; l != &proc; l = l->next) {
                 p = list_entry(l, struct process, all_tag);
                 if(!p)
@@ -586,10 +587,12 @@ int kill(int pid)
                                 if(p->thread[i])
                                         scheduler_wake(p->thread[i]);
                         spinlock_release(&p->lock);
+                        spinlock_release(&wait_lock);
                         return 0;
                 }
                 spinlock_release(&p->lock);
         }
+        spinlock_release(&wait_lock);
         return -1;
 }
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -198,7 +198,7 @@ void wakeup(void* chan)
                 spinlock_acquire(&t->lock);
                 if(t->sleep_chan == chan &&
                    t->state == THREAD_SLEEPING)
-                        t->state = THREAD_RUNNABLE;
+                        scheduler_make_runnable(t);
                 spinlock_release(&t->lock);
         }
 }
@@ -358,7 +358,7 @@ void userinit(void)
 	if (!p)
                 PANIC("userinit");
 	t = p->thread[0];
-	t->state = THREAD_RUNNABLE;
+	scheduler_make_runnable(t);
 	p->sz = 0;
 	p->brk = 0;
 	p->brk_start = 0;
@@ -452,7 +452,7 @@ int process_fork(uint64 child_stack)
         spinlock_release(&wait_lock);
 
         spinlock_acquire(&newt->lock);
-        newt->state = THREAD_RUNNABLE;
+        scheduler_make_runnable(newt);
         spinlock_release(&newt->lock);
 
         /* Return for parent process */

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -73,6 +73,10 @@ pagedir_t process_pagedir(process_t p)
 {
         int ret;
         pagedir_t pgdir;
+        thread_t thread = p->thread[0];
+
+        if(!thread)
+                return 0;
         /* Malloc memory for page-talble */
         pgdir = pagedir_alloc();
 	if (!pgdir)
@@ -91,7 +95,8 @@ pagedir_t process_pagedir(process_t p)
 		pagedir_free(pgdir);
 		return 0;
 	}
-        ret = vm_map(pgdir, TRAPFRAME(0), (uint64)p->cur_thread->trapframe, PGSIZE, PTE_W | PTE_R);
+        ret = vm_map(pgdir, TRAPFRAME(0), (uint64)thread->trapframe,
+                     PGSIZE, PTE_W | PTE_R);
 	if(ret){
                 /* We don't need free the address that PTE points because it is a code seg */
 		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
@@ -133,8 +138,7 @@ static void proc_first_start(void)
 	process_t process = cur_proc();
 
         /* The function scheduler will acquire the lock */
-        spinlock_release(&cur_proc()->lock);
-        spinlock_release(&cur_proc()->cur_thread->lock);
+        spinlock_release(&cur_thread()->lock);
 	if (!fs_started) {
 		fs_started = 1;
 		if (vfs_mount_root(ROOT_FILESYSTEM, block_device_get(1), 0) < 0)
@@ -170,48 +174,32 @@ static int pid_alloc(void)
 #ifndef PROCESS_NO_SCHED
 void sleep(void* chan, spinlock_t lk)
 {
-        process_t p = cur_proc();
-        thread_t t = p->cur_thread;
+        thread_t t = cur_thread();
 
-        spinlock_acquire(&p->lock);
         spinlock_acquire(&t->lock);
         spinlock_release(lk);
 
         t->sleep_chan = chan;
-        p->state = RUNNABLE;
-        t->state = RESETING;
+        t->state = THREAD_SLEEPING;
 
         sched();
 
         t->sleep_chan = 0;
 
-        spinlock_release(&p->lock);
         spinlock_release(&t->lock);
         spinlock_acquire(lk);
 }
 
 void wakeup(void* chan)
 {
-        process_t p;
         thread_t t;
-        int i;
-        list_t l;
 
-        for(l = proc.next; l != &proc; l = l->next) {
-                p = list_entry(l, struct process, all_tag);
-                if(!p)
-                        continue;
-                if(p != cur_proc()) {
-                        spinlock_acquire(&p->lock);
-                        if(p->tnums != 0) {
-                                for(i = 0; i < p->tnums; i++) {
-                                        t = p->thread[i];
-                                        if(t->sleep_chan == chan && t->state == RESETING)
-                                                t->state = READY;
-                                }
-                        }
-                        spinlock_release(&p->lock);
-                }
+        for(t = &thread[0]; t <= &thread[NTHREAD - 1]; t++) {
+                spinlock_acquire(&t->lock);
+                if(t->sleep_chan == chan &&
+                   t->state == THREAD_SLEEPING)
+                        t->state = THREAD_RUNNABLE;
+                spinlock_release(&t->lock);
         }
 }
 void sleep_(void* chan, spinlock_t lk)
@@ -260,6 +248,7 @@ static process_t process_alloc(void)
                 return 0;
 	memset(p, 0, sizeof(*p));
 	p->umask = 0022;
+	p->state = PROCESS_LIVE;
         
         spinlock_init(&p->lock, "process");
         spinlock_acquire(&p->lock);
@@ -281,8 +270,6 @@ static process_t process_alloc(void)
 
         p->tinfo->nums = 1;
 
-        p->cur_thread = t;
-
         /* Alloc memory for page-table */
         p->pagetable = process_pagedir(p);
         if(!p->pagetable) {
@@ -296,11 +283,12 @@ static process_t process_alloc(void)
         t->context.ra = (uint64)(proc_first_start);
 
         list_init(&p->all_tag);
+        spinlock_acquire(&wait_lock);
         list_insert_after(&proc, &p->all_tag);
+        spinlock_release(&wait_lock);
 
         return p;
 r2:
-	p->cur_thread = 0;
 	pfree(p->tinfo);
 r1:
 	thread_free(t);
@@ -313,20 +301,25 @@ r0:
 
 static void process_free(process_t p)
 {
+        thread_t thread;
         int i;
 
+        spinlock_acquire(&p->lock);
         if(p->pagetable) {
                 process_freepagedir(p->pagetable, p->sz);
         }
         for(i = 0; i < PROC_MAXTHREAD; i++) {
-                if(p->thread[i] != 0) {
-                        thread_free(p->thread[i]);
-                        p->thread[i] = 0;
-                }
+                thread = p->thread[i];
+                if(!thread)
+                        continue;
+                spinlock_acquire(&thread->lock);
+                thread_free(thread);
+                spinlock_release(&thread->lock);
         }
 	if (p->tinfo)
 		pfree(p->tinfo);
         list_remove(&p->all_tag);
+        spinlock_release(&p->lock);
         free(p);
         // p->pid = 0;
         // p->sz = 0;
@@ -361,20 +354,17 @@ void userinit(void)
         thread_t t;
 
         /* Alloc a process */
-        p = process_alloc();
+	p = process_alloc();
 	if (!p)
                 PANIC("userinit");
-	t = p->cur_thread;
-	t->state = READY;
+	t = p->thread[0];
+	t->state = THREAD_RUNNABLE;
 	p->sz = 0;
 	p->brk = 0;
 	p->brk_start = 0;
 	p->mmap_top = USER_MMAP_TOP;
 
 	safe_strncpy(p->name, "kernel-init", MAXNAME);
-        /* Allow schedule */
-        p->state = RUNNABLE;
-
         first = p;
 
         /* The lock will be held in process_alloc */
@@ -417,13 +407,15 @@ int process_fork(uint64 child_stack)
 	if(!newp)
 		return -1;
 
-        oldt = oldp->cur_thread;
-        newt = newp->cur_thread;
+        oldt = cur_thread();
+        newt = newp->thread[0];
 
 	if(vm_copy(oldp->pagetable, newp->pagetable) != 0) {
 		spinlock_release(&newt->lock);
 		spinlock_release(&newp->lock);
+		spinlock_acquire(&wait_lock);
 		process_free(newp);
+		spinlock_release(&wait_lock);
 		return -1;
 	}
 
@@ -453,18 +445,15 @@ int process_fork(uint64 child_stack)
 	        sizeof(newp->signal_actions));
 
         spinlock_release(&newp->lock);
-        spinlock_release(&newp->cur_thread->lock);
+        spinlock_release(&newt->lock);
 
         spinlock_acquire(&wait_lock);
         newp->parent = oldp;
         spinlock_release(&wait_lock);
 
-        spinlock_acquire(&newp->lock);
-        newp->state = RUNNABLE;
-        spinlock_acquire(&newp->cur_thread->lock);
-        newp->cur_thread->state = READY;
-        spinlock_release(&newp->cur_thread->lock);
-        spinlock_release(&newp->lock);
+        spinlock_acquire(&newt->lock);
+        newt->state = THREAD_RUNNABLE;
+        spinlock_release(&newt->lock);
 
         /* Return for parent process */
         return pid;
@@ -473,10 +462,12 @@ int process_fork(uint64 child_stack)
 void exit(int cause)
 {
         process_t p;
+        thread_t current;
         file_t f;
         int fd, i;
 
         p = cur_proc();
+        current = cur_thread();
 
         for(fd = 0; fd < NOFILE; fd++) {
                 if((f = p->ofile[fd]) != 0) {
@@ -492,19 +483,20 @@ void exit(int cause)
 
         reparent(p);
 
+        spinlock_acquire(&p->lock);
+        p->exit_state = cause;
+        p->state = PROCESS_ZOMBIE;
+        spinlock_release(&p->lock);
+
         wakeup(p->parent);
 
-        spinlock_acquire(&p->lock);
-        spinlock_acquire(&p->cur_thread->lock);
-
-        p->exit_state = cause;
-        p->state = ZOMBIE;
-        p->cur_thread->state = DIED;
+        spinlock_acquire(&current->lock);
+        current->state = THREAD_EXITED;
         
         for(i = 0; i < p->tnums; i++) {
-                if(p->thread[i] && p->thread[i] != p->cur_thread) {
+                if(p->thread[i] && p->thread[i] != current) {
                         spinlock_acquire(&p->thread[i]->lock);
-                        p->thread[i]->state = DIED;
+                        p->thread[i]->state = THREAD_EXITED;
                         spinlock_release(&p->thread[i]->lock);
                 }
         }
@@ -535,7 +527,7 @@ int process_wait(int target, uint64 status_address, int nohang)
 			   (target == -1 || target == pp->pid)) {
                                 spinlock_acquire(&pp->lock);
                                 kids = 1;
-                                if(pp->state == ZOMBIE) {
+				if(pp->state == PROCESS_ZOMBIE) {
                                         pid = pp->pid;
 
 					exit_status =
@@ -590,8 +582,9 @@ int kill(int pid)
                 spinlock_acquire(&p->lock);
                 if(p->pid == pid) {
                         p->killed = 1;
-                        if(p->state == SLEEPING)
-                                p->state = RUNNABLE;
+                        for(int i = 0; i < p->tnums; i++)
+                                if(p->thread[i])
+                                        scheduler_wake(p->thread[i]);
                         spinlock_release(&p->lock);
                         return 0;
                 }

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -399,12 +399,10 @@ int process_fork(uint64 child_stack)
 void exit(int cause)
 {
         process_t p;
-        thread_t current;
         file_t f;
-        int fd, i;
+        int fd;
 
         p = cur_proc();
-        current = cur_thread();
 
         for(fd = 0; fd < NOFILE; fd++) {
                 if((f = p->ofile[fd]) != 0) {
@@ -421,6 +419,8 @@ void exit(int cause)
         reparent(p);
 
         spinlock_acquire(&p->lock);
+	if (p->tnums != 1)
+		PANIC("multithreaded exit unsupported");
         p->exit_state = cause;
         p->state = PROCESS_ZOMBIE;
         spinlock_release(&p->lock);
@@ -428,21 +428,8 @@ void exit(int cause)
         if(p->parent)
                 wait_queue_wake_all(&p->parent->child_wait);
 
-        spinlock_acquire(&current->lock);
-        current->state = THREAD_EXITED;
-        
-        for(i = 0; i < p->tnums; i++) {
-                if(p->thread[i] && p->thread[i] != current) {
-                        spinlock_acquire(&p->thread[i]->lock);
-                        p->thread[i]->state = THREAD_EXITED;
-                        spinlock_release(&p->thread[i]->lock);
-                }
-        }
-
         spinlock_release(&wait_lock);
-
-        sched();
-        PANIC("exit");
+	scheduler_exit();
 }
 
 int process_wait(int target, uint64 status_address, int nohang)

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -171,71 +171,6 @@ static int pid_alloc(void)
         spinlock_release(&pid_lock);
         return pid;
 }
-#ifndef PROCESS_NO_SCHED
-void sleep(void* chan, spinlock_t lk)
-{
-        thread_t t = cur_thread();
-
-        spinlock_acquire(&t->lock);
-        spinlock_release(lk);
-
-        t->sleep_chan = chan;
-        t->state = THREAD_SLEEPING;
-
-        sched();
-
-        t->sleep_chan = 0;
-
-        spinlock_release(&t->lock);
-        spinlock_acquire(lk);
-}
-
-void wakeup(void* chan)
-{
-        thread_t t;
-
-        for(t = &thread[0]; t <= &thread[NTHREAD - 1]; t++) {
-                spinlock_acquire(&t->lock);
-                if(t->sleep_chan == chan &&
-                   t->state == THREAD_SLEEPING)
-                        scheduler_make_runnable(t);
-                spinlock_release(&t->lock);
-        }
-}
-void sleep_(void* chan, spinlock_t lk)
-{
-        sleep(chan, lk);
-}
-void wakeup_(void* chan)
-{
-        wakeup(chan);
-}
-#else
-/* TODO */
-static volatile uint8 test_flag = 0;
-void sleep_(void* chan, spinlock_t lk)
-{
-        test_flag = 1;
-        spinlock_release(lk);
-        intr_on();
-        while(test_flag);
-        spinlock_acquire(lk);
-}
-
-void wakeup_(void* chan)
-{
-        test_flag = 0;
-}
-void sleep(void* chan, spinlock_t lk)
-{
- 
-}
-
-void wakeup(void* chan)
-{
-
-}
-#endif
 /* Alloc a process */
 static process_t process_alloc(void)
 {
@@ -328,7 +263,6 @@ static void process_free(process_t p)
         // p->sz = 0;
         // p->state = UNUSED;
         // p->parent = 0;
-        // p->sleep_chan = 0;
         // p->name[0] = 0;
 }
 
@@ -588,9 +522,8 @@ int kill(int pid)
                 if(p->pid == pid) {
                         p->killed = 1;
                         for(int i = 0; i < p->tnums; i++)
-                                if(p->thread[i] &&
-                                   !wait_queue_wake_thread(p->thread[i]))
-                                        scheduler_wake(p->thread[i]);
+                                if(p->thread[i])
+                                        wait_queue_wake_thread(p->thread[i]);
                         spinlock_release(&p->lock);
                         spinlock_release(&wait_lock);
                         return 0;

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -418,6 +418,12 @@ void exit(int cause)
 
         reparent(p);
 
+	/*
+	 * Keep the final thread alive from publishing PROCESS_ZOMBIE until
+	 * the scheduler has switched away. A parent on another CPU may reap
+	 * the process as soon as wait_lock is released.
+	 */
+	spinlock_acquire(&cur_thread()->lock);
         spinlock_acquire(&p->lock);
 	if (p->tnums != 1)
 		PANIC("multithreaded exit unsupported");
@@ -426,10 +432,10 @@ void exit(int cause)
         spinlock_release(&p->lock);
 
         if(p->parent)
-                wait_queue_wake_all(&p->parent->child_wait);
+		wait_queue_wake_all(&p->parent->child_wait);
 
         spinlock_release(&wait_lock);
-	scheduler_exit();
+	scheduler_exit_locked();
 }
 
 int process_wait(int target, uint64 status_address, int nohang)

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -61,7 +61,7 @@ static void reparent(process_t p)
                         if(pp->parent == p) {
                                 pp->parent = first;
                                 spinlock_release(&pp->lock);
-                                wakeup(pp->parent);
+                                wait_queue_wake_all(&first->child_wait);
                                 continue;
                         }  
                         spinlock_release(&pp->lock);
@@ -249,6 +249,7 @@ static process_t process_alloc(void)
 	memset(p, 0, sizeof(*p));
 	p->umask = 0022;
 	p->state = PROCESS_LIVE;
+        wait_queue_init(&p->child_wait, "child wait");
         
         spinlock_init(&p->lock, "process");
         spinlock_acquire(&p->lock);
@@ -305,6 +306,8 @@ static void process_free(process_t p)
         int i;
 
         spinlock_acquire(&p->lock);
+        if(!wait_queue_empty(&p->child_wait))
+                PANIC("free process with child waiter");
         if(p->pagetable) {
                 process_freepagedir(p->pagetable, p->sz);
         }
@@ -488,7 +491,8 @@ void exit(int cause)
         p->state = PROCESS_ZOMBIE;
         spinlock_release(&p->lock);
 
-        wakeup(p->parent);
+        if(p->parent)
+                wait_queue_wake_all(&p->parent->child_wait);
 
         spinlock_acquire(&current->lock);
         current->state = THREAD_EXITED;
@@ -560,7 +564,7 @@ int process_wait(int target, uint64 status_address, int nohang)
 			return 0;
 		}
 
-                sleep(p, &wait_lock);
+                wait_queue_sleep(&p->child_wait, &wait_lock);
         }
 }
 
@@ -584,7 +588,8 @@ int kill(int pid)
                 if(p->pid == pid) {
                         p->killed = 1;
                         for(int i = 0; i < p->tnums; i++)
-                                if(p->thread[i])
+                                if(p->thread[i] &&
+                                   !wait_queue_wake_thread(p->thread[i]))
                                         scheduler_wake(p->thread[i]);
                         spinlock_release(&p->lock);
                         spinlock_release(&wait_lock);

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -209,16 +209,26 @@ void yield(void)
         sched();
         spinlock_release(&current->lock);
 }
-void scheduler_exit(void)
+void scheduler_exit_locked(void)
 {
 	thread_t current = cur_thread();
 
-	spinlock_acquire(&current->lock);
-	if (current->state != THREAD_RUNNING)
+	if (!current || !spinlock_holding(&current->lock) ||
+	    current->state != THREAD_RUNNING)
 		PANIC("exit non-running thread");
 	current->state = THREAD_EXITED;
 	sched();
 	PANIC("scheduled exited thread");
+}
+
+void scheduler_exit(void)
+{
+	thread_t current = cur_thread();
+
+	if (!current)
+		PANIC("exit without thread");
+	spinlock_acquire(&current->lock);
+	scheduler_exit_locked();
 }
 
 void scheduler_request_resched(void)

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -209,6 +209,18 @@ void yield(void)
         sched();
         spinlock_release(&current->lock);
 }
+void scheduler_exit(void)
+{
+	thread_t current = cur_thread();
+
+	spinlock_acquire(&current->lock);
+	if (current->state != THREAD_RUNNING)
+		PANIC("exit non-running thread");
+	current->state = THREAD_EXITED;
+	sched();
+	PANIC("scheduled exited thread");
+}
+
 void scheduler_request_resched(void)
 {
 	cpu_t cpu = cur_cpu();

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -208,11 +208,3 @@ void yield(void)
         sched();
         spinlock_release(&current->lock);
 }
-
-void scheduler_wake(thread_t thread)
-{
-        spinlock_acquire(&thread->lock);
-        if(thread->state == THREAD_SLEEPING)
-                scheduler_make_runnable(thread);
-        spinlock_release(&thread->lock);
-}

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -8,6 +8,12 @@
 extern void switchto(context_t c, context_t p);
 struct cpu cpus[NCPU];
 
+static struct {
+        struct spinlock lock;
+        struct list runnable;
+        uint32 count;
+} runqueue;
+
 /* Get hart id */
 uint8 cpuid(void)
 {
@@ -37,6 +43,55 @@ process_t cur_proc(void)
         return current ? current->home : 0;
 }
 
+void scheduler_init(void)
+{
+        spinlock_init(&runqueue.lock, "runqueue");
+        list_init(&runqueue.runnable);
+        runqueue.count = 0;
+}
+
+/* The caller must hold thread->lock. */
+void scheduler_make_runnable(thread_t thread)
+{
+        if(!spinlock_holding(&thread->lock))
+                PANIC("runnable lock");
+
+        spinlock_acquire(&runqueue.lock);
+        if(thread->on_runqueue ||
+           (thread->state != THREAD_ALLOCATED &&
+            thread->state != THREAD_RUNNING &&
+            thread->state != THREAD_SLEEPING))
+                PANIC("invalid runnable thread");
+        thread->state = THREAD_RUNNABLE;
+        list_insert_before(&runqueue.runnable, &thread->run_node);
+        thread->on_runqueue = 1;
+        runqueue.count++;
+        spinlock_release(&runqueue.lock);
+}
+
+static thread_t scheduler_dequeue(void)
+{
+        thread_t thread = 0;
+        list_t node;
+
+        spinlock_acquire(&runqueue.lock);
+        if(runqueue.count) {
+                node = runqueue.runnable.next;
+                if(node == &runqueue.runnable)
+                        PANIC("empty runqueue");
+                thread = list_entry(node, struct thread, run_node);
+                if(!thread->on_runqueue)
+                        PANIC("unqueued thread");
+                list_remove(node);
+                thread->on_runqueue = 0;
+                runqueue.count--;
+        } else if(runqueue.runnable.next != &runqueue.runnable) {
+                PANIC("runqueue count");
+        }
+        spinlock_release(&runqueue.lock);
+        return thread;
+}
+
 void scheduler(void)
 {
         volatile cpu_t cpu = cur_cpu();
@@ -48,22 +103,20 @@ void scheduler(void)
                 /* Open interrupt to avoid dead lock */
                 intr_on();
 
-                for(t = &thread[0]; t <= &thread[NTHREAD - 1]; t ++) {
-			int ret = spinlock_trylock(&t->lock);
-			if (ret)
-				continue;
+                t = scheduler_dequeue();
+                if(!t)
+                        continue;
 
-                        if(t->state == THREAD_RUNNABLE) {
-                                if(!t->home)
-                                        PANIC("scheduler");
-                                t->state = THREAD_RUNNING;
-                                t->home->tinfo->addr = TRAPFRAME(t->id_p);
-                                cpu->current = t;
-                                switchto(&cpu->context, &t->context);
-                                cpu->current = 0;
-                        }
-                        spinlock_release(&t->lock);
-                }
+                spinlock_acquire(&t->lock);
+                if(t->state != THREAD_RUNNABLE || t->on_runqueue ||
+                   !t->home)
+                        PANIC("invalid scheduled thread");
+                t->state = THREAD_RUNNING;
+                t->home->tinfo->addr = TRAPFRAME(t->id_p);
+                cpu->current = t;
+                switchto(&cpu->context, &t->context);
+                cpu->current = 0;
+                spinlock_release(&t->lock);
         } 
 }
 
@@ -105,7 +158,7 @@ void yield(void)
         thread_t current = cur_thread();
 
         spinlock_acquire(&current->lock);
-        current->state = THREAD_RUNNABLE;
+        scheduler_make_runnable(current);
         sched();
         spinlock_release(&current->lock);
 }
@@ -114,6 +167,6 @@ void scheduler_wake(thread_t thread)
 {
         spinlock_acquire(&thread->lock);
         if(thread->state == THREAD_SLEEPING)
-                thread->state = THREAD_RUNNABLE;
+                scheduler_make_runnable(thread);
         spinlock_release(&thread->lock);
 }

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -160,6 +160,7 @@ void scheduler(void)
                 t->state = THREAD_RUNNING;
                 t->home->tinfo->addr = TRAPFRAME(t->id_p);
                 cpu->current = t;
+		cpu->need_resched = 0;
                 switchto(&cpu->context, &t->context);
                 cpu->current = 0;
                 spinlock_release(&t->lock);
@@ -207,4 +208,22 @@ void yield(void)
         scheduler_enqueue(current, 0);
         sched();
         spinlock_release(&current->lock);
+}
+void scheduler_request_resched(void)
+{
+	cpu_t cpu = cur_cpu();
+
+	if (cpu->current)
+		cpu->need_resched = 1;
+}
+
+int scheduler_should_resched(void)
+{
+        cpu_t cpu = cur_cpu();
+
+        if(!cpu->need_resched || !cpu->current ||
+           cpu->current->state != THREAD_RUNNING)
+                return 0;
+        cpu->need_resched = 0;
+        return 1;
 }

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -169,8 +169,8 @@ void sched(void)
         before_lock = cpu->before_lock;
         /* Change the context to  kernel scheduler */
         switchto(&p->cur_thread->context, &cpu->context);
-        /* Restore the value of lock */
-        cpu->before_lock = before_lock;
+	/* A resumed thread may have migrated to another CPU. */
+	cur_cpu()->before_lock = before_lock;
 }
 
 void yield(void)

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -4,6 +4,8 @@
 #include <riscv.h>
 #include <list.h>
 #include <debug.h>
+#include <cpu.h>
+#include <sbi.h>
 
 extern void switchto(context_t c, context_t p);
 struct cpu cpus[NCPU];
@@ -50,9 +52,29 @@ void scheduler_init(void)
         runqueue.count = 0;
 }
 
-/* The caller must hold thread->lock. */
-void scheduler_make_runnable(thread_t thread)
+static int scheduler_claim_idle_cpu(void)
 {
+        cpu_t current = cur_cpu();
+        int logical;
+
+        if(current->idle) {
+                current->idle = 0;
+                return -1;
+        }
+        for(logical = 0; logical < cpu_count(); logical++) {
+                if(&cpus[logical] == current ||
+                   !cpus[logical].online || !cpus[logical].idle)
+                        continue;
+                cpus[logical].idle = 0;
+                return logical;
+        }
+        return -1;
+}
+
+static void scheduler_enqueue(thread_t thread, int wake_idle)
+{
+        int target = -1;
+
         if(!spinlock_holding(&thread->lock))
                 PANIC("runnable lock");
 
@@ -66,15 +88,29 @@ void scheduler_make_runnable(thread_t thread)
         list_insert_before(&runqueue.runnable, &thread->run_node);
         thread->on_runqueue = 1;
         runqueue.count++;
+        if(wake_idle)
+                target = scheduler_claim_idle_cpu();
         spinlock_release(&runqueue.lock);
+
+        if(target >= 0 && sbi_send_ipi(cpu_hart_id(target)))
+                PANIC("SBI send IPI failed");
 }
 
-static thread_t scheduler_dequeue(void)
+/* The caller must hold thread->lock. */
+void scheduler_make_runnable(thread_t thread)
+{
+        scheduler_enqueue(thread, 1);
+}
+
+static thread_t scheduler_next(cpu_t cpu)
 {
         thread_t thread = 0;
         list_t node;
 
+        if(intr_status())
+                PANIC("scheduler interrupts enabled");
         spinlock_acquire(&runqueue.lock);
+        cpu->idle = 0;
         if(runqueue.count) {
                 node = runqueue.runnable.next;
                 if(node == &runqueue.runnable)
@@ -87,6 +123,8 @@ static thread_t scheduler_dequeue(void)
                 runqueue.count--;
         } else if(runqueue.runnable.next != &runqueue.runnable) {
                 PANIC("runqueue count");
+        } else {
+                cpu->idle = 1;
         }
         spinlock_release(&runqueue.lock);
         return thread;
@@ -98,14 +136,22 @@ void scheduler(void)
         thread_t t;
 
         cpu->current = 0;
+        cpu->idle = 0;
 
         for(;;) {
-                /* Open interrupt to avoid dead lock */
-                intr_on();
-
-                t = scheduler_dequeue();
-                if(!t)
+                /*
+                 * Keep global interrupts disabled through WFI. An IPI that
+                 * arrives after the empty check then remains pending and
+                 * makes WFI return instead of being consumed too early.
+                 */
+                intr_off();
+                t = scheduler_next(cpu);
+                if(!t) {
+                        wait_for_interrupt();
+                        intr_on();
                         continue;
+                }
+                intr_on();
 
                 spinlock_acquire(&t->lock);
                 if(t->state != THREAD_RUNNABLE || t->on_runqueue ||
@@ -158,7 +204,7 @@ void yield(void)
         thread_t current = cur_thread();
 
         spinlock_acquire(&current->lock);
-        scheduler_make_runnable(current);
+        scheduler_enqueue(current, 0);
         sched();
         spinlock_release(&current->lock);
 }

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -5,7 +5,6 @@
 #include <list.h>
 #include <debug.h>
 
-extern struct list all_thread;
 extern void switchto(context_t c, context_t p);
 struct cpu cpus[NCPU];
 
@@ -25,88 +24,25 @@ cpu_t cur_cpu(void)
 }
 
 /* Get current thread */
-// thread_t cur_thread()
-// {
-//         return cur_cpu()->thread;
-// }
+thread_t cur_thread(void)
+{
+        return cur_cpu()->current;
+}
 
 /* Get current process */
-process_t cur_proc()
+process_t cur_proc(void)
 {
-        return cur_cpu()->proc;
+        thread_t current = cur_thread();
+
+        return current ? current->home : 0;
 }
 
-/* 
-        Them must be called with interrupts disabled above functions
-        to prevent race with thread being moved to a different CPU
-*/
-#if 0
 void scheduler(void)
 {
         volatile cpu_t cpu = cur_cpu();
-        thread_t thread;
-        list_t p;
-        
-        cpu->thread = 0;
-        for(;;) {
-                /* Open interrupt to avoid dead lock */
-                intr_on();
-               
-                for(p = all_thread.next; p != &all_thread; p = p->next) {
-                        thread = list_entry(p, struct thread, all_tag);
-                        if(!thread)
-                                continue;
-                        
-                        if(thread->state == READY) {
-                                // spinlock_acquire(&thread->lock);
-                                thread->state = ACTIVE;
-                                cpu->thread = thread;
-                                list_remove(&thread->all_tag);
-                                // spinlock_release(&thread->lock);
-                                switchto(&cpu->context, &thread->context);
-                                // break;
-                        }
-                        // spinlock_release(&thread->lock);
-                }
-        }
-        
-}
-
-/* Change the context to kernel scheduler */
-void sched(void)
-{
-        cpu_t cpu = cur_cpu();
-        /* Save the value of lock */
-        uint8 before_lock = cpu->before_lock;
-        /* Change the context to  kernel scheduler */
-        switchto(&cpu->thread->context, &cpu->context);
-        /* Restore the value of lock */
-        cpu->before_lock = before_lock;
-}
-
-/* Give up the cpu */
-void yield(void)
-{
-        cpu_t cpu = cur_cpu();
-        // spinlock_acquire(&cpu->thread->lock);
-        /* Modify the value of state to READY */
-        cpu->thread->state = READY;
-        /* Insert node in the tail */
-        list_insert_before(&all_thread, &cpu->thread->all_tag);
-        // spinlock_release(&cpu->thread->lock);
-        sched();
-        
-}
-#endif
-#include <printf.h>
-extern struct process proc[NPROC];
-void scheduler(void)
-{
-        volatile cpu_t cpu = cur_cpu();
-        process_t p;
         thread_t t;
 
-        cpu->proc = 0;
+        cpu->current = 0;
 
         for(;;) {
                 /* Open interrupt to avoid dead lock */
@@ -117,23 +53,14 @@ void scheduler(void)
 			if (ret)
 				continue;
 
-                        if(t->state == READY) {
+                        if(t->state == THREAD_RUNNABLE) {
                                 if(!t->home)
                                         PANIC("scheduler");
-                                p = t->home;
-                                spinlock_acquire(&p->lock);
-                                if(p->state == RUNNABLE) {
-                                        // printf("%s\n", p->name);
-                                        p->state = RUNNING;
-                                        p->cur_thread = t;
-                                        p->cur_thread->state = ACTIVE;
-                                        p->tinfo->addr = TRAPFRAME(t->id_p);
-                                        cpu->proc = p;
-                                        switchto(&cpu->context,
-                                                 &p->cur_thread->context);
-                                        cpu->proc = 0;
-                                }
-                                spinlock_release(&p->lock);
+                                t->state = THREAD_RUNNING;
+                                t->home->tinfo->addr = TRAPFRAME(t->id_p);
+                                cpu->current = t;
+                                switchto(&cpu->context, &t->context);
+                                cpu->current = 0;
                         }
                         spinlock_release(&t->lock);
                 }
@@ -144,10 +71,10 @@ void scheduler(void)
 void sched(void)
 {
         cpu_t cpu = cur_cpu();
-        process_t p = cpu->proc;
+        thread_t current = cpu->current;
         uint8 before_lock;
 
-        if(!spinlock_holding(&p->lock)) {
+        if(!current || !spinlock_holding(&current->lock)) {
                 PANIC("sched holding");
         }
 
@@ -155,12 +82,12 @@ void sched(void)
                 PANIC("sched intr open");
         }
 
-        if(cpu->lock_nest_depth != 2) {
+        if(cpu->lock_nest_depth != 1) {
                 printf("%d->", cpu->lock_nest_depth);
                 PANIC("sched lock_nest_depth");
         }
 
-        if(p->state == RUNNING) {
+        if(current->state == THREAD_RUNNING) {
                 PANIC("sched running");
         }
 
@@ -168,19 +95,25 @@ void sched(void)
         /* Save the value of lock */
         before_lock = cpu->before_lock;
         /* Change the context to  kernel scheduler */
-        switchto(&p->cur_thread->context, &cpu->context);
+        switchto(&current->context, &cpu->context);
 	/* A resumed thread may have migrated to another CPU. */
 	cur_cpu()->before_lock = before_lock;
 }
 
 void yield(void)
 {
-        process_t p = cur_proc();
-        spinlock_acquire(&p->lock);
-        p->state = RUNNABLE;
-        spinlock_acquire(&p->cur_thread->lock);
-        p->cur_thread->state = READY;
+        thread_t current = cur_thread();
+
+        spinlock_acquire(&current->lock);
+        current->state = THREAD_RUNNABLE;
         sched();
-        spinlock_release(&p->lock);
-        spinlock_release(&p->cur_thread->lock);   
+        spinlock_release(&current->lock);
+}
+
+void scheduler_wake(thread_t thread)
+{
+        spinlock_acquire(&thread->lock);
+        if(thread->state == THREAD_SLEEPING)
+                thread->state = THREAD_RUNNABLE;
+        spinlock_release(&thread->lock);
 }

--- a/kernel/sleeplock.c
+++ b/kernel/sleeplock.c
@@ -1,14 +1,15 @@
 #include <sleeplock.h>
-#include <process.h>
 #include <scheduler.h>
 #include <debug.h>
+#include <wait.h>
 
 void sleeplock_init(sleeplock_t lk, const char* name)
 {
         spinlock_init(&lk->lk, name);
+        wait_queue_init(&lk->waiters, name);
 
         lk->name = name;
-        lk->p = 0;
+        lk->owner = 0;
         lk->locked = 0;  
 }
 
@@ -18,7 +19,7 @@ uint8 sleeplock_holding(sleeplock_t lk)
         
         spinlock_acquire(&lk->lk);
 
-        r = (lk->locked && (cur_proc() == (process_t)lk->p));
+        r = lk->locked && cur_thread() == lk->owner;
 
         spinlock_release(&lk->lk);
 
@@ -30,21 +31,20 @@ void sleeplock_acquire(sleeplock_t lk)
         spinlock_acquire(&lk->lk);
 
         while(lk->locked) {
-                sleep(lk, &lk->lk);
+                wait_queue_sleep(&lk->waiters, &lk->lk);
         }
         lk->locked = 1;
-        lk->p = cur_proc();
+        lk->owner = cur_thread();
         spinlock_release(&lk->lk);
 }
 
 void sleeplock_release(sleeplock_t lk)
 {
-        if(!sleeplock_holding(lk)) {
-                PANIC("sleeplock_release");
-        }
         spinlock_acquire(&lk->lk);
+        if(!lk->locked || lk->owner != cur_thread())
+                PANIC("sleeplock_release");
         lk->locked = 0;
-        lk->p = 0;
-        wakeup(lk);
+        lk->owner = 0;
+        wait_queue_wake_one(&lk->waiters);
         spinlock_release(&lk->lk);    
 }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -8,8 +8,7 @@
 
 static uint64 argraw(int n)
 {
-	process_t p = cur_proc();
-	uint64 *args = &p->cur_thread->trapframe->a0;
+	uint64 *args = &cur_thread()->trapframe->a0;
 
 	if (n >= 0 && n <= 5)
 		return args[n];
@@ -156,14 +155,15 @@ void syscall(void)
 {
 	uint64 nr;
 	process_t p = cur_proc();
+	thread_t current = cur_thread();
 
-	nr = p->cur_thread->trapframe->a7;
+	nr = current->trapframe->a7;
 	if (nr < NELEM(linux_syscalls) && linux_syscalls[nr]) {
-		p->cur_thread->trapframe->a0 = linux_syscalls[nr]();
+		current->trapframe->a0 = linux_syscalls[nr]();
 		return;
 	}
 
 	printf("Unsupported Linux syscall %d from pid %d (%s)\n",
 	       nr, p->pid, p->name);
-	p->cur_thread->trapframe->a0 = -LINUX_ENOSYS;
+	current->trapframe->a0 = -LINUX_ENOSYS;
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -29,7 +29,7 @@ uint64 sys_linux_set_tid_address(void)
 
 	argaddr(0, &address);
 	p->clear_child_tid = address;
-	return p->cur_thread->tid;
+	return cur_thread()->tid;
 }
 
 uint64 sys_linux_brk(void)
@@ -172,7 +172,7 @@ uint64 sys_linux_getegid(void)
 
 uint64 sys_linux_gettid(void)
 {
-	return cur_proc()->cur_thread->tid;
+	return cur_thread()->tid;
 }
 
 uint64 sys_linux_umask(void)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -88,7 +88,6 @@ found:
         p->thread[t->id_p] = t;
 
         t->state = THREAD_ALLOCATED;
-        t->sleep_chan = 0;
         t->on_runqueue = 0;
         list_init(&t->run_node);
         t->waiting_on = 0;
@@ -115,7 +114,6 @@ r2:
         p->thread[t->id_p] = 0;
 r1:
         t->state = THREAD_UNUSED;
-        t->sleep_chan = 0;
         t->home = 0;
         spinlock_release(&t->lock);
         return 0;
@@ -147,7 +145,6 @@ void thread_free(thread_t t)
         if(t->trapframe)
                 pfree(t->trapframe);
         t->trapframe = 0;
-        t->sleep_chan = 0;
         t->home = 0;
         list_init(&t->run_node);
         list_init(&t->wait_node);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -58,6 +58,9 @@ void thread_setup(void)
                 t->state = THREAD_UNUSED;
                 t->on_runqueue = 0;
                 list_init(&t->run_node);
+                t->waiting_on = 0;
+                t->on_waitqueue = 0;
+                list_init(&t->wait_node);
                 strncpy(t->name, "thread", 7);
         }
 }
@@ -88,6 +91,9 @@ found:
         t->sleep_chan = 0;
         t->on_runqueue = 0;
         list_init(&t->run_node);
+        t->waiting_on = 0;
+        t->on_waitqueue = 0;
+        list_init(&t->wait_node);
 
         t->trapframe = (trapframe_t)palloc();
         if(!t->trapframe) {
@@ -124,6 +130,8 @@ void thread_free(thread_t t)
 
         if(t->on_runqueue)
                 PANIC("thread_free runnable");
+        if(t->on_waitqueue || t->waiting_on)
+                PANIC("thread_free waiting");
         if(p->tnums == 0)
                 PANIC("thread_free");
 
@@ -142,4 +150,5 @@ void thread_free(thread_t t)
         t->sleep_chan = 0;
         t->home = 0;
         list_init(&t->run_node);
+        list_init(&t->wait_node);
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -56,6 +56,8 @@ void thread_setup(void)
                 spinlock_init(&t->lock, "thread");
                 t->kstack = KSTACK((int)(t - thread));;
                 t->state = THREAD_UNUSED;
+                t->on_runqueue = 0;
+                list_init(&t->run_node);
                 strncpy(t->name, "thread", 7);
         }
 }
@@ -84,6 +86,8 @@ found:
 
         t->state = THREAD_ALLOCATED;
         t->sleep_chan = 0;
+        t->on_runqueue = 0;
+        list_init(&t->run_node);
 
         t->trapframe = (trapframe_t)palloc();
         if(!t->trapframe) {
@@ -118,6 +122,8 @@ void thread_free(thread_t t)
 
         p = t->home;
 
+        if(t->on_runqueue)
+                PANIC("thread_free runnable");
         if(p->tnums == 0)
                 PANIC("thread_free");
 
@@ -135,4 +141,5 @@ void thread_free(thread_t t)
         t->trapframe = 0;
         t->sleep_chan = 0;
         t->home = 0;
+        list_init(&t->run_node);
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -16,8 +16,6 @@
 #include <vm.h>
 #include <process.h>
 
-struct list all_thread;
-
 struct thread thread[NTHREAD];
 
 static int next_tid = 1;
@@ -57,7 +55,7 @@ void thread_setup(void)
         for(t = thread; t <= &thread[NTHREAD - 1]; t++) {
                 spinlock_init(&t->lock, "thread");
                 t->kstack = KSTACK((int)(t - thread));;
-                t->state = NUSED;
+                t->state = THREAD_UNUSED;
                 strncpy(t->name, "thread", 7);
         }
 }
@@ -71,7 +69,7 @@ thread_t thread_alloc(process_t p)
 		if (ret)
 			continue;
 
-                if(t->state == NUSED) {
+                if(t->state == THREAD_UNUSED) {
                         t->home = p;
                         goto found;
                 }
@@ -84,7 +82,8 @@ found:
         t->id_p = p->tnums ++;
         p->thread[t->id_p] = t;
 
-        t->state = NREADY;
+        t->state = THREAD_ALLOCATED;
+        t->sleep_chan = 0;
 
         t->trapframe = (trapframe_t)palloc();
         if(!t->trapframe) {
@@ -103,7 +102,11 @@ found:
         return t;
 r2:
         p->tnums --;
+        p->thread[t->id_p] = 0;
 r1:
+        t->state = THREAD_UNUSED;
+        t->sleep_chan = 0;
+        t->home = 0;
         spinlock_release(&t->lock);
         return 0;
 }
@@ -126,8 +129,10 @@ void thread_free(thread_t t)
         }
         p->tnums --;
 
-        t->state = NUSED;
+        t->state = THREAD_UNUSED;
         if(t->trapframe)
                 pfree(t->trapframe);
         t->trapframe = 0;
+        t->sleep_chan = 0;
+        t->home = 0;
 }

--- a/kernel/wait.c
+++ b/kernel/wait.c
@@ -1,0 +1,125 @@
+#include <debug.h>
+#include <scheduler.h>
+#include <thread.h>
+#include <wait.h>
+
+void wait_queue_init(wait_queue_t queue, const char *name)
+{
+	spinlock_init(&queue->lock, name);
+	list_init(&queue->waiters);
+	queue->name = name;
+}
+
+void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock)
+{
+	thread_t current = cur_thread();
+
+	if (!current || !spinlock_holding(condition_lock))
+		PANIC("wait without condition lock");
+	spinlock_acquire(&queue->lock);
+	spinlock_acquire(&current->lock);
+	if (current->state != THREAD_RUNNING || current->on_waitqueue ||
+	    current->waiting_on)
+		PANIC("invalid wait state");
+	current->waiting_on = queue;
+	current->on_waitqueue = 1;
+	list_insert_before(&queue->waiters, &current->wait_node);
+	current->state = THREAD_SLEEPING;
+	spinlock_release(condition_lock);
+	spinlock_release(&queue->lock);
+
+	sched();
+
+	if (current->on_waitqueue || current->waiting_on)
+		PANIC("scheduled wait entry");
+	spinlock_release(&current->lock);
+	spinlock_acquire(condition_lock);
+}
+
+static void wait_queue_wake_locked(wait_queue_t queue, thread_t thread)
+{
+	spinlock_acquire(&thread->lock);
+	if (!thread->on_waitqueue || thread->waiting_on != queue ||
+	    thread->state != THREAD_SLEEPING)
+		PANIC("invalid wait queue entry");
+	list_remove(&thread->wait_node);
+	thread->on_waitqueue = 0;
+	thread->waiting_on = 0;
+	scheduler_make_runnable(thread);
+	spinlock_release(&thread->lock);
+}
+
+int wait_queue_wake_one(wait_queue_t queue)
+{
+	thread_t thread;
+	list_t node;
+
+	spinlock_acquire(&queue->lock);
+	node = queue->waiters.next;
+	if (node == &queue->waiters) {
+		spinlock_release(&queue->lock);
+		return 0;
+	}
+	thread = list_entry(node, struct thread, wait_node);
+	wait_queue_wake_locked(queue, thread);
+	spinlock_release(&queue->lock);
+	return 1;
+}
+
+int wait_queue_wake_all(wait_queue_t queue)
+{
+	thread_t thread;
+	list_t node;
+	int count = 0;
+
+	spinlock_acquire(&queue->lock);
+	while ((node = queue->waiters.next) != &queue->waiters) {
+		thread = list_entry(node, struct thread, wait_node);
+		wait_queue_wake_locked(queue, thread);
+		count++;
+	}
+	spinlock_release(&queue->lock);
+	return count;
+}
+
+int wait_queue_wake_thread(thread_t thread)
+{
+	wait_queue_t queue;
+
+	for (;;) {
+		spinlock_acquire(&thread->lock);
+		if (thread->state != THREAD_SLEEPING ||
+		    !thread->on_waitqueue || !thread->waiting_on) {
+			spinlock_release(&thread->lock);
+			return 0;
+		}
+		queue = thread->waiting_on;
+		/*
+		 * Normal wakeup takes queue->lock before thread->lock. Do not
+		 * block in the inverse order: retry so that an in-flight waker
+		 * can remove the entry. Keeping thread->lock across a successful
+		 * trylock also keeps the attached queue alive.
+		 */
+		if (spinlock_trylock(&queue->lock)) {
+			spinlock_release(&thread->lock);
+			continue;
+		}
+		list_remove(&thread->wait_node);
+		thread->on_waitqueue = 0;
+		thread->waiting_on = 0;
+		scheduler_make_runnable(thread);
+		spinlock_release(&queue->lock);
+		spinlock_release(&thread->lock);
+		return 1;
+	}
+}
+
+int wait_queue_empty(wait_queue_t queue)
+{
+	int empty;
+
+	spinlock_acquire(&queue->lock);
+	empty = queue->waiters.next == &queue->waiters;
+	spinlock_release(&queue->lock);
+	return empty;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,3 +16,13 @@ opensbi:
 qemu:
 	TEST_OUTPUT="$(TEST_OUTPUT)" JOBS="$(JOBS)" \
 		$(CURDIR)/scripts/run-qemu.sh
+
+.PHONY: scheduler-perf
+scheduler-perf:
+	$(MAKE) -C $(TOPDIR) -j$(JOBS)
+	TEST_OUTPUT="$(TEST_OUTPUT)" JOBS="$(JOBS)" \
+		$(CURDIR)/scripts/build-rootfs.sh
+	KERNEL="$(TOPDIR)/output/kernel" \
+	ROOT_IMAGE="$(TEST_OUTPUT)/root.ext4" \
+		$(CURDIR)/scripts/benchmark-scheduler.py \
+		--output "$(TEST_OUTPUT)/scheduler-benchmark.json" --check

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,6 +29,12 @@ CLINT access, `mret`, `-bios none`, and a kernel entry other than
 
 The guest selftest covers:
 
+- repeated fork, exec, exit, and wait cycles;
+- FIFO scheduler progress with 24 runnable processes, timer preemption, and
+  more runnable work than CPUs;
+- concurrent CPU, allocator, ext4, VirtIO completion, sleeplock, and process
+  wait activity;
+- multiple TTY sleepers and repeated wake-all/requeue behavior;
 - devfs character devices and device numbers;
 - `/dev/ttyS0` metadata, `/dev/tty` error semantics, and terminal ioctls;
 - termios set/get state, canonical echo and erase, raw input, CR/NL handling,
@@ -44,9 +50,24 @@ checks FAT32 with `fsck.fat`, reads persistent values from both images, and
 verifies that tmpfs data did not reach the ext4 image.
 
 Required host commands are `riscv64-linux-gnu-*`, `qemu-system-riscv64`,
-`curl`, `expect`, `mke2fs`, `e2fsck`, `debugfs`, `mkfs.fat`, and `mtools`.
+`curl`, `expect`, `mke2fs`, `e2fsck`, `debugfs`, `mkfs.fat`, `mtools`, and
+`python3`.
 The firmware audit also requires `rg`. The GitHub Actions workflow installs
 these dependencies automatically.
+
+Measure one-CPU and eight-CPU command latency and verify that an idle
+eight-CPU guest consumes less than one host CPU with:
+
+```bash
+make -C tests scheduler-perf
+```
+
+This target builds a fresh test root image before measuring it. The
+benchmark reports 13-sample medians for a shell builtin, `pwd`, and
+`ls` on tmpfs, devfs, and ext4. Absolute command latency and the SMP ratio are
+reported rather than used as CI gates because shared-runner timing is noisy.
+Idle QEMU CPU usage is gated because the pre-fix scheduler consistently
+consumed one host CPU per guest CPU while doing no work.
 
 Run the same matrix against an externally built OpenSBI image with:
 

--- a/tests/scheduler_runtime.c
+++ b/tests/scheduler_runtime.c
@@ -1,0 +1,223 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define EXEC_ROUNDS 32
+#define EXEC_SMOKE_ROUNDS 8
+#define RUNNABLE_CHILDREN 24
+#define RUNNABLE_SMOKE_CHILDREN 12
+#define MIXED_CHILDREN 16
+#define TTY_WAITERS 8
+
+static int last_wait_status;
+
+static int fail(const char *test, int code)
+{
+	char message[128];
+	int length;
+
+	length = snprintf(message, sizeof(message),
+	                  "SCHED_RUNTIME_FAIL=%s:%d errno=%d status=%d\n",
+	                  test, code, errno, last_wait_status);
+	write(1, message, length);
+	return code;
+}
+
+static void pass(const char *message)
+{
+	write(1, message, strlen(message));
+}
+
+static int wait_for_child(pid_t pid, int expected)
+{
+	int status;
+
+	last_wait_status = -1;
+	if (waitpid(pid, &status, 0) != pid)
+		return -1;
+	last_wait_status = status;
+	if (!WIFEXITED(status) ||
+	    WEXITSTATUS(status) != expected)
+		return -1;
+	return 0;
+}
+
+static int test_exec(int rounds)
+{
+	int round;
+
+	for (round = 0; round < rounds; round++) {
+		pid_t pid = fork();
+
+		if (pid < 0)
+			return fail("exec-fork", 10);
+		if (!pid) {
+			execl("/bin/scheduler-runtime", "scheduler-runtime",
+			      "exec-child", NULL);
+			_exit(127);
+		}
+		if (wait_for_child(pid, 0))
+			return fail("exec-wait", 11);
+	}
+	pass("SCHED_EXEC_OK\n");
+	return 0;
+}
+
+static void runnable_child(int index)
+{
+	volatile uint64_t value = index + 1;
+	int iteration;
+
+	for (iteration = 0; iteration < 1000000; iteration++)
+		value = value * 6364136223846793005ULL + 1;
+	_exit(value == UINT64_MAX ? 101 : index);
+}
+
+static int test_runqueue(int count)
+{
+	pid_t children[RUNNABLE_CHILDREN];
+	int done[RUNNABLE_CHILDREN] = { 0 };
+	int index, remaining = count;
+
+	for (index = 0; index < count; index++) {
+		children[index] = fork();
+		if (children[index] < 0)
+			return fail("runqueue-fork", 20);
+		if (!children[index])
+			runnable_child(index);
+	}
+	while (remaining) {
+		for (index = 0; index < count; index++) {
+			pid_t result;
+			int status;
+
+			if (done[index])
+				continue;
+			result = waitpid(children[index], &status, WNOHANG);
+			if (!result)
+				continue;
+			last_wait_status = status;
+			if (result != children[index] || !WIFEXITED(status) ||
+			    WEXITSTATUS(status) != index)
+				return fail("runqueue-wait", 21);
+			done[index] = 1;
+			remaining--;
+		}
+	}
+	pass("SCHED_RUNQUEUE_OK\n");
+	return 0;
+}
+
+static int read_busybox(void)
+{
+	char buffer[1024];
+	ssize_t count;
+	int fd = open("/bin/busybox", O_RDONLY);
+
+	if (fd < 0)
+		return -1;
+	while ((count = read(fd, buffer, sizeof(buffer))) > 0)
+		;
+	if (count < 0 || close(fd))
+		return -1;
+	return 0;
+}
+
+static void mixed_child(int index)
+{
+	volatile uint64_t value = index + 1;
+	char *allocation;
+	int iteration;
+
+	allocation = malloc(65536);
+	if (!allocation)
+		_exit(110);
+	memset(allocation, index, 65536);
+	if (index & 1) {
+		if (read_busybox())
+			_exit(111);
+	} else {
+		for (iteration = 0; iteration < 400000; iteration++)
+			value = value * 2862933555777941757ULL + 3037000493ULL;
+	}
+	free(allocation);
+	_exit(value == UINT64_MAX ? 112 : index);
+}
+
+static int test_mixed(void)
+{
+	pid_t children[MIXED_CHILDREN];
+	int index;
+
+	for (index = 0; index < MIXED_CHILDREN; index++) {
+		children[index] = fork();
+		if (children[index] < 0)
+			return fail("mixed-fork", 30);
+		if (!children[index])
+			mixed_child(index);
+	}
+	for (index = 0; index < MIXED_CHILDREN; index++)
+		if (wait_for_child(children[index], index))
+			return fail("mixed-wait", 31);
+	pass("SCHED_MIXED_OK\n");
+	return 0;
+}
+
+static void tty_waiter(void)
+{
+	char input[32];
+	int fd = open("/dev/ttyS0", O_RDONLY);
+
+	if (fd < 0)
+		_exit(120);
+	pass("SCHED_TTY_READY\n");
+	if (read(fd, input, sizeof(input)) <= 0 || close(fd))
+		_exit(121);
+	_exit(0);
+}
+
+static int test_tty_wait(void)
+{
+	pid_t children[TTY_WAITERS];
+	int index;
+
+	for (index = 0; index < TTY_WAITERS; index++) {
+		children[index] = fork();
+		if (children[index] < 0)
+			return fail("tty-fork", 40);
+		if (!children[index])
+			tty_waiter();
+	}
+	for (index = 0; index < TTY_WAITERS; index++)
+		if (wait_for_child(children[index], 0))
+			return fail("tty-wait", 41);
+	pass("SCHED_TTY_WAIT_OK\n");
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc == 2 && !strcmp(argv[1], "exec-child"))
+		return 0;
+	if (argc == 2 && !strcmp(argv[1], "tty-wait"))
+		return test_tty_wait();
+	if (argc == 2 && !strcmp(argv[1], "smoke")) {
+		if (test_exec(EXEC_SMOKE_ROUNDS) ||
+		    test_runqueue(RUNNABLE_SMOKE_CHILDREN))
+			return 1;
+		pass("SCHED_SMOKE_OK\n");
+		return 0;
+	}
+	if (argc != 1)
+		return fail("arguments", 1);
+	if (test_exec(EXEC_ROUNDS) ||
+	    test_runqueue(RUNNABLE_CHILDREN) || test_mixed())
+		return 1;
+	pass("SCHED_RUNTIME_OK\n");
+	return 0;
+}

--- a/tests/scripts/benchmark-scheduler.py
+++ b/tests/scripts/benchmark-scheduler.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import pty
+import select
+import statistics
+import subprocess
+import sys
+import time
+
+
+COMMANDS = (
+    ":",
+    "/bin/pwd >/dev/null",
+    "/bin/ls /tmp >/dev/null",
+    "/bin/ls /dev >/dev/null",
+    "/bin/ls / >/dev/null",
+    "/bin/ls /",
+)
+
+
+class Guest:
+    def __init__(self, qemu, kernel, root_image, cpus, memory, timeout):
+        self.timeout = timeout
+        self.buffer = b""
+        self.master, slave = pty.openpty()
+        command = [
+            qemu,
+            "-machine", "virt",
+            "-bios", os.environ.get("SBI_FIRMWARE", "default"),
+            "-kernel", kernel,
+            "-m", memory,
+            "-smp", str(cpus),
+            "-nographic",
+            "-snapshot",
+            "-global", "virtio-mmio.force-legacy=false",
+            "-drive", f"file={root_image},if=none,format=raw,id=x0",
+            "-device",
+            "virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0",
+        ]
+        self.process = subprocess.Popen(
+            command,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            close_fds=True,
+        )
+        os.close(slave)
+        try:
+            self.read_until(b"# ")
+        except Exception:
+            self.close()
+            raise
+
+    def read_until(self, marker):
+        deadline = time.monotonic() + self.timeout
+        while marker not in self.buffer:
+            if b"[PANIC]" in self.buffer:
+                raise RuntimeError("kernel panic during scheduler benchmark")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"guest did not produce {marker!r}")
+            readable, _, _ = select.select([self.master], [], [], remaining)
+            if not readable:
+                continue
+            try:
+                data = os.read(self.master, 65536)
+            except OSError as error:
+                raise RuntimeError("QEMU terminal closed") from error
+            if not data:
+                raise RuntimeError("QEMU exited unexpectedly")
+            self.buffer += data
+        position = self.buffer.index(marker) + len(marker)
+        result = self.buffer[:position]
+        self.buffer = self.buffer[position:]
+        return result
+
+    def run(self, command):
+        start = time.perf_counter_ns()
+        os.write(self.master, command.encode() + b"\n")
+        output = self.read_until(b"# ")
+        elapsed = (time.perf_counter_ns() - start) / 1_000_000
+        if b"[PANIC]" in output:
+            raise RuntimeError("kernel panic during scheduler benchmark")
+        for error in (b"Bad address", b"not found", b"No such file"):
+            if error in output:
+                raise RuntimeError(
+                    f"benchmark command failed: {command}: {error!r}")
+        return elapsed
+
+    def cpu_ticks(self):
+        with open(f"/proc/{self.process.pid}/stat", encoding="ascii") as file:
+            fields = file.read().split()
+        return int(fields[13]) + int(fields[14])
+
+    def idle_cpu_percent(self, seconds):
+        ticks = self.cpu_ticks()
+        start = time.monotonic()
+        time.sleep(seconds)
+        elapsed = time.monotonic() - start
+        ticks = self.cpu_ticks() - ticks
+        return ticks / os.sysconf("SC_CLK_TCK") / elapsed * 100
+
+    def close(self):
+        if self.process.poll() is None:
+            try:
+                os.write(self.master, b"\x01x")
+                self.process.wait(timeout=5)
+            except (BrokenPipeError, subprocess.TimeoutExpired):
+                self.process.terminate()
+                try:
+                    self.process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self.process.kill()
+                    self.process.wait()
+        os.close(self.master)
+
+
+def benchmark(args, cpus):
+    guest = Guest(args.qemu, args.kernel, args.root_image, cpus,
+                  args.memory, args.timeout)
+    try:
+        for command in COMMANDS:
+            for _ in range(args.warmups):
+                guest.run(command)
+        idle = guest.idle_cpu_percent(args.idle_seconds)
+        commands = {}
+        for command in COMMANDS:
+            samples = [guest.run(command) for _ in range(args.samples)]
+            commands[command] = {
+                "median_ms": round(statistics.median(samples), 3),
+                "min_ms": round(min(samples), 3),
+                "max_ms": round(max(samples), 3),
+            }
+        return {
+            "idle_host_cpu_percent": round(idle, 1),
+            "commands": commands,
+        }
+    finally:
+        guest.close()
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Measure Caffeinix SMP scheduler behavior under QEMU")
+    parser.add_argument("--qemu", default=os.environ.get(
+        "QEMU", "qemu-system-riscv64"))
+    parser.add_argument("--kernel", default=os.environ.get("KERNEL"))
+    parser.add_argument("--root-image", default=os.environ.get("ROOT_IMAGE"))
+    parser.add_argument("--memory", default="256M")
+    parser.add_argument("--samples", type=int, default=13)
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--idle-seconds", type=float, default=3)
+    parser.add_argument("--timeout", type=float, default=60)
+    parser.add_argument("--max-idle-cpu", type=float, default=100)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--output")
+    args = parser.parse_args()
+    if not args.kernel or not args.root_image:
+        parser.error("--kernel and --root-image are required")
+    args.kernel = os.path.abspath(args.kernel)
+    args.root_image = os.path.abspath(args.root_image)
+    return args
+
+
+def main():
+    args = parse_arguments()
+    result = {"results": {}}
+
+    for cpus in (1, 8):
+        result["results"][str(cpus)] = benchmark(args, cpus)
+    one = result["results"]["1"]["commands"]
+    eight = result["results"]["8"]["commands"]
+    result["eight_to_one_median_ratio"] = {
+        command: round(eight[command]["median_ms"] /
+                       one[command]["median_ms"], 3)
+        for command in COMMANDS
+    }
+    output = json.dumps(result, indent=2, sort_keys=True)
+    print(output)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as file:
+            file.write(output + "\n")
+    if args.check and result["results"]["8"][
+            "idle_host_cpu_percent"] >= args.max_idle_cpu:
+        print("eight-CPU guest consumes a full host CPU while idle",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/build-rootfs.sh
+++ b/tests/scripts/build-rootfs.sh
@@ -180,6 +180,12 @@ install -d \
 	"$tests_dir/tty_runtime.c" \
 	-o "$staging/bin/tty-runtime"
 
+"$musl_cc" \
+	-static -march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror \
+	"$tests_dir/scheduler_runtime.c" \
+	-o "$staging/bin/scheduler-runtime"
+
 if "${cross_compile}readelf" -l "$staging/bin/fs-runtime" |
 	grep -q INTERP; then
 	echo "guest selftest must be statically linked" >&2
@@ -189,6 +195,12 @@ fi
 if "${cross_compile}readelf" -l "$staging/bin/tty-runtime" |
 	grep -q INTERP; then
 	echo "TTY selftest must be statically linked" >&2
+	exit 1
+fi
+
+if "${cross_compile}readelf" -l "$staging/bin/scheduler-runtime" |
+	grep -q INTERP; then
+	echo "scheduler selftest must be statically linked" >&2
 	exit 1
 fi
 

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -42,6 +42,23 @@ expect {
 	eof { abort_test "QEMU exited before shell startup" }
 }
 
+send -- "/bin/scheduler-runtime smoke\r"
+expect {
+	-re {\r?\nSCHED_SMOKE_OK} {}
+	-re {SCHED_RUNTIME_FAIL=[^\r\n]*} {
+		abort_test "scheduler smoke test reported failure"
+	}
+	-re {\[PANIC\]} { abort_test "kernel panic in scheduler smoke test" }
+	timeout { abort_test "scheduler smoke test timeout" }
+	eof { abort_test "QEMU exited during scheduler smoke test" }
+}
+expect {
+	-re {\r?\n# $} {}
+	-re {\[PANIC\]} { abort_test "kernel panic after scheduler smoke test" }
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited before final shell prompt" }
+}
+
 send -- "echo OPENSBI_BOOT_OK\r"
 expect {
 	-re {\r?\nOPENSBI_BOOT_OK} {}

--- a/tests/scripts/run-qemu.exp
+++ b/tests/scripts/run-qemu.exp
@@ -63,6 +63,47 @@ expect {
 }
 expect_prompt
 
+send -- "/bin/scheduler-runtime\r"
+expect {
+	-re {\r?\nSCHED_RUNTIME_OK} {}
+	-re {SCHED_RUNTIME_FAIL=[^\r\n]*} {
+		abort_test "scheduler runtime test reported failure"
+	}
+	-re {\[PANIC\]} { abort_test "kernel panic in scheduler runtime test" }
+	timeout { abort_test "scheduler runtime test timeout" }
+	eof { abort_test "QEMU exited during scheduler runtime test" }
+}
+expect_prompt
+
+send -- "/bin/scheduler-runtime tty-wait\r"
+set ready_count 0
+while {$ready_count < 8} {
+	expect {
+		-re {\r?\nSCHED_TTY_READY} { incr ready_count }
+		-re {SCHED_RUNTIME_FAIL=[^\r\n]*} {
+			abort_test "scheduler TTY wait setup failed"
+		}
+		-re {\[PANIC\]} {
+			abort_test "kernel panic before scheduler TTY wait"
+		}
+		timeout { abort_test "scheduler TTY waiter ready timeout" }
+		eof { abort_test "QEMU exited before scheduler TTY wait" }
+	}
+}
+for {set index 0} {$index < 8} {incr index} {
+	send -- "scheduler-wakeup-$index\r"
+}
+expect {
+	-re {\r?\nSCHED_TTY_WAIT_OK} {}
+	-re {SCHED_RUNTIME_FAIL=[^\r\n]*} {
+		abort_test "scheduler TTY wait test reported failure"
+	}
+	-re {\[PANIC\]} { abort_test "kernel panic in scheduler TTY wait" }
+	timeout { abort_test "scheduler TTY wait completion timeout" }
+	eof { abort_test "QEMU exited during scheduler TTY wait" }
+}
+expect_prompt
+
 send -- "/bin/tty-runtime metadata\r"
 expect {
 	-re {\r?\nTTY_METADATA_OK} {}

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -22,7 +22,7 @@ require_command()
 }
 
 for command in \
-	"$qemu" expect e2fsck debugfs fsck.fat mtype rg \
+	"$qemu" expect e2fsck debugfs fsck.fat mtype python3 rg \
 	"${CROSS_COMPILE:-riscv64-linux-gnu-}objdump" \
 	"${CROSS_COMPILE:-riscv64-linux-gnu-}readelf"; do
 	require_command "$command"
@@ -112,6 +112,11 @@ run_boot_smoke()
 		echo "OpenSBI BusyBox smoke marker is missing" >&2
 		exit 1
 	fi
+	if [ "$(awk '$0 == "SCHED_SMOKE_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "scheduler smoke marker is missing" >&2
+		exit 1
+	fi
 	check_boot_log "$clean" "$cpus"
 }
 
@@ -128,6 +133,11 @@ check_boot_log "$clean_log" "$QEMU_CPUS"
 
 for marker in \
 	BUSYBOX_SHELL_OK \
+	SCHED_EXEC_OK \
+	SCHED_RUNQUEUE_OK \
+	SCHED_MIXED_OK \
+	SCHED_RUNTIME_OK \
+	SCHED_TTY_WAIT_OK \
 	TTY_METADATA_OK \
 	TTY_CANONICAL_OK \
 	TTY_RAW_OK \
@@ -165,7 +175,8 @@ if ! grep -Fq $'abc\b \bd' "$qemu_log"; then
 fi
 
 if grep -Eq \
-	'\[PANIC\]|Unhandled interrupt|FS_RUNTIME_FAIL=|TTY_RUNTIME_FAIL=' \
+	-e '\[PANIC\]|Unhandled interrupt' \
+	-e 'FS_RUNTIME_FAIL=|SCHED_RUNTIME_FAIL=|TTY_RUNTIME_FAIL=' \
 	"$clean_log"; then
 	echo "QEMU log contains a guest failure" >&2
 	exit 1
@@ -206,5 +217,12 @@ if [ "$fat_utf8" != utf8 ]; then
 	echo "FAT UTF-8 long-name value was not persisted" >&2
 	exit 1
 fi
+
+"$script_dir/benchmark-scheduler.py" \
+	--qemu "$qemu" \
+	--kernel "$KERNEL" \
+	--root-image "$root_image" \
+	--output "$test_output/scheduler-benchmark.json" \
+	--check
 
 echo QEMU_RUNTIME_OK


### PR DESCRIPTION
The scheduler still scans process slots, relies on channel-wide wakeups,
and leaves idle harts spinning. This scales poorly under SMP and makes
blocking object lifetime difficult to reason about.

Make threads the execution unit, add a FIFO runnable queue and object wait
queues, and defer timer preemption to trap return. Use SBI IPIs and WFI for
SMP wakeup and idle, while serializing allocator, PID, and exit lifetime
races.

CI covers 1, 2, 4, and 8 harts, runnable oversubscription, fork/exec/wait,
allocator and filesystem contention, TTY waiters, and idle behavior. The
workflow also accepts stacked pull-request bases so each following layer can
be tested independently.
