### PR TITLE
kernel: add asynchronous execution primitives

### DIFF
--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -6,6 +6,7 @@
 #include <printf.h>
 #include <plic.h>
 #include <timer.h>
+#include <wait.h>
 
 extern void kernel_vec(void);
 extern char trampoline[], user_vec[], user_ret[];
@@ -47,8 +48,9 @@ static int dev_intr(uint64 scause)
                 }
                 return 1;
         } else if(scause == 0x8000000000000005L) {
-                /* Supervisor timer interrupt delivered through SBI TIME. */
+		/* Supervisor timer interrupt delivered through SBI TIME. */
 		timer_interrupt();
+		wait_queue_expire(time_r());
                 if(cpuid() == 0) {
                         tick_intr();
 		}

--- a/include/kernel_config.h
+++ b/include/kernel_config.h
@@ -22,6 +22,8 @@
 /* For ms */
 #define TICK_INTERVAL                   100
 
+#define WORKQUEUE_NAME                  "kworker"
+
 #define ROOT_FILESYSTEM                 "ext4"
 #define INIT_PATH                       "/bin/sh"
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,5 +6,5 @@ CFLAGS_file.o :=
 obj-y += string.o palloc.o spinlock.o ktime.o thread.o wait.o \
 sleeplock.o switchto.o trampoline.o process.o\
 plic.o console.o printf.o scheduler.o \
-exec.o sysfile.o syscall.o sysproc.o main.o
+exec.o sysfile.o syscall.o sysproc.o workqueue.o main.o
 obj-y += irq/

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -3,7 +3,7 @@ EXTRA_LDFLAGS := -T ./kernel.ld
 CFLAGS_file.o := 
 
 
-obj-y += string.o palloc.o spinlock.o thread.o wait.o \
+obj-y += string.o palloc.o spinlock.o ktime.o thread.o wait.o \
 sleeplock.o switchto.o trampoline.o process.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o main.o

--- a/kernel/include/ktime.h
+++ b/kernel/include/ktime.h
@@ -1,0 +1,11 @@
+#ifndef __CAFFEINIX_KERNEL_KTIME_H
+#define __CAFFEINIX_KERNEL_KTIME_H
+
+#include <typedefs.h>
+
+uint64 ktime_get_ticks(void);
+uint64 ktime_get_ms(void);
+uint64 ktime_get_ns(void);
+uint64 ktime_ms_to_ticks(uint64 milliseconds);
+
+#endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -30,6 +30,7 @@ void yield(void);
 void sched(void);
 void scheduler_exit(void);
 void scheduler_exit_locked(void);
+void scheduler_block_current(void);
 void scheduler_make_runnable(thread_t thread);
 void scheduler_request_resched(void);
 int scheduler_should_resched(void);

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -19,6 +19,7 @@
 
 typedef struct process *process_t;
 struct wait_queue;
+typedef void (*thread_func_t)(void *);
 
 typedef enum thread_state {
         THREAD_UNUSED,
@@ -108,21 +109,29 @@ typedef struct thread {
         struct context context;
 
         process_t home;
+	thread_func_t kernel_function;
+	void *kernel_argument;
+	uint8 kernel_thread;
         struct list run_node;
         uint8 on_runqueue;
         struct wait_queue *waiting_on;
         struct list wait_node;
         uint8 on_waitqueue;
+	struct list timeout_node;
+	uint64 wait_deadline;
+	int wait_result;
+	uint8 on_timeout_queue;
 }*thread_t;
 
 extern struct thread thread[NTHREAD];
-
-typedef void (*thread_func_t)(void*);
 
 void map_kernel_stack(pagedir_t pgdir);
 
 void thread_setup(void);
 thread_t thread_alloc(process_t p);
 void thread_free(thread_t t);
+thread_t kernel_thread_create(const char *name, thread_func_t function,
+			      void *argument);
+void kernel_thread_reap(thread_t thread);
 
 #endif

--- a/kernel/include/wait.h
+++ b/kernel/include/wait.h
@@ -18,9 +18,13 @@ typedef struct wait_queue {
  */
 void wait_queue_init(wait_queue_t queue, const char *name);
 void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock);
+int wait_queue_sleep_timeout(wait_queue_t queue,
+			     spinlock_t condition_lock, uint64 timeout_ms);
 int wait_queue_wake_one(wait_queue_t queue);
 int wait_queue_wake_all(wait_queue_t queue);
 int wait_queue_wake_thread(struct thread *thread);
 int wait_queue_empty(wait_queue_t queue);
+void wait_queue_timeout_init(void);
+void wait_queue_expire(uint64 now);
 
 #endif

--- a/kernel/include/workqueue.h
+++ b/kernel/include/workqueue.h
@@ -1,0 +1,26 @@
+#ifndef __CAFFEINIX_KERNEL_WORKQUEUE_H
+#define __CAFFEINIX_KERNEL_WORKQUEUE_H
+
+#include <list.h>
+#include <typedefs.h>
+#include <wait.h>
+
+struct work_struct;
+
+typedef void (*work_func_t)(struct work_struct *work);
+
+struct work_struct {
+	struct list node;
+	work_func_t function;
+	uint8 pending;
+	uint8 running;
+	struct wait_queue completion;
+};
+
+void workqueue_init(void);
+void work_init(struct work_struct *work, work_func_t function);
+int schedule_work(struct work_struct *work);
+int cancel_work(struct work_struct *work);
+int cancel_work_sync(struct work_struct *work);
+
+#endif

--- a/kernel/ktime.c
+++ b/kernel/ktime.c
@@ -1,0 +1,51 @@
+#include <ktime.h>
+#include <riscv.h>
+#include <timer.h>
+
+#define NSEC_PER_SEC 1000000000ULL
+#define MSEC_PER_SEC 1000ULL
+
+uint64 ktime_get_ticks(void)
+{
+	return time_r();
+}
+
+uint64 ktime_get_ms(void)
+{
+	uint64 ticks = time_r();
+	uint64 frequency = timer_frequency();
+
+	return ticks / frequency * MSEC_PER_SEC +
+	       ticks % frequency * MSEC_PER_SEC / frequency;
+}
+
+uint64 ktime_get_ns(void)
+{
+	uint64 ticks = time_r();
+	uint64 frequency = timer_frequency();
+
+	return ticks / frequency * NSEC_PER_SEC +
+	       ticks % frequency * NSEC_PER_SEC / frequency;
+}
+
+uint64 ktime_ms_to_ticks(uint64 milliseconds)
+{
+	uint64 frequency = timer_frequency();
+	uint64 seconds = milliseconds / MSEC_PER_SEC;
+	uint64 remainder = milliseconds % MSEC_PER_SEC;
+	uint64 fraction;
+	uint64 partial;
+	uint64 ticks;
+
+	if (seconds > ~(uint64)0 / frequency)
+		return ~(uint64)0;
+	ticks = seconds * frequency;
+	partial = frequency / MSEC_PER_SEC * remainder;
+	fraction = frequency % MSEC_PER_SEC * remainder;
+	partial += fraction / MSEC_PER_SEC;
+	if (fraction % MSEC_PER_SEC)
+		partial++;
+	if (ticks > ~(uint64)0 - partial)
+		return ~(uint64)0;
+	return ticks + partial;
+}

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -40,6 +40,7 @@
 #include <sbi.h>
 #include <timer.h>
 #include <cpu.h>
+#include <wait.h>
 
 volatile static uint8 start = 0;
 extern char end[];
@@ -70,6 +71,7 @@ void main(void)
                 kvm_init();
                 thread_setup();
                 scheduler_init();
+		wait_queue_timeout_init();
                 trap_init_lock();
                 trap_init();
 		timer_init_hart();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -41,6 +41,7 @@
 #include <timer.h>
 #include <cpu.h>
 #include <wait.h>
+#include <workqueue.h>
 
 volatile static uint8 start = 0;
 extern char end[];
@@ -72,6 +73,7 @@ void main(void)
                 thread_setup();
                 scheduler_init();
 		wait_queue_timeout_init();
+		workqueue_init();
                 trap_init_lock();
                 trap_init();
 		timer_init_hart();

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -155,14 +155,17 @@ void scheduler(void)
 
                 spinlock_acquire(&t->lock);
                 if(t->state != THREAD_RUNNABLE || t->on_runqueue ||
-                   !t->home)
+		   (!t->home && !t->kernel_thread))
                         PANIC("invalid scheduled thread");
                 t->state = THREAD_RUNNING;
-                t->home->tinfo->addr = TRAPFRAME(t->id_p);
+		if (t->home)
+			t->home->tinfo->addr = TRAPFRAME(t->id_p);
                 cpu->current = t;
 		cpu->need_resched = 0;
                 switchto(&cpu->context, &t->context);
                 cpu->current = 0;
+		if (t->state == THREAD_EXITED && t->kernel_thread)
+			kernel_thread_reap(t);
                 spinlock_release(&t->lock);
         } 
 }
