### PR TITLE
net: add the network device framework

### DIFF
--- a/Documentation/networking/virtio.md
+++ b/Documentation/networking/virtio.md
@@ -1,8 +1,8 @@
 # VirtIO and DMA contracts
 
-The generic VirtIO code separates device drivers from their transport.  The
+The generic VirtIO code is shared by the block and network drivers.  The
 transport owns registers, interrupts, queue construction, and notification;
-the block driver owns requests and their completion lifetime.
+the device driver owns requests and their completion lifetime.
 
 ## Device and driver lifetime
 
@@ -55,8 +55,33 @@ to the free list.  Sixteen-bit shadow indices intentionally wrap.  A device
 cannot report more unconsumed used elements than the queue size.
 
 The IRQ handler acknowledges MMIO interrupt status before invoking bounded
-queue callbacks.  The block callback completes already-submitted requests
-and does not allocate objects, copy userspace data, or sleep.
+queue callbacks.  The block callback completes already-submitted requests;
+the network callback schedules its budgeted worker.  Neither callback may
+allocate protocol objects, copy userspace data, or sleep.
+
+The network core marks an interface down before draining active
+`start_xmit()` calls.  The driver's stop callback therefore cannot overlap a
+new or already admitted transmission.  A stopped receive path may recycle
+device buffers, but it must not deliver their packets to the network core.
+State notifications run after the lifecycle transition is committed, so a
+notification may open or close its device.  Recursive state changes are
+queued until the current callback returns.  Unregistration is synchronous
+before driver storage can be released.  It returns an error when called by a
+receive, state, or `start_xmit()` callback; such a callback must defer
+unregistration until it returns to its caller.
+
+Carrier changes reported by the system workqueue are delivered from separate
+core-owned work, so callbacks do not return through work embedded in driver
+storage.  Device lookups acquire a lifecycle reference; callers must use
+`net_device_put()` when finished, and unregistration waits for those
+references before removing the device from the registry.
+
+Receive callbacks are serialized, including same-thread loopback reentry.
+Recursive packets remain queued until the current callback returns, so
+callback unregistration can drain every invocation except its current caller
+without allowing an outer recursive invocation to retain stale state.  Each
+queued packet pins its device until delivery or disposal, preventing removal
+from reclaiming driver storage while receive work still refers to it.
 
 ## Block driver
 
@@ -74,6 +99,7 @@ disks therefore cannot redirect storage.
 ## Supported VirtIO subset
 
 The implementation requires modern VirtIO MMIO version 2 and split rings.
-It supports block ID 2.  Packed rings, indirect descriptors, event index,
-network devices, shared interrupts, reset recovery, hot removal, and legacy
-MMIO are deferred.  `virtio-blk` negotiates optional flush.
+It supports block ID 2 and network ID 1.  Packed rings, indirect descriptors,
+event index, shared interrupts, reset recovery, hot removal, and legacy MMIO
+are deferred.  `virtio-net` negotiates only MAC and link-status features;
+`virtio-blk` negotiates optional flush.

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ export TOPDIR
 # variable records (the subdirectory must contain a makefile)
 obj-y += arch/riscv/boot/
 obj-y += drivers/
+obj-y += net/
 obj-y += kernel/fs/
 obj-y += kernel/
 obj-y += arch/riscv/
@@ -128,7 +129,7 @@ qemu-gdb: all .gdbinit check-fs-img
 	@echo "*** Now run 'gdb' in another window." 1>&2
 
 clean:
-	@find arch drivers kernel -type f \( -name "*.o" -o \
+	@find arch drivers kernel net -type f \( -name "*.o" -o \
 		-name "*.asm" -o \
 		-name "*.sym" -o -name "*.d" \) -delete
 	@find . -maxdepth 1 -type f \( -name "*.o" -o \

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ QEMU ?= qemu-system-riscv64
 SBI_FIRMWARE ?= default
 FS_IMG ?=
 FAT_IMG ?=
+NET_BACKEND ?=
+NET_BUS ?= virtio-mmio-bus.2
+NET_MAC ?= 52:54:00:12:34:56
 MEMORY ?= 256M
 QEMUOPTS = -machine virt -bios $(SBI_FIRMWARE) -kernel $(TARGET)
 QEMUOPTS += -m $(MEMORY) -smp $(CPUS) -nographic
@@ -95,6 +98,10 @@ QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 ifneq ($(strip $(FAT_IMG)),)
 QEMUOPTS += -drive file=$(FAT_IMG),if=none,format=raw,id=x1
 QEMUOPTS += -device virtio-blk-device,drive=x1,bus=virtio-mmio-bus.1
+endif
+ifneq ($(strip $(NET_BACKEND)),)
+QEMUOPTS += -netdev $(NET_BACKEND),id=n0
+QEMUOPTS += -device virtio-net-device,netdev=n0,bus=$(NET_BUS),mac=$(NET_MAC)
 endif
 ifndef CPUS
 CPUS := 8

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifndef KBUILD_RECURSIVE
 built-in.o: start_recursive_build
 endif
 
-$(TARGET) : built-in.o
+$(TARGET) : built-in.o kernel/kernel.ld
 	@if [ ! -d $(OUTPUT) ]; then \
         	mkdir $(OUTPUT); \
     	fi

--- a/Makefile.build
+++ b/Makefile.build
@@ -4,7 +4,6 @@ __build:
 obj-y :=
 subdir-y :=
 EXTRA_CFLAGS :=
-EXTRA_LDFLAGS :=
 
 # Tell the top-level Makefile that it is being parsed by the recursive build
 # engine, so it does not add the top-level bootstrap dependency again.
@@ -68,7 +67,7 @@ built-in.o : $(cur_objs) $(subdir_objs)
     # LD represents the cross-compiler linker; the -r option represents relocatable output, 
     # and an output file can be input again as ld
     # -o Set output file; $@ target name; $^ all non-duplicate dependent files
-	$(LD) $(LDFLAGS) $(EXTRA_LDFLAGS) -r -o $@ $^
+	$(LD) $(LDFLAGS) -r -o $@ $^
 
 dep_file = .$@.d
 

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -1,5 +1,4 @@
 EXTRA_CFLAGS := -I ../../include -I ./include -I ../../kernel/include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
 CFLAGS_file.o := 
 
 

--- a/arch/riscv/boot/Makefile
+++ b/arch/riscv/boot/Makefile
@@ -1,5 +1,4 @@
 EXTRA_CFLAGS := -I ../../../include -I ../include
-EXTRA_LDFLAGS := -T ../../../kernel/kernel.ld
 CFLAGS_file.o := 
 
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,6 +1,4 @@
 EXTRA_CFLAGS := -I ../kernel/include -I ../arch/riscv/include -I ../include
-EXTRA_LDFLAGS := -T ../kernel/kernel.ld
-
 obj-y += base/
 obj-y += block/
 obj-y += dma/

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -2,6 +2,7 @@ EXTRA_CFLAGS := -I ../kernel/include -I ../arch/riscv/include -I ../include
 obj-y += base/
 obj-y += block/
 obj-y += dma/
+obj-y += net/
 obj-y += of/
 obj-y += platform/
 obj-y += tty/

--- a/drivers/base/Makefile
+++ b/drivers/base/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += core.o selftest.o

--- a/drivers/block/Makefile
+++ b/drivers/block/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += core.o virtio_blk.o

--- a/drivers/dma/Makefile
+++ b/drivers/dma/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += mapping.o

--- a/drivers/net/Makefile
+++ b/drivers/net/Makefile
@@ -1,0 +1,3 @@
+EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
+EXTRA_CFLAGS += -I ../../include
+obj-y += virtio_net.o

--- a/drivers/net/virtio_net.c
+++ b/drivers/net/virtio_net.c
@@ -1,0 +1,370 @@
+#include <debug.h>
+#include <mystring.h>
+#include <netdevice.h>
+#include <palloc.h>
+#include <printf.h>
+#include <virtio.h>
+#include <virtio_ring.h>
+#include <workqueue.h>
+
+#define VIRTIO_NET_F_MAC 5
+#define VIRTIO_NET_F_STATUS 16
+#define VIRTIO_NET_S_LINK_UP 1
+#define VIRTIO_NET_CONFIG_STATUS 6
+
+#define VIRTIO_NET_RX_QUEUE 0
+#define VIRTIO_NET_TX_QUEUE 1
+#define VIRTIO_NET_QUEUE_COUNT 2
+#define VIRTIO_NET_RX_BUFFERS 32
+#define VIRTIO_NET_RX_BUDGET 32
+
+struct virtio_net_header {
+	uint8 flags;
+	uint8 gso_type;
+	uint16 header_length;
+	uint16 gso_size;
+	uint16 checksum_start;
+	uint16 checksum_offset;
+	uint16 num_buffers;
+};
+
+/* VERSION_1 devices always include num_buffers in the network header. */
+_Static_assert(sizeof(struct virtio_net_header) == 12,
+	       "VirtIO net header layout changed");
+
+struct virtio_net_rx_buffer {
+	void *page;
+};
+
+struct virtio_net_tx_request {
+	struct virtio_net_header header;
+	struct net_packet *packet;
+};
+
+struct virtio_net {
+	struct virtio_device *virtio;
+	struct virtqueue *rx_queue;
+	struct virtqueue *tx_queue;
+	struct net_device netdev;
+	struct work_struct poll_work;
+	uint32 rx_buffers;
+	uint8 rx_enabled;
+};
+
+static void virtio_net_update_carrier(struct virtio_net *network)
+{
+	uint16 status = VIRTIO_NET_S_LINK_UP;
+
+	if (virtio_has_feature(network->virtio, VIRTIO_NET_F_STATUS))
+		network->virtio->config->get_config(network->virtio,
+			VIRTIO_NET_CONFIG_STATUS, &status, sizeof(status));
+	net_device_set_carrier(&network->netdev,
+			       status & VIRTIO_NET_S_LINK_UP);
+}
+
+static int virtio_net_post_rx(struct virtio_net *network,
+			      struct virtio_net_rx_buffer *receive)
+{
+	struct virtio_buffer buffer = {
+		.address = receive->page,
+		.length = sizeof(struct virtio_net_header) + NET_PACKET_SIZE,
+		.direction = DMA_FROM_DEVICE,
+	};
+
+	return virtqueue_add(network->rx_queue, &buffer, 1, receive);
+}
+
+static void virtio_net_free_rx(struct virtio_net_rx_buffer *receive)
+{
+	if (!receive)
+		return;
+	if (receive->page)
+		pfree(receive->page);
+	free(receive);
+}
+
+static void virtio_net_reap_tx(struct virtio_net *network)
+{
+	struct virtio_net_tx_request *transmit;
+	int completed = 0;
+
+	while ((transmit = virtqueue_get_used(network->tx_queue, 0))) {
+		net_packet_put(transmit->packet);
+		free(transmit);
+		completed = 1;
+	}
+	if (completed)
+		netif_wake_queue(&network->netdev);
+}
+
+static void virtio_net_poll(struct work_struct *work)
+{
+	struct virtio_net *network =
+		container_of(work, struct virtio_net, poll_work);
+	struct virtio_net_rx_buffer *receive;
+	struct net_packet *packet;
+	uint32 budget = VIRTIO_NET_RX_BUDGET;
+	uint32 length;
+	int kick = 0;
+
+	virtio_net_reap_tx(network);
+	while (budget-- && (receive = virtqueue_get_used(
+		       network->rx_queue, &length))) {
+		if (__atomic_load_n(&network->rx_enabled,
+				    __ATOMIC_ACQUIRE) &&
+		    length > sizeof(struct virtio_net_header) &&
+		    length <= sizeof(struct virtio_net_header) +
+			      NET_ETH_HEADER_LENGTH + NET_ETH_MTU) {
+			struct virtio_net_header *header = receive->page;
+
+			length -= sizeof(struct virtio_net_header);
+			packet = header->flags || header->gso_type ||
+				length < NET_ETH_HEADER_LENGTH ? 0 :
+				net_packet_alloc(length);
+			if (packet) {
+				memmove(packet->data,
+					receive->page +
+						sizeof(struct virtio_net_header),
+					length);
+				packet->length = length;
+				packet->device = &network->netdev;
+				netif_receive(packet);
+			} else {
+				net_device_rx_drop(&network->netdev);
+			}
+		} else {
+			net_device_rx_drop(&network->netdev);
+		}
+		if (virtio_net_post_rx(network, receive) < 0) {
+			virtio_net_free_rx(receive);
+			network->rx_buffers--;
+		} else {
+			kick = 1;
+		}
+	}
+	if (kick)
+		virtqueue_kick(network->rx_queue);
+	if (virtqueue_has_used(network->rx_queue) ||
+	    virtqueue_has_used(network->tx_queue))
+		schedule_work(&network->poll_work);
+	virtio_net_update_carrier(network);
+}
+
+static void virtio_net_queue_done(struct virtqueue *queue)
+{
+	struct virtio_net *network = queue->private;
+
+	if (network)
+		schedule_work(&network->poll_work);
+}
+
+static int virtio_net_open(struct net_device *device)
+{
+	struct virtio_net *network = device->private;
+
+	__atomic_store_n(&network->rx_enabled, 1, __ATOMIC_RELEASE);
+	virtqueue_kick(network->rx_queue);
+	schedule_work(&network->poll_work);
+	return 0;
+}
+
+static void virtio_net_stop(struct net_device *device)
+{
+	struct virtio_net *network = device->private;
+
+	__atomic_store_n(&network->rx_enabled, 0, __ATOMIC_RELEASE);
+	cancel_work_sync(&network->poll_work);
+	virtio_net_reap_tx(network);
+}
+
+static int virtio_net_xmit(struct net_device *device,
+			   struct net_packet *packet)
+{
+	struct virtio_net *network = device->private;
+	struct virtio_net_tx_request *request;
+	struct virtio_buffer buffers[2];
+	int status;
+
+	request = calloc(1, sizeof(*request));
+	if (!request)
+		return -1;
+	request->packet = packet;
+	buffers[0].address = &request->header;
+	buffers[0].length = sizeof(request->header);
+	buffers[0].direction = DMA_TO_DEVICE;
+	buffers[1].address = packet->data;
+	buffers[1].length = packet->length;
+	buffers[1].direction = DMA_TO_DEVICE;
+	status = virtqueue_add(network->tx_queue, buffers, 2, request);
+	if (status < 0) {
+		free(request);
+		if (status != -1)
+			return -1;
+		netif_stop_queue(device);
+		if (virtqueue_num_free(network->tx_queue) >= 2)
+			netif_wake_queue(device);
+		return NETDEV_TX_BUSY;
+	}
+	if (virtqueue_num_free(network->tx_queue) < 2) {
+		netif_stop_queue(device);
+		if (virtqueue_num_free(network->tx_queue) >= 2)
+			netif_wake_queue(device);
+	}
+	virtqueue_kick(network->tx_queue);
+	return 0;
+}
+
+static const struct net_device_operations virtio_net_operations = {
+	.open = virtio_net_open,
+	.stop = virtio_net_stop,
+	.start_xmit = virtio_net_xmit,
+};
+
+static int virtio_net_fill_rx(struct virtio_net *network)
+{
+	uint32 count, index;
+
+	count = virtqueue_num_free(network->rx_queue);
+	if (count > VIRTIO_NET_RX_BUFFERS)
+		count = VIRTIO_NET_RX_BUFFERS;
+	for (index = 0; index < count; index++) {
+		struct virtio_net_rx_buffer *receive;
+
+		receive = calloc(1, sizeof(*receive));
+		if (!receive)
+			return -1;
+		receive->page = palloc();
+		if (!receive->page) {
+			free(receive);
+			return -1;
+		}
+		memset(receive->page, 0, PGSIZE);
+		if (virtio_net_post_rx(network, receive) < 0) {
+			virtio_net_free_rx(receive);
+			return -1;
+		}
+		network->rx_buffers++;
+	}
+	return 0;
+}
+
+static int virtio_net_probe(struct virtio_device *device)
+{
+	static const char *const names[] = {
+		"virtio-net receive", "virtio-net transmit",
+	};
+	void (*callbacks[])(struct virtqueue *) = {
+		virtio_net_queue_done, virtio_net_queue_done,
+	};
+	struct virtqueue *queues[VIRTIO_NET_QUEUE_COUNT];
+	struct virtio_net *network;
+
+	network = calloc(1, sizeof(*network));
+	if (!network)
+		return DRIVER_ERR_BUSY;
+	network->virtio = device;
+	work_init(&network->poll_work, virtio_net_poll);
+	if (virtio_find_vqs(device, VIRTIO_NET_QUEUE_COUNT, queues,
+			    callbacks, names) < 0)
+		goto failed;
+	network->rx_queue = queues[VIRTIO_NET_RX_QUEUE];
+	network->tx_queue = queues[VIRTIO_NET_TX_QUEUE];
+	if (virtqueue_num_free(network->tx_queue) < 2)
+		goto failed;
+	network->rx_queue->private = network;
+	network->tx_queue->private = network;
+	if (virtio_net_fill_rx(network) < 0)
+		goto failed;
+	network->netdev.parent = &device->device;
+	network->netdev.mtu = NET_ETH_MTU;
+	network->netdev.operations = &virtio_net_operations;
+	network->netdev.private = network;
+	if (virtio_has_feature(device, VIRTIO_NET_F_MAC))
+		device->config->get_config(device, 0,
+			network->netdev.address,
+			sizeof(network->netdev.address));
+	else {
+		network->netdev.address[0] = 0x02;
+		network->netdev.address[5] = device->transport_index;
+	}
+	if (net_device_register(&network->netdev) < 0)
+		goto failed;
+	dev_set_drvdata(&device->device, network);
+	printf("virtio-net: registered %s\n", network->netdev.name);
+	return DRIVER_OK;
+
+failed:
+	if (network->rx_queue) {
+		struct virtio_net_rx_buffer *receive;
+
+		while ((receive = virtqueue_detach_unused(
+			       network->rx_queue)))
+			virtio_net_free_rx(receive);
+		device->config->del_vqs(device);
+	}
+	free(network);
+	return DRIVER_ERR_NODEV;
+}
+
+static void virtio_net_ready(struct virtio_device *device)
+{
+	struct virtio_net *network = dev_get_drvdata(&device->device);
+
+	if (!network)
+		return;
+	virtio_net_update_carrier(network);
+	if (net_device_open(&network->netdev) < 0)
+		PANIC("open virtio-net device");
+}
+
+static void virtio_net_config_changed(struct virtio_device *device)
+{
+	struct virtio_net *network = dev_get_drvdata(&device->device);
+
+	if (network)
+		schedule_work(&network->poll_work);
+}
+
+static void virtio_net_remove(struct virtio_device *device)
+{
+	struct virtio_net *network = dev_get_drvdata(&device->device);
+	struct virtio_net_rx_buffer *receive;
+	struct virtio_net_tx_request *transmit;
+
+	if (!network)
+		return;
+	cancel_work_sync(&network->poll_work);
+	if (net_device_unregister(&network->netdev) < 0)
+		PANIC("unregister virtio-net device");
+	while ((receive = virtqueue_detach_unused(network->rx_queue)))
+		virtio_net_free_rx(receive);
+	while ((transmit = virtqueue_detach_unused(network->tx_queue))) {
+		net_packet_put(transmit->packet);
+		free(transmit);
+	}
+	dev_set_drvdata(&device->device, 0);
+	free(network);
+}
+
+static const struct virtio_device_id virtio_net_ids[] = {
+	{ VIRTIO_ID_NET, VIRTIO_DEV_ANY_ID },
+	{ 0 },
+};
+
+static struct virtio_driver virtio_net_driver = {
+	.driver = {
+		.name = "virtio-net",
+	},
+	.id_table = virtio_net_ids,
+	.feature_table = (1ULL << VIRTIO_NET_F_MAC) |
+			 (1ULL << VIRTIO_NET_F_STATUS),
+	.probe = virtio_net_probe,
+	.ready = virtio_net_ready,
+	.config_changed = virtio_net_config_changed,
+	.remove = virtio_net_remove,
+};
+
+int virtio_net_init(void)
+{
+	return virtio_driver_register(&virtio_net_driver);
+}

--- a/drivers/of/Makefile
+++ b/drivers/of/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../include -I ./libfdt
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += core.o libfdt/

--- a/drivers/of/libfdt/Makefile
+++ b/drivers/of/libfdt/Makefile
@@ -1,6 +1,4 @@
 EXTRA_CFLAGS := -I ../../../kernel/include
 EXTRA_CFLAGS += -I ../../../arch/riscv/include -I ../../../include -I .
 EXTRA_CFLAGS += -Wno-sign-compare
-EXTRA_LDFLAGS := -T ../../../kernel/kernel.ld
-
 obj-y += fdt.o fdt_ro.o fdt_check.o

--- a/drivers/platform/Makefile
+++ b/drivers/platform/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += platform.o io.o selftest.o

--- a/drivers/tty/Makefile
+++ b/drivers/tty/Makefile
@@ -1,6 +1,4 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include \
 	-I ../../include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += tty.o
 obj-y += serial/

--- a/drivers/tty/serial/Makefile
+++ b/drivers/tty/serial/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../../kernel/include \
 	-I ../../../arch/riscv/include -I ../../../include
-EXTRA_LDFLAGS := -T ../../../kernel/kernel.ld
-
 obj-y += earlycon.o uart.o ns16550.o

--- a/drivers/virtio/Makefile
+++ b/drivers/virtio/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../include
-EXTRA_LDFLAGS := -T ../../kernel/kernel.ld
-
 obj-y += core.o ring.o mmio.o

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,5 +1,4 @@
 EXTRA_CFLAGS := -I ./include -I ../arch/riscv/include -I ../include 
-EXTRA_LDFLAGS := -T ./kernel.ld
 CFLAGS_file.o := 
 
 

--- a/kernel/fs/Makefile
+++ b/kernel/fs/Makefile
@@ -1,5 +1,4 @@
 EXTRA_CFLAGS := -I ../include -I ../../arch/riscv/include -I ../../include
-EXTRA_LDFLAGS := -T ../kernel.ld
 CFLAGS_file.o := 
 
 

--- a/kernel/fs/fatfs/Makefile
+++ b/kernel/fs/fatfs/Makefile
@@ -1,5 +1,3 @@
 EXTRA_CFLAGS := -I compat -I . -I ../../include \
 	-I ../../../arch/riscv/include -I ../../../include
-EXTRA_LDFLAGS := -T ../../kernel.ld
-
 obj-y += caffeinix.o diskio.o ff.o ffunicode.o

--- a/kernel/fs/lwext4/Makefile
+++ b/kernel/fs/lwext4/Makefile
@@ -3,6 +3,4 @@ include config.mk
 EXTRA_CFLAGS := -I compat -I include
 EXTRA_CFLAGS += -I ../../include -I ../../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../../include $(LWEXT4_CONFIG_CFLAGS)
-EXTRA_LDFLAGS := -T ../../kernel.ld
-
 obj-y += caffeinix.o src/

--- a/kernel/fs/lwext4/src/Makefile
+++ b/kernel/fs/lwext4/src/Makefile
@@ -3,8 +3,6 @@ include ../config.mk
 EXTRA_CFLAGS := -I ../compat -I ../include
 EXTRA_CFLAGS += -I ../../../include -I ../../../../arch/riscv/include
 EXTRA_CFLAGS += -I ../../../../include $(LWEXT4_CONFIG_CFLAGS)
-EXTRA_LDFLAGS := -T ../../../kernel.ld
-
 obj-y += ext4.o ext4_balloc.o ext4_bcache.o ext4_bitmap.o
 obj-y += ext4_block_group.o ext4_blockdev.o ext4_crc32.o
 obj-y += ext4_debug.o ext4_dir.o ext4_dir_idx.o ext4_extent.o

--- a/kernel/include/netdevice.h
+++ b/kernel/include/netdevice.h
@@ -1,0 +1,118 @@
+#ifndef __CAFFEINIX_KERNEL_NETDEVICE_H
+#define __CAFFEINIX_KERNEL_NETDEVICE_H
+
+#include <kernel_config.h>
+#include <list.h>
+#include <spinlock.h>
+#include <typedefs.h>
+#include <wait.h>
+
+#define NET_DEVICE_MAX 8
+#define NET_DEVICE_NAME_SIZE 16
+#define NET_ETH_ADDRESS_LENGTH 6
+#define NET_ETH_HEADER_LENGTH 14
+#define NET_ETH_MTU 1500
+#define NET_PACKET_SIZE 2048
+#define NET_PACKET_HEADROOM 64
+#define NET_PACKET_POOL_SIZE 128
+
+#define NETDEV_TX_BUSY -2
+
+struct device;
+struct net_device;
+
+struct net_packet {
+	struct spinlock lock;
+	struct net_device *device;
+	uint8 *buffer;
+	uint8 *data;
+	uint32 capacity;
+	uint32 length;
+	uint32 refcount;
+	struct net_packet *next_free;
+	struct net_packet *next_receive;
+	uint8 pooled;
+};
+
+struct net_device_operations {
+	int (*open)(struct net_device *device);
+	void (*stop)(struct net_device *device);
+	int (*start_xmit)(struct net_device *device,
+			  struct net_packet *packet);
+};
+
+struct net_device_stats {
+	uint64 rx_packets;
+	uint64 rx_bytes;
+	uint64 rx_dropped;
+	uint64 tx_packets;
+	uint64 tx_bytes;
+	uint64 tx_dropped;
+};
+
+struct net_device {
+	struct spinlock lock;
+	struct wait_queue lifecycle_wait;
+	char name[NET_DEVICE_NAME_SIZE];
+	uint8 address[NET_ETH_ADDRESS_LENGTH];
+	uint32 mtu;
+	uint32 index;
+	uint32 references;
+	uint32 transmit_active;
+	uint32 state_pending;
+	uint32 transmit_threads[NTHREAD];
+	uint32 transmit_cpus[NCPU];
+	struct net_device *next_state;
+	uint8 registered;
+	uint8 up;
+	uint8 carrier;
+	uint8 queue_stopped;
+	uint8 lifecycle_transition;
+	uint8 stop_pending;
+	uint8 state_queued;
+	uint8 loopback;
+	struct device *parent;
+	const struct net_device_operations *operations;
+	void *private;
+	struct net_device_stats stats;
+};
+
+typedef void (*net_receive_t)(struct net_packet *packet, void *argument);
+typedef void (*net_state_t)(struct net_device *device, void *argument);
+
+void net_device_init(void);
+int net_device_register(struct net_device *device);
+int net_device_unregister(struct net_device *device);
+/* Lookup results remain registered until the matching put. */
+struct net_device *net_device_get(uint32 index);
+struct net_device *net_device_first(void);
+void net_device_put(struct net_device *device);
+int net_device_open(struct net_device *device);
+void net_device_close(struct net_device *device);
+void net_device_set_carrier(struct net_device *device, int carrier);
+int net_device_carrier_ok(struct net_device *device);
+void netif_stop_queue(struct net_device *device);
+void netif_wake_queue(struct net_device *device);
+int netif_queue_stopped(struct net_device *device);
+int net_device_xmit(struct net_device *device,
+		    struct net_packet *packet);
+void net_device_rx_drop(struct net_device *device);
+void net_device_get_stats(struct net_device *device,
+			  struct net_device_stats *stats);
+int net_receive_register(net_receive_t receive, void *argument);
+void net_receive_unregister(net_receive_t receive, void *argument);
+int net_state_register(net_state_t state, void *argument);
+void net_state_unregister(net_state_t state, void *argument);
+void netif_receive(struct net_packet *packet);
+
+struct net_packet *net_packet_alloc(uint32 capacity);
+struct net_packet *net_packet_get(struct net_packet *packet);
+void net_packet_put(struct net_packet *packet);
+uint32 net_packet_pool_available(void);
+
+int net_core_selftest(void);
+int net_loopback_init(void);
+
+int virtio_net_init(void);
+
+#endif

--- a/kernel/include/workqueue.h
+++ b/kernel/include/workqueue.h
@@ -22,5 +22,6 @@ void work_init(struct work_struct *work, work_func_t function);
 int schedule_work(struct work_struct *work);
 int cancel_work(struct work_struct *work);
 int cancel_work_sync(struct work_struct *work);
+int workqueue_in_worker(void);
 
 #endif

--- a/kernel/irq/Makefile
+++ b/kernel/irq/Makefile
@@ -1,4 +1,2 @@
 EXTRA_CFLAGS := -I ../include -I ../../arch/riscv/include -I ../../include
-EXTRA_LDFLAGS := -T ../kernel.ld
-
 obj-y += irq.o

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -1,6 +1,12 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY( _entry )
 
+PHDRS
+{
+  text PT_LOAD FLAGS(5);
+  data PT_LOAD FLAGS(6);
+}
+
 SECTIONS
 {
   /*
@@ -15,7 +21,7 @@ SECTIONS
     *(trampsec)
     . = ALIGN(0x1000);
     PROVIDE(etext = .);
-  }
+  } :text
   
 
   .rodata : {
@@ -23,21 +29,29 @@ SECTIONS
     *(.srodata .srodata.*) /* do not need to distinguish this from .rodata */
     . = ALIGN(16);
     *(.rodata .rodata.*)
-  }
+  } :data
+
+  .eh_frame : {
+    *(.eh_frame .eh_frame.*)
+  } :data
 
   .data : {
     . = ALIGN(16);
     *(.sdata .sdata.*) /* do not need to distinguish this from .data */
     . = ALIGN(16);
     *(.data .data.*)
-  }
+  } :data
 
   .bss : {
     . = ALIGN(16);
     *(.sbss .sbss.*) /* do not need to distinguish this from .bss */
     . = ALIGN(16);
     *(.bss .bss.*)
-  }
+  } :data
 
   PROVIDE(end = .);