@@ -229,6 +232,16 @@ void scheduler_exit(void)
 		PANIC("exit without thread");
 	spinlock_acquire(&current->lock);
 	scheduler_exit_locked();
+}
+
+void scheduler_block_current(void)
+{
+	thread_t current = cur_thread();
+
+	if (!current || !spinlock_holding(&current->lock) ||
+	    current->state != THREAD_RUNNING)
+		PANIC("block non-running thread");
+	current->state = THREAD_SLEEPING;
 }
 
 void scheduler_request_resched(void)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -15,11 +15,24 @@
 #include <printf.h>
 #include <vm.h>
 #include <process.h>
+#include <scheduler.h>
 
 struct thread thread[NTHREAD];
 
 static int next_tid = 1;
 static struct spinlock tid_lock;
+
+static void kernel_thread_entry(void)
+{
+	thread_t current = cur_thread();
+	thread_func_t function = current->kernel_function;
+	void *argument = current->kernel_argument;
+
+	spinlock_release(&current->lock);
+	intr_on();
+	function(argument);
+	scheduler_exit();
+}
 
 static int tid_alloc(void)
 {
@@ -61,6 +74,8 @@ void thread_setup(void)
                 t->waiting_on = 0;
                 t->on_waitqueue = 0;
                 list_init(&t->wait_node);
+		t->on_timeout_queue = 0;
+		list_init(&t->timeout_node);
                 strncpy(t->name, "thread", 7);
         }
 }
@@ -93,6 +108,11 @@ found:
         t->waiting_on = 0;
         t->on_waitqueue = 0;
         list_init(&t->wait_node);
+	t->on_timeout_queue = 0;
+	list_init(&t->timeout_node);
+	t->kernel_function = 0;
+	t->kernel_argument = 0;
+	t->kernel_thread = 0;
 
         t->trapframe = (trapframe_t)palloc();
         if(!t->trapframe) {
@@ -117,6 +137,64 @@ r1:
         t->home = 0;
         spinlock_release(&t->lock);
         return 0;
+}
+
+thread_t kernel_thread_create(const char *name, thread_func_t function,
+			      void *argument)
+{
+	thread_t t;
+
+	if (!name || !function)
+		return 0;
+	for (t = thread; t <= &thread[NTHREAD - 1]; t++) {
+		if (spinlock_trylock(&t->lock))
+			continue;
+		if (t->state == THREAD_UNUSED)
+			goto found;
+		spinlock_release(&t->lock);
+	}
+	return 0;
+
+found:
+	t->state = THREAD_ALLOCATED;
+	t->tid = tid_alloc();
+	t->id_p = -1;
+	t->home = 0;
+	t->trapframe = 0;
+	t->kernel_function = function;
+	t->kernel_argument = argument;
+	t->kernel_thread = 1;
+	t->on_runqueue = 0;
+	list_init(&t->run_node);
+	t->waiting_on = 0;
+	t->on_waitqueue = 0;
+	list_init(&t->wait_node);
+	t->on_timeout_queue = 0;
+	list_init(&t->timeout_node);
+	memset(&t->context, 0, sizeof(t->context));
+	t->context.ra = (uint64)kernel_thread_entry;
+	t->context.sp = t->kstack + KSTACK_SIZE;
+	safe_strncpy(t->name, name, sizeof(t->name));
+	scheduler_make_runnable(t);
+	spinlock_release(&t->lock);
+	return t;
+}
+
+void kernel_thread_reap(thread_t t)
+{
+	if (!t || !spinlock_holding(&t->lock) || !t->kernel_thread ||
+	    t->state != THREAD_EXITED || t->on_runqueue ||
+	    t->on_waitqueue || t->on_timeout_queue)
+		PANIC("reap kernel thread");
+	t->state = THREAD_UNUSED;
+	t->tid = 0;
+	t->kernel_thread = 0;
+	t->kernel_function = 0;
+	t->kernel_argument = 0;
+	list_init(&t->run_node);
+	list_init(&t->wait_node);
+	list_init(&t->timeout_node);
+	safe_strncpy(t->name, "thread", sizeof(t->name));
 }
 
 void thread_free(thread_t t)