+  ASSERT(etext == ADDR(.text) + SIZEOF(.text),
+         "etext does not cover the final text section")
+  ASSERT(end == ADDR(.bss) + SIZEOF(.bss),
+         "end does not cover the final BSS section")
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -100,6 +100,8 @@ void main(void)
 			PANIC("register loopback device");
 		if (virtio_blk_init() < 0)
 			PANIC("register virtio-blk driver");
+		if (virtio_net_init() < 0)
+			PANIC("register virtio-net driver");
 		if (virtio_mmio_init() < 0)
 			PANIC("register virtio-mmio driver");
                 file_init();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -42,6 +42,7 @@
 #include <wait.h>
 #include <workqueue.h>
 #include <virtio.h>
+#include <netdevice.h>
 
 volatile static uint8 start = 0;
 extern char end[];
@@ -92,6 +93,11 @@ void main(void)
 		if (uart_core_selftest() < 0)
 			PANIC("UART core selftest");
                 block_device_init();
+		net_device_init();
+		if (net_core_selftest() < 0)
+			PANIC("network core selftest");
+		if (net_loopback_init() < 0)
+			PANIC("register loopback device");
 		if (virtio_blk_init() < 0)
 			PANIC("register virtio-blk driver");
 		if (virtio_mmio_init() < 0)

--- a/kernel/workqueue.c
+++ b/kernel/workqueue.c
@@ -121,3 +121,9 @@ int cancel_work_sync(struct work_struct *work)
 	spinlock_release(&system_workqueue.lock);
 	return cancelled;
 }
+
+int workqueue_in_worker(void)
+{
+	return system_workqueue.worker &&
+	       cur_thread() == system_workqueue.worker;
+}

--- a/net/Makefile
+++ b/net/Makefile
@@ -1,0 +1,3 @@
+EXTRA_CFLAGS := -I ../kernel/include -I ../arch/riscv/include
+EXTRA_CFLAGS += -I ../include
+obj-y += core/

--- a/net/core/Makefile
+++ b/net/core/Makefile
@@ -1,0 +1,3 @@
+EXTRA_CFLAGS := -I ../../kernel/include -I ../../arch/riscv/include
+EXTRA_CFLAGS += -I ../../include
+obj-y += device.o loopback.o packet.o selftest.o

--- a/net/core/device.c
+++ b/net/core/device.c
@@ -1,0 +1,833 @@
+#include <debug.h>
+#include <kernel_config.h>
+#include <mystring.h>
+#include <netdevice.h>
+#include <scheduler.h>
+#include <thread.h>
+#include <wait.h>
+#include <workqueue.h>
+
+struct net_callback_slot {
+	int thread;
+	int cpu;
+};
+
+static struct {
+	struct spinlock lock;
+	struct net_device *devices[NET_DEVICE_MAX];
+	net_receive_t receive;
+	void *receive_argument;
+	uint32 receive_active;
+	uint32 receive_threads[NTHREAD];
+	uint32 receive_cpus[NCPU];
+	uint8 receive_draining;
+	uint8 receive_dispatching;
+	struct net_packet *receive_head;
+	struct net_packet *receive_tail;
+	struct wait_queue receive_wait;
+	net_state_t state;
+	void *state_argument;
+	uint32 state_active;
+	uint32 state_threads[NTHREAD];
+	uint32 state_cpus[NCPU];
+	uint8 state_draining;
+	struct net_device *state_head;
+	struct net_device *state_tail;
+	struct wait_queue state_wait;
+	struct work_struct state_work;
+} network;
+
+extern void net_packet_pool_init(void);
+static void net_state_notify_pending(struct net_device *device);
+
+static int net_state_queue_locked(struct net_device *device)
+{
+	int queued = 0;
+
+	spinlock_acquire(&device->lock);
+	if (device->state_pending && !device->state_queued) {
+		device->state_queued = 1;
+		device->next_state = 0;
+		if (network.state_tail)
+			network.state_tail->next_state = device;
+		else
+			network.state_head = device;
+		network.state_tail = device;
+		queued = 1;
+	}
+	spinlock_release(&device->lock);
+	return queued;
+}
+
+static struct net_device *net_state_next_queued(void)
+{
+	struct net_device *device;
+
+	spinlock_acquire(&network.lock);
+	device = network.state_head;
+	if (device) {
+		network.state_head = device->next_state;
+		if (!network.state_head)
+			network.state_tail = 0;
+		spinlock_acquire(&device->lock);
+		device->next_state = 0;
+		device->state_queued = 0;
+		spinlock_release(&device->lock);
+	}
+	spinlock_release(&network.lock);
+	return device;
+}
+
+static void net_state_work(struct work_struct *work)
+{
+	struct net_device *device;
+
+	(void)work;
+	while ((device = net_state_next_queued()))
+		net_state_notify_pending(device);
+}
+
+static struct net_callback_slot net_callback_slot(void)
+{
+	struct net_callback_slot slot = { .thread = -1, .cpu = -1 };
+	thread_t current = cur_thread();
+
+	if (current) {
+		slot.thread = current - thread;
+		if (slot.thread < 0 || slot.thread >= NTHREAD)
+			slot.thread = -1;
+	} else if (cpuid() < NCPU) {
+		slot.cpu = cpuid();
+	}
+	return slot;
+}
+
+static uint32 net_callback_owned_locked(uint32 *threads, uint32 *cpus)
+{
+	struct net_callback_slot slot = net_callback_slot();
+
+	if (slot.thread >= 0)
+		return threads[slot.thread];
+	if (slot.cpu >= 0)
+		return cpus[slot.cpu];
+	return 0;
+}
+
+static void net_callback_wait_turn_locked(uint32 *active, uint32 *threads,
+					  uint32 *cpus,
+					  struct wait_queue *wait)
+{
+	while (*active && !net_callback_owned_locked(threads, cpus))
+		wait_queue_sleep(wait, &network.lock);
+}
+
+static uint32 net_device_transmit_owned_locked(struct net_device *device)
+{
+	return net_callback_owned_locked(device->transmit_threads,
+					  device->transmit_cpus);
+}
+
+static void net_callback_enter_locked(struct net_callback_slot *slot,
+				      uint32 *threads, uint32 *cpus)
+{
+	*slot = net_callback_slot();
+	if (slot->thread >= 0)
+		threads[slot->thread]++;
+	else if (slot->cpu >= 0)
+		cpus[slot->cpu]++;
+}
+
+static void net_callback_leave_locked(struct net_callback_slot *slot,
+				      uint32 *threads, uint32 *cpus)
+{
+	if (slot->thread >= 0)
+		threads[slot->thread]--;
+	else if (slot->cpu >= 0)
+		cpus[slot->cpu]--;
+}
+
+static int net_device_name_exists_locked(const char *name)
+{
+	uint32 index;
+
+	for (index = 1; index < NET_DEVICE_MAX; index++) {
+		if (network.devices[index] &&
+		    !strcmp(network.devices[index]->name, name))
+			return 1;
+	}
+	return 0;
+}
+
+static int net_device_assign_name_locked(struct net_device *device)
+{
+	uint32 number;
+
+	if (device->name[0])
+		return net_device_name_exists_locked(device->name) ? -1 : 0;
+	for (number = 0; number < NET_DEVICE_MAX - 1; number++) {
+		safe_strncpy(device->name, "eth0", sizeof(device->name));
+		device->name[3] = '0' + number;
+		if (!net_device_name_exists_locked(device->name))
+			return 0;
+	}
+	device->name[0] = 0;
+	return -1;
+}
+
+void net_device_init(void)
+{
+	spinlock_init(&network.lock, "network devices");
+	wait_queue_init(&network.receive_wait, "network receive callbacks");
+	wait_queue_init(&network.state_wait, "network state callbacks");
+	work_init(&network.state_work, net_state_work);
+	net_packet_pool_init();
+}
+
+int net_device_register(struct net_device *device)
+{
+	uint32 free_index = 0, index;
+
+	if (!device || !device->operations ||
+	    !device->operations->start_xmit || !device->mtu ||
+	    device->mtu > NET_PACKET_SIZE - NET_ETH_HEADER_LENGTH)
+		return -1;
+	spinlock_acquire(&network.lock);
+	if (device->registered) {
+		spinlock_release(&network.lock);
+		return -1;
+	}
+	if (net_device_assign_name_locked(device) < 0) {
+		spinlock_release(&network.lock);
+		return -1;
+	}
+	for (index = 1; index < NET_DEVICE_MAX; index++) {
+		if (!network.devices[index] && !free_index)
+			free_index = index;
+	}
+	if (!free_index) {
+		spinlock_release(&network.lock);
+		return -1;
+	}
+	index = free_index;
+	device->index = index;
+	device->references = 0;
+	device->registered = 1;
+	device->up = 0;
+	device->carrier = 0;
+	device->queue_stopped = 0;
+	device->transmit_active = 0;
+	memset(device->transmit_threads, 0,
+	       sizeof(device->transmit_threads));
+	memset(device->transmit_cpus, 0, sizeof(device->transmit_cpus));
+	device->lifecycle_transition = 0;
+	device->stop_pending = 0;
+	device->state_pending = 0;
+	device->state_queued = 0;
+	device->next_state = 0;
+	memset(&device->stats, 0, sizeof(device->stats));
+	spinlock_init(&device->lock, device->name);
+	wait_queue_init(&device->lifecycle_wait, device->name);
+	network.devices[index] = device;
+	spinlock_release(&network.lock);
+	return 0;
+}
+
+int net_device_unregister(struct net_device *device)
+{
+	int was_up;
+
+	if (!device)
+		return -1;
+	for (;;) {
+		spinlock_acquire(&network.lock);
+		if (!device->registered || !device->index ||
+		    device->index >= NET_DEVICE_MAX ||
+		    network.devices[device->index] != device) {
+			spinlock_release(&network.lock);
+			return -1;
+		}
+		if (net_callback_owned_locked(network.state_threads,
+					      network.state_cpus)) {
+			spinlock_release(&network.lock);
+			return -1;
+		}
+		spinlock_acquire(&device->lock);
+		if (net_device_transmit_owned_locked(device)) {
+			spinlock_release(&device->lock);
+			spinlock_release(&network.lock);
+			return -1;
+		}
+		if (device->references) {
+			if (net_callback_owned_locked(
+			    network.receive_threads,
+			    network.receive_cpus)) {
+				spinlock_release(&device->lock);
+				spinlock_release(&network.lock);
+				return -1;
+			}
+			spinlock_release(&network.lock);
+			wait_queue_sleep(&device->lifecycle_wait,
+					 &device->lock);
+			spinlock_release(&device->lock);
+			continue;
+		}
+		if (device->lifecycle_transition || device->state_pending) {
+			spinlock_release(&network.lock);
+			wait_queue_sleep(&device->lifecycle_wait,
+					 &device->lock);
+			spinlock_release(&device->lock);
+			continue;
+		}
+		network.devices[device->index] = 0;
+		device->registered = 0;
+		device->index = 0;
+		device->lifecycle_transition = 1;
+		was_up = device->up;
+		device->up = 0;
+		device->queue_stopped = 1;
+		spinlock_release(&device->lock);
+		spinlock_release(&network.lock);
+		break;
+	}
+
+	spinlock_acquire(&device->lock);
+	while (device->transmit_active)
+		wait_queue_sleep(&device->lifecycle_wait, &device->lock);
+	spinlock_release(&device->lock);
+	if (was_up && device->operations->stop)
+		device->operations->stop(device);
+	spinlock_acquire(&device->lock);
+	device->state_pending++;
+	device->lifecycle_transition = 0;
+	wait_queue_wake_all(&device->lifecycle_wait);
+	spinlock_release(&device->lock);
+	net_state_notify_pending(device);
+	return 0;
+}
+
+struct net_device *net_device_get(uint32 index)
+{
+	struct net_device *device;
+
+	if (!index || index >= NET_DEVICE_MAX)
+		return 0;
+	spinlock_acquire(&network.lock);
+	device = network.devices[index];
+	if (device) {
+		spinlock_acquire(&device->lock);
+		device->references++;
+		spinlock_release(&device->lock);
+	}
+	spinlock_release(&network.lock);
+	return device;
+}
+
+struct net_device *net_device_first(void)
+{
+	uint32 index;
+
+	spinlock_acquire(&network.lock);
+	for (index = 1; index < NET_DEVICE_MAX; index++) {
+		if (network.devices[index]) {
+			struct net_device *device = network.devices[index];
+
+			spinlock_acquire(&device->lock);
+			device->references++;
+			spinlock_release(&device->lock);
+			spinlock_release(&network.lock);
+			return device;
+		}
+	}
+	spinlock_release(&network.lock);
+	return 0;
+}
+
+void net_device_put(struct net_device *device)
+{
+	if (!device)
+		return;
+	spinlock_acquire(&device->lock);
+	if (!device->references)
+		PANIC("put unreferenced network device");
+	device->references--;
+	if (!device->references)
+		wait_queue_wake_all(&device->lifecycle_wait);
+	spinlock_release(&device->lock);
+}
+
+int net_device_open(struct net_device *device)
+{
+	int status;
+
+	if (!device)
+		return -1;
+	spinlock_acquire(&network.lock);
+	if (!device->registered || !device->index ||
+	    device->index >= NET_DEVICE_MAX ||
+	    network.devices[device->index] != device) {
+		spinlock_release(&network.lock);
+		return -1;
+	}
+	spinlock_acquire(&device->lock);
+	spinlock_release(&network.lock);
+	while (device->lifecycle_transition) {
+		if (net_device_transmit_owned_locked(device)) {
+			spinlock_release(&device->lock);
+			return -1;
+		}
+		wait_queue_sleep(&device->lifecycle_wait, &device->lock);
+	}
+	if (!device->registered) {
+		spinlock_release(&device->lock);
+		return -1;
+	}
+	if (device->up) {
+		spinlock_release(&device->lock);
+		return 0;
+	}
+	device->lifecycle_transition = 1;
+	spinlock_release(&device->lock);
+	status = device->operations->open ?
+		device->operations->open(device) : 0;
+	spinlock_acquire(&device->lock);
+	if (!status) {
+		device->up = 1;
+		device->queue_stopped = 0;
+		device->state_pending++;
+	}
+	device->lifecycle_transition = 0;
+	wait_queue_wake_all(&device->lifecycle_wait);
+	spinlock_release(&device->lock);
+	if (!status)
+		net_state_notify_pending(device);
+	return status;
+}
+
+static void net_device_finish_close(struct net_device *device)
+{
+	if (device->operations->stop)
+		device->operations->stop(device);
+	spinlock_acquire(&device->lock);
+	device->stop_pending = 0;
+	device->state_pending++;
+	device->lifecycle_transition = 0;
+	wait_queue_wake_all(&device->lifecycle_wait);
+	spinlock_release(&device->lock);
+	net_state_notify_pending(device);
+}
+
+void net_device_close(struct net_device *device)
+{
+	uint32 owned;
+
+	if (!device)
+		return;
+	spinlock_acquire(&device->lock);
+	while (device->lifecycle_transition) {
+		if (net_device_transmit_owned_locked(device)) {
+			spinlock_release(&device->lock);
+			return;
+		}
+		wait_queue_sleep(&device->lifecycle_wait, &device->lock);
+	}
+	if (!device->up) {
+		spinlock_release(&device->lock);
+		return;
+	}
+	device->lifecycle_transition = 1;
+	device->up = 0;
+	device->queue_stopped = 1;
+	owned = net_device_transmit_owned_locked(device);
+	while (device->transmit_active > owned)
+		wait_queue_sleep(&device->lifecycle_wait, &device->lock);
+	if (device->transmit_active) {
+		device->stop_pending = 1;
+		spinlock_release(&device->lock);
+		return;
+	}
+	spinlock_release(&device->lock);
+	net_device_finish_close(device);
+}
+
+static void net_state_notify_pending(struct net_device *device)
+{
+	net_state_t state;
+	void *argument;
+	struct net_callback_slot slot;
+	struct net_device *queued;
+	int pending;
+
+	spinlock_acquire(&network.lock);
+	if (network.state_active && net_callback_owned_locked(
+	    network.state_threads, network.state_cpus)) {
+		pending = net_state_queue_locked(device);
+		spinlock_release(&network.lock);
+		if (pending)
+			schedule_work(&network.state_work);
+		return;
+	}
+	net_callback_wait_turn_locked(&network.state_active,
+				      network.state_threads,
+				      network.state_cpus,
+				      &network.state_wait);
+	state = network.state;
+	argument = network.state_argument;
+	spinlock_acquire(&device->lock);
+	pending = !!device->state_pending;
+	device->state_pending = 0;
+	wait_queue_wake_all(&device->lifecycle_wait);
+	spinlock_release(&device->lock);
+	if (state && pending) {
+		network.state_active++;
+		net_callback_enter_locked(&slot, network.state_threads,
+					  network.state_cpus);
+	}
+	spinlock_release(&network.lock);
+	if (state && pending)
+		state(device, argument);
+	spinlock_acquire(&network.lock);
+	if (state && pending) {
+		network.state_active--;
+		net_callback_leave_locked(&slot, network.state_threads,
+					  network.state_cpus);
+	}
+	if (network.state_draining && !network.state_active &&
+	    !network.state_head)
+		network.state_draining = 0;
+	wait_queue_wake_all(&network.state_wait);
+	spinlock_release(&network.lock);
+	queued = net_state_next_queued();
+	if (queued)
+		net_state_notify_pending(queued);
+}
+
+void net_device_set_carrier(struct net_device *device, int carrier)
+{
+	int notify = 0, queue = 0;
+
+	if (!device)
+		return;
+	carrier = !!carrier;
+	spinlock_acquire(&device->lock);
+	if (device->carrier != carrier && device->registered &&
+	    !device->lifecycle_transition) {
+		device->state_pending++;
+		if (workqueue_in_worker()) {
+			queue = 1;
+		} else {
+			notify = 1;
+		}
+	}
+	device->carrier = carrier;
+	spinlock_release(&device->lock);
+	/*
+	 * A driver may report carrier state from work embedded in its private
+	 * allocation.  Run callbacks from core-owned work so a callback can
+	 * synchronously unregister and release that driver after its work has
+	 * unwound.
+	 */
+	if (queue) {
+		spinlock_acquire(&network.lock);
+		queue = net_state_queue_locked(device);
+		spinlock_release(&network.lock);
+		if (queue)
+			schedule_work(&network.state_work);
+	}
+	else if (notify)
+		net_state_notify_pending(device);
+}
+
+int net_device_carrier_ok(struct net_device *device)
+{
+	int carrier;
+
+	if (!device)
+		return 0;
+	spinlock_acquire(&device->lock);
+	carrier = device->carrier;
+	spinlock_release(&device->lock);
+	return carrier;
+}
+
+void netif_stop_queue(struct net_device *device)
+{
+	if (!device)
+		return;
+	spinlock_acquire(&device->lock);
+	device->queue_stopped = 1;
+	spinlock_release(&device->lock);
+}
+
+void netif_wake_queue(struct net_device *device)
+{
+	if (!device)
+		return;
+	spinlock_acquire(&device->lock);
+	if (device->up)
+		device->queue_stopped = 0;
+	spinlock_release(&device->lock);
+}
+
+int netif_queue_stopped(struct net_device *device)
+{
+	int stopped;
+
+	if (!device)
+		return 1;
+	spinlock_acquire(&device->lock);
+	stopped = device->queue_stopped;
+	spinlock_release(&device->lock);
+	return stopped;
+}
+
+int net_device_xmit(struct net_device *device,
+		    struct net_packet *packet)
+{
+	struct net_callback_slot slot;
+	uint32 length;
+	int finish_close = 0, status;
+
+	if (!device || !packet ||
+	    packet->length < NET_ETH_HEADER_LENGTH ||
+	    packet->length > packet->capacity)
+		return -1;
+	spinlock_acquire(&device->lock);
+	if (packet->length > device->mtu + NET_ETH_HEADER_LENGTH) {
+		spinlock_release(&device->lock);
+		return -1;
+	}
+	if (!device->registered || !device->up || !device->carrier ||
+	    device->queue_stopped) {
+		spinlock_release(&device->lock);
+		return NETDEV_TX_BUSY;
+	}
+	device->transmit_active++;
+	net_callback_enter_locked(&slot, device->transmit_threads,
+				  device->transmit_cpus);
+	spinlock_release(&device->lock);
+	packet->device = device;
+	length = packet->length;
+	status = device->operations->start_xmit(device, packet);
+	if (status < 0) {
+		if (status != NETDEV_TX_BUSY)
+			__atomic_fetch_add(&device->stats.tx_dropped, 1,
+					   __ATOMIC_RELAXED);
+	} else {
+		__atomic_fetch_add(&device->stats.tx_packets, 1,
+				   __ATOMIC_RELAXED);
+		__atomic_fetch_add(&device->stats.tx_bytes, length,
+				   __ATOMIC_RELAXED);
+		status = 0;
+	}
+	spinlock_acquire(&device->lock);
+	device->transmit_active--;
+	net_callback_leave_locked(&slot, device->transmit_threads,
+				  device->transmit_cpus);
+	if (!device->transmit_active && device->stop_pending) {
+		device->stop_pending = 0;
+		finish_close = 1;
+	}
+	if (device->lifecycle_transition)
+		wait_queue_wake_all(&device->lifecycle_wait);
+	spinlock_release(&device->lock);
+	if (finish_close)
+		net_device_finish_close(device);
+	return status;
+}
+
+void net_device_rx_drop(struct net_device *device)
+{
+	if (device)
+		__atomic_fetch_add(&device->stats.rx_dropped, 1,
+				   __ATOMIC_RELAXED);
+}
+
+void net_device_get_stats(struct net_device *device,
+			  struct net_device_stats *stats)
+{
+	if (!device || !stats)
+		return;
+	stats->rx_packets = __atomic_load_n(&device->stats.rx_packets,
+					    __ATOMIC_RELAXED);
+	stats->rx_bytes = __atomic_load_n(&device->stats.rx_bytes,
+					  __ATOMIC_RELAXED);
+	stats->rx_dropped = __atomic_load_n(&device->stats.rx_dropped,
+					    __ATOMIC_RELAXED);
+	stats->tx_packets = __atomic_load_n(&device->stats.tx_packets,
+					    __ATOMIC_RELAXED);
+	stats->tx_bytes = __atomic_load_n(&device->stats.tx_bytes,
+					  __ATOMIC_RELAXED);
+	stats->tx_dropped = __atomic_load_n(&device->stats.tx_dropped,
+					    __ATOMIC_RELAXED);
+}
+
+int net_receive_register(net_receive_t receive, void *argument)
+{
+	if (!receive)
+		return -1;
+	spinlock_acquire(&network.lock);
+	if (network.receive || network.receive_draining) {
+		spinlock_release(&network.lock);
+		return -1;
+	}
+	network.receive = receive;
+	network.receive_argument = argument;
+	spinlock_release(&network.lock);
+	return 0;
+}
+
+void net_receive_unregister(net_receive_t receive, void *argument)
+{
+	uint32 owned;
+
+	spinlock_acquire(&network.lock);
+	if (network.receive == receive &&
+	    network.receive_argument == argument) {
+		network.receive = 0;
+		network.receive_argument = 0;
+		network.receive_draining = 1;
+	}
+	if (network.receive_draining) {
+		owned = net_callback_owned_locked(network.receive_threads,
+						 network.receive_cpus);
+		while (network.receive_active > owned ||
+		       (!owned && network.receive_dispatching))
+			wait_queue_sleep(&network.receive_wait,
+					 &network.lock);
+		if (!network.receive_active && !network.receive_dispatching)
+			network.receive_draining = 0;
+	}
+	spinlock_release(&network.lock);
+}
+
+int net_state_register(net_state_t state, void *argument)
+{
+	if (!state)
+		return -1;
+	spinlock_acquire(&network.lock);
+	if (network.state || network.state_draining) {
+		spinlock_release(&network.lock);
+		return -1;
+	}
+	network.state = state;
+	network.state_argument = argument;
+	spinlock_release(&network.lock);
+	return 0;
+}
+
+void net_state_unregister(net_state_t state, void *argument)
+{
+	uint32 owned;
+
+	spinlock_acquire(&network.lock);
+	if (network.state == state && network.state_argument == argument) {
+		network.state = 0;
+		network.state_argument = 0;
+		network.state_draining = 1;
+	}
+	if (network.state_draining) {
+		owned = !!net_callback_owned_locked(network.state_threads,
+						  network.state_cpus);
+		while (network.state_active > owned)
+			wait_queue_sleep(&network.state_wait, &network.lock);
+		if (!network.state_active && !network.state_head)
+			network.state_draining = 0;
+	}
+	spinlock_release(&network.lock);
+}
+
+void netif_receive(struct net_packet *packet)
+{
+	net_receive_t receive;
+	void *argument;
+	struct net_callback_slot slot;
+	struct net_device *device;
+
+	if (!packet || !packet->device) {
+		net_packet_put(packet);
+		return;
+	}
+	device = packet->device;
+	spinlock_acquire(&network.lock);
+	if (!device->registered || !device->index ||
+	    device->index >= NET_DEVICE_MAX ||
+	    network.devices[device->index] != device) {
+		spinlock_release(&network.lock);
+		net_packet_put(packet);
+		return;
+	}
+	spinlock_acquire(&device->lock);
+	if (packet->length < NET_ETH_HEADER_LENGTH ||
+	    packet->length > packet->capacity ||
+	    packet->length > device->mtu + NET_ETH_HEADER_LENGTH) {
+		__atomic_fetch_add(&device->stats.rx_dropped, 1,
+				   __ATOMIC_RELAXED);
+		spinlock_release(&device->lock);
+		spinlock_release(&network.lock);
+		net_packet_put(packet);
+		return;
+	}
+	device->references++;
+	spinlock_release(&device->lock);
+	__atomic_fetch_add(&device->stats.rx_packets, 1,
+			   __ATOMIC_RELAXED);
+	__atomic_fetch_add(&device->stats.rx_bytes, packet->length,
+			   __ATOMIC_RELAXED);
+	if (!network.receive) {
+		spinlock_release(&network.lock);
+		net_device_rx_drop(device);
+		net_packet_put(packet);
+		net_device_put(device);
+		return;
+	}
+	packet->next_receive = 0;
+	if (network.receive_tail)
+		network.receive_tail->next_receive = packet;
+	else
+		network.receive_head = packet;
+	network.receive_tail = packet;
+	if (network.receive_dispatching) {
+		spinlock_release(&network.lock);
+		return;
+	}
+	network.receive_dispatching = 1;
+	for (;;) {
+		packet = network.receive_head;
+		network.receive_head = packet->next_receive;
+		if (!network.receive_head)
+			network.receive_tail = 0;
+		packet->next_receive = 0;
+		device = packet->device;
+		receive = network.receive;
+		argument = network.receive_argument;
+		if (receive) {
+			network.receive_active++;
+			net_callback_enter_locked(&slot,
+						  network.receive_threads,
+						  network.receive_cpus);
+		}
+		spinlock_release(&network.lock);
+		if (receive)
+			receive(packet, argument);
+		else {
+			net_device_rx_drop(device);
+			net_packet_put(packet);
+		}
+		net_device_put(device);
+		spinlock_acquire(&network.lock);
+		if (receive) {
+			network.receive_active--;
+			net_callback_leave_locked(&slot,
+						  network.receive_threads,
+						  network.receive_cpus);
+		}
+		if (network.receive_head)
+			continue;
+		network.receive_dispatching = 0;
+		if (network.receive_draining && !network.receive_active)
+			network.receive_draining = 0;
+		wait_queue_wake_all(&network.receive_wait);
+		spinlock_release(&network.lock);
+		return;
+	}
+}