@@ -148,4 +226,5 @@ void thread_free(thread_t t)
         t->home = 0;
         list_init(&t->run_node);
         list_init(&t->wait_node);
+	list_init(&t->timeout_node);
 }

--- a/kernel/wait.c
+++ b/kernel/wait.c
@@ -1,7 +1,19 @@
 #include <debug.h>
+#include <ktime.h>
 #include <scheduler.h>
 #include <thread.h>
 #include <wait.h>
+
+static struct {
+	struct spinlock lock;
+	struct list waiters;
+} timeout_queue;
+
+void wait_queue_timeout_init(void)
+{
+	spinlock_init(&timeout_queue.lock, "wait timeouts");
+	list_init(&timeout_queue.waiters);
+}
 
 void wait_queue_init(wait_queue_t queue, const char *name)
 {
@@ -10,33 +22,82 @@ void wait_queue_init(wait_queue_t queue, const char *name)
 	queue->name = name;
 }
 
-void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock)
+static void timeout_insert_locked(thread_t thread)
+{
+	struct list *node;
+
+	for (node = timeout_queue.waiters.next;
+	     node != &timeout_queue.waiters; node = node->next) {
+		thread_t queued;
+
+		queued = list_entry(node, struct thread, timeout_node);
+		if (thread->wait_deadline < queued->wait_deadline)
+			break;
+	}
+	list_insert_before(node, &thread->timeout_node);
+	thread->on_timeout_queue = 1;
+}
+
+static int wait_queue_sleep_deadline(wait_queue_t queue,
+				     spinlock_t condition_lock,
+				     uint64 deadline)
 {
 	thread_t current = cur_thread();
+	int result;
 
 	if (!current || !spinlock_holding(condition_lock))
 		PANIC("wait without condition lock");
+	spinlock_acquire(&timeout_queue.lock);
 	spinlock_acquire(&queue->lock);
 	spinlock_acquire(&current->lock);
 	if (current->state != THREAD_RUNNING || current->on_waitqueue ||
-	    current->waiting_on)
+	    current->waiting_on || current->on_timeout_queue)
 		PANIC("invalid wait state");
 	current->waiting_on = queue;
 	current->on_waitqueue = 1;
+	current->wait_deadline = deadline;
+	current->wait_result = 0;
 	list_insert_before(&queue->waiters, &current->wait_node);
-	current->state = THREAD_SLEEPING;
+	if (deadline)
+		timeout_insert_locked(current);
+	scheduler_block_current();
 	spinlock_release(condition_lock);
 	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
 
 	sched();
 
-	if (current->on_waitqueue || current->waiting_on)
+	if (current->on_waitqueue || current->waiting_on ||
+	    current->on_timeout_queue)
 		PANIC("scheduled wait entry");
+	result = current->wait_result;
 	spinlock_release(&current->lock);
 	spinlock_acquire(condition_lock);
+	return result;
 }
 
-static void wait_queue_wake_locked(wait_queue_t queue, thread_t thread)
+void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock)
+{
+	(void)wait_queue_sleep_deadline(queue, condition_lock, 0);
+}
+
+int wait_queue_sleep_timeout(wait_queue_t queue,
+			     spinlock_t condition_lock, uint64 timeout_ms)
+{
+	uint64 now, delta, deadline;
+
+	if (!timeout_ms)
+		return -1;
+	now = ktime_get_ticks();
+	delta = ktime_ms_to_ticks(timeout_ms);
+	deadline = now + delta;
+	if (deadline < now)
+		deadline = ~(uint64)0;
+	return wait_queue_sleep_deadline(queue, condition_lock, deadline);
+}
+
+static void wait_queue_wake_locked(wait_queue_t queue, thread_t thread,
+				   int result)
 {
 	spinlock_acquire(&thread->lock);
 	if (!thread->on_waitqueue || thread->waiting_on != queue ||
@@ -45,6 +106,11 @@ static void wait_queue_wake_locked(wait_queue_t queue, thread_t thread)
 	list_remove(&thread->wait_node);
 	thread->on_waitqueue = 0;
 	thread->waiting_on = 0;
+	if (thread->on_timeout_queue) {
+		list_remove(&thread->timeout_node);
+		thread->on_timeout_queue = 0;
+	}
+	thread->wait_result = result;
 	scheduler_make_runnable(thread);
 	spinlock_release(&thread->lock);
 }
@@ -54,15 +120,18 @@ int wait_queue_wake_one(wait_queue_t queue)
 	thread_t thread;
 	list_t node;
 
+	spinlock_acquire(&timeout_queue.lock);
 	spinlock_acquire(&queue->lock);
 	node = queue->waiters.next;
 	if (node == &queue->waiters) {
 		spinlock_release(&queue->lock);
+		spinlock_release(&timeout_queue.lock);
 		return 0;
 	}
 	thread = list_entry(node, struct thread, wait_node);
-	wait_queue_wake_locked(queue, thread);
+	wait_queue_wake_locked(queue, thread, 0);
 	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
 	return 1;
 }
 