--- a/net/core/loopback.c
+++ b/net/core/loopback.c
@@ -1,0 +1,43 @@
+#include <mystring.h>
+#include <netdevice.h>
+
+static struct net_device loopback;
+
+static int loopback_open(struct net_device *device)
+{
+	(void)device;
+	return 0;
+}
+
+static void loopback_stop(struct net_device *device)
+{
+	(void)device;
+}
+
+static int loopback_xmit(struct net_device *device,
+			 struct net_packet *packet)
+{
+	packet->device = device;
+	netif_receive(packet);
+	return 0;
+}
+
+static const struct net_device_operations loopback_operations = {
+	.open = loopback_open,
+	.stop = loopback_stop,
+	.start_xmit = loopback_xmit,
+};
+
+int net_loopback_init(void)
+{
+	memset(&loopback, 0, sizeof(loopback));
+	safe_strncpy(loopback.name, "lo", sizeof(loopback.name));
+	loopback.mtu = NET_ETH_MTU;
+	loopback.loopback = 1;
+	loopback.operations = &loopback_operations;
+	if (net_device_register(&loopback) < 0 ||
+	    net_device_open(&loopback) < 0)
+		return -1;
+	net_device_set_carrier(&loopback, 1);
+	return 0;
+}

--- a/net/core/packet.c
+++ b/net/core/packet.c
@@ -1,0 +1,108 @@
+#include <debug.h>
+#include <mystring.h>
+#include <netdevice.h>
+#include <palloc.h>
+
+static struct {
+	struct spinlock lock;
+	struct net_packet packets[NET_PACKET_POOL_SIZE];
+	struct net_packet *free;
+	uint32 available;
+} packet_pool;
+
+void net_packet_pool_init(void)
+{
+	uint32 index;
+
+	spinlock_init(&packet_pool.lock, "network packet pool");
+	for (index = 0; index < NET_PACKET_POOL_SIZE; index++) {
+		struct net_packet *packet = &packet_pool.packets[index];
+
+		packet->buffer = palloc();
+		if (!packet->buffer)
+			break;
+		spinlock_init(&packet->lock, "network packet");
+		packet->next_free = packet_pool.free;
+		packet_pool.free = packet;
+		packet_pool.available++;
+	}
+	if (!packet_pool.available)
+		PANIC("network packet pool");
+}
+
+struct net_packet *net_packet_alloc(uint32 capacity)
+{
+	struct net_packet *packet;
+
+	if (!capacity || capacity > NET_PACKET_SIZE)
+		return 0;
+	spinlock_acquire(&packet_pool.lock);
+	packet = packet_pool.free;
+	if (packet) {
+		packet_pool.free = packet->next_free;
+		packet_pool.available--;
+	}
+	spinlock_release(&packet_pool.lock);
+	if (!packet)
+		return 0;
+	packet->device = 0;
+	packet->data = packet->buffer + NET_PACKET_HEADROOM;
+	packet->capacity = capacity;
+	packet->length = 0;
+	packet->refcount = 1;
+	packet->next_free = 0;
+	packet->next_receive = 0;
+	packet->pooled = 1;
+	return packet;
+}
+
+struct net_packet *net_packet_get(struct net_packet *packet)
+{
+	if (!packet)
+		return 0;
+	spinlock_acquire(&packet->lock);
+	if (!packet->pooled || !packet->refcount ||
+	    packet->refcount == ~(uint32)0) {
+		spinlock_release(&packet->lock);
+		return 0;
+	}
+	packet->refcount++;
+	spinlock_release(&packet->lock);
+	return packet;
+}
+
+void net_packet_put(struct net_packet *packet)
+{
+	int release = 0;
+
+	if (!packet)
+		return;
+	spinlock_acquire(&packet->lock);
+	if (!packet->pooled || !packet->refcount)
+		PANIC("network packet underflow");
+	if (!--packet->refcount) {
+		packet->pooled = 0;
+		release = 1;
+	}
+	spinlock_release(&packet->lock);
+	if (!release)
+		return;
+	spinlock_acquire(&packet_pool.lock);
+	packet->next_receive = 0;
+	packet->next_free = packet_pool.free;
+	packet_pool.free = packet;
+	packet_pool.available++;
+	if (packet_pool.available > NET_PACKET_POOL_SIZE)
+		PANIC("network packet pool overflow");
+	spinlock_release(&packet_pool.lock);
+}
+
+uint32 net_packet_pool_available(void)
+{
+	uint32 available;
+
+	spinlock_acquire(&packet_pool.lock);
+	available = packet_pool.available;
+	spinlock_release(&packet_pool.lock);
+	return available;
+}

--- a/net/core/selftest.c
+++ b/net/core/selftest.c
@@ -1,0 +1,558 @@
+#include <mystring.h>
+#include <netdevice.h>
+
+struct net_selftest_state {
+	uint32 opened;
+	uint32 stopped;
+	uint32 transmitted;
+	uint32 received;
+	uint32 state_changes;
+	uint32 receive_unregistered;
+	uint32 receive_recursive;
+	uint32 receive_depth;
+	uint32 receive_depth_max;
+	uint32 receive_pinned;
+	uint32 state_unregistered;
+	uint32 state_recursive;
+	uint32 state_depth;
+	uint32 state_depth_max;
+	uint32 receive_closed;
+	uint32 state_closed;
+	uint32 state_opened;
+	uint32 device_unregistered;
+	uint32 removed_closed;
+	uint32 lifecycle_failures;
+	int xmit_unregister_status;
+	int receive_unregister_status;
+	int state_unregister_status;
+	struct net_device *state_recursive_device;
+};
+
+static struct net_selftest_state selftest;
+
+static int selftest_open(struct net_device *device)
+{
+	(void)device;
+	selftest.opened++;
+	return 0;
+}
+
+static int selftest_open_failed(struct net_device *device)
+{
+	(void)device;
+	return -1;
+}
+
+static void selftest_stop(struct net_device *device)
+{
+	(void)device;
+	selftest.stopped++;
+}
+
+static int selftest_xmit(struct net_device *device,
+			 struct net_packet *packet)
+{
+	(void)device;
+	selftest.transmitted++;
+	net_packet_put(packet);
+	return 0;
+}
+
+static int selftest_receive_xmit(struct net_device *device,
+				 struct net_packet *packet)
+{
+	packet->device = device;
+	netif_receive(packet);
+	return 0;
+}
+
+static void selftest_receive(struct net_packet *packet, void *argument)
+{
+	if (argument == &selftest && packet && packet->length == 64)
+		selftest.received++;
+	net_packet_put(packet);
+}
+
+static void selftest_state(struct net_device *device, void *argument)
+{
+	if (argument == &selftest && device)
+		selftest.state_changes++;
+}
+
+static void selftest_receive_unregister(struct net_packet *packet,
+					void *argument)
+{
+	if (argument == &selftest && packet)
+		selftest.receive_unregistered++;
+	net_receive_unregister(selftest_receive_unregister, argument);
+	net_packet_put(packet);
+}
+
+static void selftest_receive_recursive_unregister(struct net_packet *packet,
+						   void *argument)
+{
+	struct net_selftest_state *state = argument;
+	struct net_packet *nested;
+
+	if (state != &selftest || !packet || !packet->device) {
+		net_packet_put(packet);
+		return;
+	}
+	state->receive_depth++;
+	if (state->receive_depth > state->receive_depth_max)
+		state->receive_depth_max = state->receive_depth;
+	state->receive_recursive++;
+	if (state->receive_recursive == 1) {
+		nested = net_packet_alloc(64);
+		if (!nested)
+			state->lifecycle_failures++;
+		else {
+			nested->device = packet->device;
+			nested->length = 64;
+			netif_receive(nested);
+		}
+		spinlock_acquire(&packet->device->lock);
+		if (packet->device->references == 2)
+			state->receive_pinned++;
+		else
+			state->lifecycle_failures++;
+		spinlock_release(&packet->device->lock);
+		state->receive_unregister_status =
+			net_device_unregister(packet->device);
+	} else {
+		net_receive_unregister(
+			selftest_receive_recursive_unregister, argument);
+	}
+	state->receive_depth--;
+	net_packet_put(packet);
+}
+
+static void selftest_state_recursive_unregister(struct net_device *device,
+						 void *argument)
+{
+	struct net_selftest_state *state = argument;
+
+	if (state != &selftest || !device ||
+	    !state->state_recursive_device)
+		return;
+	state->state_depth++;
+	if (state->state_depth > state->state_depth_max)
+		state->state_depth_max = state->state_depth;
+	state->state_recursive++;
+	if (state->state_recursive == 1)
+		net_device_set_carrier(state->state_recursive_device, 1);
+	else
+		net_state_unregister(selftest_state_recursive_unregister,
+				     argument);
+	state->state_depth--;
+}
+
+static void selftest_state_unregister(struct net_device *device,
+				      void *argument)
+{
+	if (argument == &selftest && device)
+		selftest.state_unregistered++;
+	net_state_unregister(selftest_state_unregister, argument);
+}
+
+static void selftest_receive_close(struct net_packet *packet,
+				   void *argument)
+{
+	if (argument == &selftest && packet && packet->device) {
+		selftest.receive_closed++;
+		net_device_close(packet->device);
+	}
+	net_packet_put(packet);
+}
+
+static void selftest_state_close(struct net_device *device, void *argument)
+{
+	if (argument == &selftest && device && device->up) {
+		selftest.state_closed++;
+		net_device_close(device);
+	}
+}
+
+static void selftest_state_open(struct net_device *device, void *argument)
+{
+	if (argument == &selftest && device && device->registered &&
+	    !device->up) {
+		selftest.state_opened++;
+		if (net_device_open(device))
+			selftest.lifecycle_failures++;
+	}
+}
+
+static void selftest_state_device_unregister(struct net_device *device,
+					     void *argument)
+{
+	if (argument == &selftest && device && device->registered &&
+	    device->up) {
+		selftest.device_unregistered++;
+		selftest.state_unregister_status =
+			net_device_unregister(device);
+		if (selftest.state_unregister_status >= 0)
+			selftest.lifecycle_failures++;
+	}
+}
+
+static void selftest_state_removed_close(struct net_device *device,
+					 void *argument)
+{
+	if (argument == &selftest && device) {
+		selftest.removed_closed++;
+		net_device_close(device);
+	}
+}
+
+static int selftest_unregister_xmit(struct net_device *device,
+				    struct net_packet *packet)
+{
+	selftest.xmit_unregister_status = net_device_unregister(device);
+	net_packet_put(packet);
+	return 0;
+}
+
+int net_core_selftest(void)
+{
+	static const struct net_device_operations operations = {
+		.open = selftest_open,
+		.stop = selftest_stop,
+		.start_xmit = selftest_xmit,
+	};
+	static const struct net_device_operations failed_operations = {
+		.open = selftest_open_failed,
+		.start_xmit = selftest_xmit,
+	};
+	static const struct net_device_operations receive_operations = {
+		.open = selftest_open,
+		.stop = selftest_stop,
+		.start_xmit = selftest_receive_xmit,
+	};
+	static const struct net_device_operations unregister_operations = {
+		.open = selftest_open,
+		.stop = selftest_stop,
+		.start_xmit = selftest_unregister_xmit,
+	};
+	struct net_device device = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device duplicate = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device failed = {
+		.mtu = NET_ETH_MTU,
+		.operations = &failed_operations,
+	};
+	struct net_device receive_close = {
+		.mtu = NET_ETH_MTU,
+		.operations = &receive_operations,
+	};
+	struct net_device state_close = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device state_unregister = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device state_recursive = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device xmit_unregister = {
+		.mtu = NET_ETH_MTU,
+		.operations = &unregister_operations,
+	};
+	struct net_device removed_close = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device lookup_device = {
+		.mtu = NET_ETH_MTU,
+		.operations = &operations,
+	};
+	struct net_device *by_index = 0, *first = 0;
+	struct net_device_stats stats;
+	struct net_packet *packet;
+	uint32 available = net_packet_pool_available();
+	int result = -1;
+
+	memset(&selftest, 0, sizeof(selftest));
+	safe_strncpy(device.name, "net-test", sizeof(device.name));
+	safe_strncpy(duplicate.name, "net-test", sizeof(duplicate.name));
+	safe_strncpy(failed.name, "net-fail", sizeof(failed.name));
+	safe_strncpy(receive_close.name, "net-close",
+		     sizeof(receive_close.name));
+	safe_strncpy(state_close.name, "net-state-close",
+		     sizeof(state_close.name));
+	safe_strncpy(state_unregister.name, "net-state-unreg",
+		     sizeof(state_unregister.name));
+	safe_strncpy(state_recursive.name, "net-state-rec",
+		     sizeof(state_recursive.name));
+	safe_strncpy(xmit_unregister.name, "net-xmit-unreg",
+		     sizeof(xmit_unregister.name));
+	safe_strncpy(removed_close.name, "net-removed-close",
+		     sizeof(removed_close.name));
+	safe_strncpy(lookup_device.name, "net-lookup",
+		     sizeof(lookup_device.name));
+	if (net_device_register(&device) ||
+	    !net_device_register(&duplicate) ||
+	    net_state_register(selftest_state, &selftest) ||
+	    net_receive_register(selftest_receive, &selftest))
+		goto out;
+	if (net_device_open(&device))
+		goto out;
+	if (net_device_open(&device) || selftest.opened != 1)
+		goto out;
+	net_device_set_carrier(&device, 1);
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->length = NET_ETH_HEADER_LENGTH - 1;
+	if (net_device_xmit(&device, packet) >= 0) {
+		net_packet_put(packet);
+		goto out;
+	}
+	net_packet_put(packet);
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->device = &device;
+	packet->length = NET_ETH_HEADER_LENGTH - 1;
+	netif_receive(packet);
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->length = 64;
+	if (net_device_xmit(&device, packet)) {
+		net_packet_put(packet);
+		goto out;
+	}
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->device = &device;
+	packet->length = 64;
+	netif_receive(packet);
+	netif_stop_queue(&device);
+	net_device_set_carrier(&device, 0);
+	netif_wake_queue(&device);
+	if (netif_queue_stopped(&device))
+		goto out;
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->length = 64;
+	if (net_device_xmit(&device, packet) != NETDEV_TX_BUSY) {
+		net_packet_put(packet);
+		goto out;
+	}
+	net_packet_put(packet);
+	net_device_set_carrier(&device, 1);
+	if (netif_queue_stopped(&device))
+		goto out;
+	net_device_get_stats(&device, &stats);
+	if (stats.tx_packets != 1 || stats.tx_bytes != 64 ||
+	    stats.rx_packets != 1 || stats.rx_bytes != 64 ||
+	    stats.rx_dropped != 1 ||
+	    selftest.opened != 1 || selftest.transmitted != 1 ||
+	    selftest.received != 1 || selftest.state_changes < 2 ||
+	    device.transmit_active)
+		goto out;
+	net_device_close(&device);
+	if (device.up || selftest.stopped != 1)
+		goto out;
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->length = 64;
+	if (net_device_xmit(&device, packet) != NETDEV_TX_BUSY) {
+		net_packet_put(packet);
+		goto out;
+	}
+	net_packet_put(packet);
+	if (net_device_open(&device) || selftest.opened != 2)
+		goto out;
+	if (net_device_register(&failed) || !net_device_open(&failed))
+		goto out;
+	net_device_unregister(&failed);
+	net_receive_unregister(selftest_receive, &selftest);
+	if (net_receive_register(selftest_receive_unregister, &selftest))
+		goto out;
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->device = &device;
+	packet->length = 64;
+	netif_receive(packet);
+	if (selftest.receive_unregistered != 1 ||
+	    net_receive_register(selftest_receive, &selftest))
+		goto out;
+	net_receive_unregister(selftest_receive, &selftest);
+	if (net_receive_register(selftest_receive_recursive_unregister,
+				 &selftest))
+		goto out;
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->device = &device;
+	packet->length = 64;
+	netif_receive(packet);
+	if (selftest.receive_recursive != 2 || selftest.receive_depth ||
+	    selftest.receive_depth_max != 1 || selftest.receive_pinned != 1 ||
+	    selftest.receive_unregister_status >= 0 || device.references ||
+	    selftest.lifecycle_failures ||
+	    net_receive_register(selftest_receive, &selftest))
+		goto out;
+	net_state_unregister(selftest_state, &selftest);
+	if (net_state_register(selftest_state_unregister, &selftest))
+		goto out;
+	net_device_set_carrier(&device, 0);
+	if (selftest.state_unregistered != 1 ||
+	    net_state_register(selftest_state, &selftest))
+		goto out;
+	net_device_set_carrier(&device, 1);
+	if (net_device_register(&state_recursive) ||
+	    net_device_open(&state_recursive))
+		goto out;
+	selftest.state_recursive_device = &state_recursive;
+	net_state_unregister(selftest_state, &selftest);
+	if (net_state_register(selftest_state_recursive_unregister,
+			       &selftest))
+		goto out;
+	net_device_set_carrier(&device, 0);
+	if (selftest.state_recursive != 2 || selftest.state_depth ||
+	    selftest.state_depth_max != 1 || selftest.lifecycle_failures ||
+	    net_state_register(selftest_state, &selftest))
+		goto out;
+	net_device_set_carrier(&device, 1);
+	net_receive_unregister(selftest_receive, &selftest);
+	if (net_receive_register(selftest_receive_close, &selftest) ||
+	    net_device_register(&receive_close) ||
+	    net_device_open(&receive_close))
+		goto out;
+	net_device_set_carrier(&receive_close, 1);
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->length = 64;
+	if (net_device_xmit(&receive_close, packet) ||
+	    selftest.receive_closed != 1 || receive_close.up ||
+	    receive_close.lifecycle_transition ||
+	    receive_close.transmit_active || selftest.stopped != 2)
+		goto out;
+	net_receive_unregister(selftest_receive_close, &selftest);
+	if (net_device_unregister(&receive_close))
+		goto out;
+	net_state_unregister(selftest_state, &selftest);
+	if (net_state_register(selftest_state_close, &selftest) ||
+	    net_device_register(&state_close) ||
+	    net_device_open(&state_close) || state_close.up ||
+	    selftest.state_closed != 1)
+		goto out;
+	net_state_unregister(selftest_state_close, &selftest);
+	if (net_state_register(selftest_state_open, &selftest) ||
+	    net_device_open(&state_close))
+		goto out;
+	net_device_close(&state_close);
+	if (!state_close.up || selftest.state_opened != 1 ||
+	    selftest.lifecycle_failures)
+		goto out;
+	if (net_device_unregister(&state_close))
+		goto out;
+	net_state_unregister(selftest_state_open, &selftest);
+	if (net_state_register(selftest_state_device_unregister,
+			       &selftest) ||
+	    net_device_register(&state_unregister) ||
+	    net_device_open(&state_unregister) ||
+	    !state_unregister.registered || !state_unregister.up ||
+	    selftest.device_unregistered != 1 ||
+	    selftest.state_unregister_status >= 0 ||
+	    selftest.lifecycle_failures)
+		goto out;
+	net_state_unregister(selftest_state_device_unregister, &selftest);
+	if (net_device_unregister(&state_unregister))
+		goto out;
+	if (net_state_register(selftest_state, &selftest) ||
+	    net_device_register(&xmit_unregister) ||
+	    net_device_open(&xmit_unregister))
+		goto out;
+	net_device_set_carrier(&xmit_unregister, 1);
+	packet = net_packet_alloc(64);
+	if (!packet)
+		goto out;
+	packet->length = 64;
+	selftest.xmit_unregister_status = 0;
+	if (net_device_xmit(&xmit_unregister, packet) ||
+	    selftest.xmit_unregister_status >= 0 ||
+	    !xmit_unregister.registered || !xmit_unregister.up)
+		goto out;
+	if (net_device_unregister(&xmit_unregister))
+		goto out;
+	if (net_device_register(&lookup_device) ||
+	    net_device_open(&lookup_device))
+		goto out;
+	by_index = net_device_get(lookup_device.index);
+	first = net_device_first();
+	if (by_index != &lookup_device || !first)
+		goto out;
+	net_device_put(first);
+	first = 0;
+	net_device_put(by_index);
+	by_index = 0;
+	if (lookup_device.references ||
+	    net_device_unregister(&lookup_device))
+		goto out;
+	if (net_device_register(&removed_close) ||
+	    net_device_open(&removed_close))
+		goto out;
+	net_state_unregister(selftest_state, &selftest);
+	if (net_state_register(selftest_state_removed_close, &selftest) ||
+	    net_device_unregister(&removed_close) ||
+	    selftest.removed_closed != 1)
+		goto out;
+	result = 0;
+
+out:
+	if (first)
+		net_device_put(first);
+	if (by_index)
+		net_device_put(by_index);
+	net_receive_unregister(selftest_receive, &selftest);
+	net_receive_unregister(selftest_receive_unregister, &selftest);
+	net_receive_unregister(selftest_receive_recursive_unregister,
+			       &selftest);
+	net_receive_unregister(selftest_receive_close, &selftest);
+	net_state_unregister(selftest_state, &selftest);
+	net_state_unregister(selftest_state_unregister, &selftest);
+	net_state_unregister(selftest_state_recursive_unregister, &selftest);
+	net_state_unregister(selftest_state_close, &selftest);
+	net_state_unregister(selftest_state_open, &selftest);
+	net_state_unregister(selftest_state_device_unregister, &selftest);
+	net_state_unregister(selftest_state_removed_close, &selftest);
+	net_device_unregister(&device);
+	if (failed.registered)
+		net_device_unregister(&failed);
+	if (duplicate.registered)
+		net_device_unregister(&duplicate);
+	if (receive_close.registered)
+		net_device_unregister(&receive_close);
+	if (state_close.registered)
+		net_device_unregister(&state_close);
+	if (state_unregister.registered)
+		net_device_unregister(&state_unregister);
+	if (state_recursive.registered)
+		net_device_unregister(&state_recursive);
+	if (xmit_unregister.registered)
+		net_device_unregister(&xmit_unregister);
+	if (removed_close.registered)
+		net_device_unregister(&removed_close);
+	if (lookup_device.registered)
+		net_device_unregister(&lookup_device);
+	if (net_packet_pool_available() != available)
+		result = -1;
+	return result;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,8 @@ CLINT access, `mret`, `-bios none`, and a kernel entry other than
 
 The guest selftest covers:
 
+- network device registration, packet ownership, queue state, and a
+  VirtIO network device attached to every boot;
 - repeated fork, exec, exit, and wait cycles;
 - FIFO scheduler progress with 24 runnable processes, timer preemption, and
   more runnable work than CPUs;

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -32,7 +32,9 @@ set command [list \
 	-snapshot \
 	-global virtio-mmio.force-legacy=false \
 	-drive file=$env(ROOT_IMAGE),if=none,format=raw,id=x0 \
-	-device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0]
+	-device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0 \
+	-netdev user,id=n0 \
+	-device virtio-net-device,netdev=n0,bus=virtio-mmio-bus.1]
 
 spawn -noecho {*}$command
 expect {
@@ -77,4 +79,13 @@ send -- "\001x"
 expect {
 	eof {}
 	timeout { abort_test "QEMU exit timeout" }
+}
+
+log_file
+set log_handle [open $env(QEMU_LOG) r]
+set log_contents [read $log_handle]
+close $log_handle
+set net_devices [regexp -all -- {virtio-net: registered eth0} $log_contents]
+if {$net_devices != 1} {
+	abort_test "expected one registered VirtIO network device"
 }

--- a/tests/scripts/run-qemu.exp
+++ b/tests/scripts/run-qemu.exp
@@ -43,7 +43,9 @@ set command [list \
 	-drive file=$env(ROOT_IMAGE),if=none,format=raw,id=x0 \
 	-device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0 \
 	-drive file=$env(FAT_IMAGE),if=none,format=raw,id=x1 \
-	-device virtio-blk-device,drive=x1,bus=virtio-mmio-bus.1]
+	-device virtio-blk-device,drive=x1,bus=virtio-mmio-bus.1 \
+	-netdev user,id=n0 \
+	-device virtio-net-device,netdev=n0,bus=virtio-mmio-bus.2]
 
 spawn -noecho {*}$command
 


### PR DESCRIPTION
Depends on #45.

Networking needs a device boundary that is independent of both the protocol
stack and a particular transport. Packet ownership, queue backpressure,
carrier state, and deferred receive work otherwise leak into each driver.

Add the network-device core, packet pools, loopback support, and a VirtIO
network driver on the shared MMIO transport. Make the QEMU network backend
configurable without introducing socket UAPI or a protocol stack here.

CI attaches a VirtIO network device to every QEMU boot. This layer exercises
device probe, queue setup, carrier transitions, interrupt completion, packet
ownership, and deferred receive paths only.