@@ -72,13 +141,15 @@ int wait_queue_wake_all(wait_queue_t queue)
 	list_t node;
 	int count = 0;
 
+	spinlock_acquire(&timeout_queue.lock);
 	spinlock_acquire(&queue->lock);
 	while ((node = queue->waiters.next) != &queue->waiters) {
 		thread = list_entry(node, struct thread, wait_node);
-		wait_queue_wake_locked(queue, thread);
+		wait_queue_wake_locked(queue, thread, 0);
 		count++;
 	}
 	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
 	return count;
 }
 
@@ -86,32 +157,56 @@ int wait_queue_wake_thread(thread_t thread)
 {
 	wait_queue_t queue;
 
-	for (;;) {
-		spinlock_acquire(&thread->lock);
-		if (thread->state != THREAD_SLEEPING ||
-		    !thread->on_waitqueue || !thread->waiting_on) {
-			spinlock_release(&thread->lock);
-			return 0;
-		}
-		queue = thread->waiting_on;
-		/*
-		 * Normal wakeup takes queue->lock before thread->lock. Do not
-		 * block in the inverse order: retry so that an in-flight waker
-		 * can remove the entry. Keeping thread->lock across a successful
-		 * trylock also keeps the attached queue alive.
-		 */
-		if (spinlock_trylock(&queue->lock)) {
-			spinlock_release(&thread->lock);
-			continue;
-		}
-		list_remove(&thread->wait_node);
-		thread->on_waitqueue = 0;
-		thread->waiting_on = 0;
-		scheduler_make_runnable(thread);
-		spinlock_release(&queue->lock);
-		spinlock_release(&thread->lock);
-		return 1;
+	spinlock_acquire(&timeout_queue.lock);
+	queue = thread->waiting_on;
+	if (!queue) {
+		spinlock_release(&timeout_queue.lock);
+		return 0;
 	}
+	spinlock_acquire(&queue->lock);
+	spinlock_acquire(&thread->lock);
+	if (thread->state != THREAD_SLEEPING || !thread->on_waitqueue ||
+	    thread->waiting_on != queue) {
+		spinlock_release(&thread->lock);
+		spinlock_release(&queue->lock);
+		spinlock_release(&timeout_queue.lock);
+		return 0;
+	}
+	list_remove(&thread->wait_node);
+	thread->on_waitqueue = 0;
+	thread->waiting_on = 0;
+	if (thread->on_timeout_queue) {
+		list_remove(&thread->timeout_node);
+		thread->on_timeout_queue = 0;
+	}
+	thread->wait_result = 0;
+	scheduler_make_runnable(thread);
+	spinlock_release(&thread->lock);
+	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
+	return 1;
+}
+
+void wait_queue_expire(uint64 now)
+{
+	struct list *node;
+	thread_t thread;
+	wait_queue_t queue;
+
+	spinlock_acquire(&timeout_queue.lock);
+	while ((node = timeout_queue.waiters.next) !=
+	       &timeout_queue.waiters) {
+		thread = list_entry(node, struct thread, timeout_node);
+		if (thread->wait_deadline > now)
+			break;
+		queue = thread->waiting_on;
+		if (!queue)
+			PANIC("timeout without wait queue");
+		spinlock_acquire(&queue->lock);
+		wait_queue_wake_locked(queue, thread, -1);
+		spinlock_release(&queue->lock);
+	}
+	spinlock_release(&timeout_queue.lock);
 }
 
 int wait_queue_empty(wait_queue_t queue)

--- a/kernel/workqueue.c
+++ b/kernel/workqueue.c
@@ -1,0 +1,123 @@
+#include <debug.h>
+#include <kernel_config.h>
+#include <scheduler.h>
+#include <spinlock.h>
+#include <wait.h>
+#include <workqueue.h>
+
+static struct {
+	struct spinlock lock;
+	struct wait_queue wait;
+	struct list pending;
+	struct work_struct *current;
+	thread_t worker;
+} system_workqueue;
+
+static void workqueue_thread(void *argument)
+{
+	(void)argument;
+
+	for (;;) {
+		struct work_struct *work;
+		struct list *node;
+
+		spinlock_acquire(&system_workqueue.lock);
+		while (system_workqueue.pending.next ==
+		       &system_workqueue.pending)
+			wait_queue_sleep(&system_workqueue.wait,
+			                 &system_workqueue.lock);
+		node = system_workqueue.pending.next;
+		list_remove(node);
+		work = list_entry(node, struct work_struct, node);
+		work->pending = 0;
+		work->running = 1;
+		system_workqueue.current = work;
+		spinlock_release(&system_workqueue.lock);
+		work->function(work);
+		spinlock_acquire(&system_workqueue.lock);
+		system_workqueue.current = 0;
+		work->running = 0;
+		wait_queue_wake_all(&work->completion);
+		spinlock_release(&system_workqueue.lock);
+	}
+}
+
+void workqueue_init(void)
+{
+	spinlock_init(&system_workqueue.lock, "system workqueue");
+	wait_queue_init(&system_workqueue.wait, "system workqueue");
+	list_init(&system_workqueue.pending);
+	system_workqueue.current = 0;
+	system_workqueue.worker =
+		kernel_thread_create(WORKQUEUE_NAME, workqueue_thread, 0);
+	if (!system_workqueue.worker)
+		PANIC("create system workqueue");
+}
+
+void work_init(struct work_struct *work, work_func_t function)
+{
+	if (!work || !function)
+		PANIC("invalid work");
+	list_init(&work->node);
+	work->function = function;
+	work->pending = 0;
+	work->running = 0;
+	wait_queue_init(&work->completion, "work completion");
+}
+
+int schedule_work(struct work_struct *work)
+{
+	if (!work || !work->function)
+		return -1;
+	spinlock_acquire(&system_workqueue.lock);
+	if (work->pending) {
+		spinlock_release(&system_workqueue.lock);
+		return 0;
+	}
+	work->pending = 1;
+	list_insert_before(&system_workqueue.pending, &work->node);
+	wait_queue_wake_one(&system_workqueue.wait);
+	spinlock_release(&system_workqueue.lock);
+	return 1;
+}
+
+int cancel_work(struct work_struct *work)
+{
+	if (!work)
+		return -1;
+	spinlock_acquire(&system_workqueue.lock);
+	if (!work->pending) {
+		spinlock_release(&system_workqueue.lock);
+		return 0;
+	}
+	list_remove(&work->node);
+	work->pending = 0;
+	spinlock_release(&system_workqueue.lock);
+	return 1;
+}
+
+int cancel_work_sync(struct work_struct *work)
+{
+	int cancelled = 0;
+
+	if (!work)
+		return -1;
+	spinlock_acquire(&system_workqueue.lock);
+	for (;;) {
+		if (work->pending) {
+			list_remove(&work->node);
+			work->pending = 0;
+			cancelled = 1;
+		}
+		if (!work->running)
+			break;
+		cancelled = 1;
+		if (system_workqueue.current == work &&
+		    cur_thread() == system_workqueue.worker)
+			break;
+		wait_queue_sleep(&work->completion,
+				 &system_workqueue.lock);
+	}
+	spinlock_release(&system_workqueue.lock);
+	return cancelled;
+}


### PR DESCRIPTION
Depends on #43.

Drivers need execution contexts that can sleep, expire waits, and defer work
outside interrupt handlers. The kernel currently has no common facility for
those operations.

Add a monotonic kernel clock, timed wait queues, scheduler-managed kernel
threads, and a system workqueue. These primitives provide the execution
boundary needed by later asynchronous drivers without adding device-specific
worker loops.

CI builds the new primitives and boots the existing SMP runtime matrix. No
driver or network tests are introduced in this layer.
