### PR TITLE
sched: add weighted virtual-runtime scheduling

### DIFF
--- a/Documentation/networking/lwip.md
+++ b/Documentation/networking/lwip.md
@@ -54,8 +54,8 @@ git -C /tmp/lwip-update rev-parse HEAD
 Replace only `COPYING`, `src/api`, `src/core`, `src/include`, and
 `src/netif/ethernet.c`.  Do not overwrite `net/lwip/port/` or the Caffeinix
 Makefiles under `upstream/`.  Update `UPSTREAM`, inspect upstream option and
-API changes, then run the UAPI, host ring, QEMU networking, offline-NIC, SMP,
-and filesystem-consistency tests.
+API changes, then run the UAPI, host ring/tree, QEMU networking, offline-NIC,
+SMP, pressure, and filesystem-consistency tests.
 
 Keep upstream C files unchanged unless an independently explained upstream
 compatibility patch is unavoidable.  Caffeinix-specific headers and libc

--- a/Documentation/networking/socket-uapi.md
+++ b/Documentation/networking/socket-uapi.md
@@ -23,10 +23,10 @@ datagram, and raw ICMP sockets.  The implemented calls are:
 - `ppoll`, `FIONREAD`, `FIONBIO`, `SOCK_CLOEXEC`, `SOCK_NONBLOCK`, and
   `F_SETFL(O_NONBLOCK)`.
 
-The socket path also supplies monotonic `clock_gettime` and `ftruncate`
-required by the current musl tests.  Linux errors are translated explicitly;
-unsupported families, flags, control messages, and options fail instead of
-reporting false success.
+The current musl tests also use monotonic `clock_gettime`, `ftruncate`, and
+process nice calls. Linux errors are translated explicitly; unsupported
+families, flags, control messages, and options fail instead of reporting
+false success.
 
 Socket payload copies are bounded to one page per syscall.  TCP may return a
 short read or write and userspace must retry.  An oversized datagram fails

--- a/Documentation/scheduler.md
+++ b/Documentation/scheduler.md
@@ -1,0 +1,83 @@
+# CFS-style scheduler
+
+Caffeinix uses a small SMP scheduler based on the classic Linux Completely
+Fair Scheduler model. It is an independent implementation of the same core
+ideas, not copied Linux scheduler source and not a claim of full Linux
+scheduler compatibility.
+
+## Model
+
+Every runnable thread has a scheduling entity containing virtual runtime,
+actual runtime, current-slice start, nice value, weight, and red-black-tree
+node. One global runqueue orders entities by virtual runtime and uses the
+thread ID as a stable tie breaker.
+
+Runtime is charged when a running thread yields, blocks, exits, changes nice,
+or is examined for preemption. Virtual runtime advances as:
+
+```text
+delta_vruntime = delta_execution * NICE_0_LOAD / weight
+```
+
+The 40-entry weight table for nice values -20 through 19 matches the classic
+Linux CFS weights. A lower-priority task therefore advances farther in
+virtual time for the same physical execution and is selected less often.
+
+The leftmost tree entity has the least virtual runtime and runs next. A new
+thread begins at the runqueue minimum. A waking thread that fell too far
+behind is placed no earlier than one wakeup granularity behind that minimum,
+preventing unlimited sleeper credit.
+
+## Slices and preemption
+
+The target latency is 48 ms, minimum granularity is 6 ms, wakeup granularity
+is 4 ms, and the absolute minimum slice is 1 ms. A selected entity receives
+its weighted share of the scheduling period. The timer requests reschedule
+when the slice expires or when the current entity is sufficiently to the
+right of the leftmost runnable entity. The actual context switch happens at
+a trap-return safe point.
+
+A waking entity can request preemption of the CPU with the greatest virtual
+runtime. Idle CPUs are preferred and are awakened through the SBI IPI
+extension. The implementation coalesces reschedule requests.
+
+## SMP state and locking
+
+`runqueue.lock` protects the tree, aggregate weight, runnable count, minimum
+virtual runtime, and each CPU's scheduler-visible `current` and `selected`
+state. `selected` covers the interval after a CPU removes an entity from the
+tree but before it obtains that thread's lock and starts it. This prevents
+the entity from disappearing from load and minimum-runtime accounting.
+
+A thread lock is held across every context switch back to the scheduler.
+The scheduler verifies that a thread is in exactly one of these locations:
+running on one CPU, selected by one CPU, queued once, sleeping on one wait
+queue, exited, or unused.
+
+Process exit holds the final thread lock while publishing zombie state and
+until the scheduler switches away. A parent on another CPU can observe the
+zombie immediately, but cannot reclaim its thread or kernel stack before the
+handoff completes.
+
+## Idle policy
+
+An empty CPU publishes itself idle while synchronized with enqueue, then
+executes `WFI` with interrupt sources enabled. CPU 0 retains a 10 ms timer
+because it expires global timed waits. Other idle CPUs use a 100 ms timer;
+an active CPU restores the 10 ms interval. Runnable work wakes an idle CPU
+with an IPI instead of waiting for either timer.
+
+## Current limits
+
+There is one global runqueue rather than Linux per-CPU runqueues. Caffeinix
+does not yet implement CPU affinity, load balancing, scheduler classes,
+real-time policies, cgroups, bandwidth control, NUMA placement, or CPU
+hotplug. Modern Linux also has scheduler evolution beyond the classic CFS
+picker; this milestone intentionally implements the smaller vruntime model
+needed by Caffeinix.
+
+The host benchmark under `tests/scripts/benchmark-scheduler.py` compares one
+and eight guest CPUs, records command medians, and measures idle QEMU CPU
+use. Guest tests cover nice-weight ordering, more runnable processes than
+CPUs, fork/exec/exit/wait, blocking I/O, timed waits, and mixed CPU, network,
+and filesystem pressure.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ modern VirtIO network device through lwIP.
 
 - Architecture: RISC-V 64-bit little-endian
 - ISA and ABI: RV64GC with LP64D
-- Machine: QEMU `virt`, one, two, and four harts tested
-- Firmware: OpenSBI with SBI v0.2 or newer, TIME, and HSM for SMP
+- Machine: QEMU `virt`, one, two, four, and eight harts tested
+- Firmware: OpenSBI with SBI v0.2 or newer, TIME, HSM, and IPI for SMP
 - Userspace: static non-PIE musl ELF executables
 - Root filesystem: ext4 with 1 KiB filesystem blocks
 - Optional data filesystem: FAT16 or FAT32
@@ -230,6 +230,8 @@ layer ownership rules and the Device Tree needed to add another serial port.
 The shared VirtIO, block, network-device, and protocol-stack boundaries are
 described in the
 [`network architecture`](Documentation/networking/architecture.md).
+The SMP scheduling and virtual-runtime rules are described in
+[`Documentation/scheduler.md`](Documentation/scheduler.md).
 
 ## Run
 

--- a/arch/riscv/include/timer.h
+++ b/arch/riscv/include/timer.h
@@ -7,6 +7,8 @@ void timer_init(void);
 void timer_init_hart(void);
 void timer_wait_for_interrupt(void);
 void timer_interrupt(void);
+void timer_set_active(void);
+void timer_set_idle(void);
 uint64 timer_frequency(void);
 
 #endif

--- a/arch/riscv/timer.c
+++ b/arch/riscv/timer.c
@@ -9,7 +9,9 @@
 
 static uint64 clock_frequency;
 static uint64 tick_interval;
+static uint64 idle_tick_interval;
 static volatile uint8 timer_seen[NCPU];
+static volatile uint8 timer_idle[NCPU];
 
 void timer_init(void)
 {
@@ -22,7 +24,8 @@ void timer_init(void)
 		PANIC("missing timebase-frequency");
 	clock_frequency = frequency;
 	tick_interval = clock_frequency * TICK_INTERVAL / 1000;
-	if (!tick_interval)
+	idle_tick_interval = clock_frequency * IDLE_TICK_INTERVAL / 1000;
+	if (!tick_interval || !idle_tick_interval)
 		PANIC("invalid timer interval");
 }
 
@@ -53,15 +56,44 @@ void timer_wait_for_interrupt(void)
 void timer_interrupt(void)
 {
 	int logical = cpuid();
+	uint64 interval;
 
 	if (logical < 0 || logical >= NCPU)
 		PANIC("invalid timer CPU");
-	if (sbi_set_timer(time_r() + tick_interval))
+	interval = timer_idle[logical] ? idle_tick_interval : tick_interval;
+	if (sbi_set_timer(time_r() + interval))
 		PANIC("SBI timer rearm failed");
 	if (!timer_seen[logical]) {
 		timer_seen[logical] = 1;
 		printf("CPU: logical=%d timer active\n", logical);
 	}
+}
+
+void timer_set_active(void)
+{
+	int logical = cpuid();
+
+	if (logical < 0 || logical >= NCPU)
+		PANIC("invalid timer CPU");
+	if (!__atomic_exchange_n(&timer_idle[logical], 0,
+				 __ATOMIC_ACQ_REL))
+		return;
+	if (sbi_set_timer(time_r() + tick_interval))
+		PANIC("SBI active timer failed");
+}
+
+void timer_set_idle(void)
+{
+	int logical = cpuid();
+
+	if (logical < 0 || logical >= NCPU)
+		PANIC("invalid timer CPU");
+	/* CPU0 retains the fine tick that expires global timed waits. */
+	if (!logical || __atomic_exchange_n(&timer_idle[logical], 1,
+					    __ATOMIC_ACQ_REL))
+		return;
+	if (sbi_set_timer(time_r() + idle_tick_interval))
+		PANIC("SBI idle timer failed");
 }
 
 uint64 timer_frequency(void)

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -78,7 +78,9 @@ void kernel_trap(void)
                 PANIC("kerneltrap");
         }
 
-	if(which_dev == 2 || which_dev == 3)
+	if (which_dev == 2)
+		scheduler_tick();
+	else if (which_dev == 3)
                 scheduler_request_resched();
 
         if(scheduler_should_resched())
@@ -123,7 +125,9 @@ void user_trap_entry(void)
         if(killed(p))
                 exit(-1);
 
-	if(which_dev == 2 || which_dev == 3)
+	if (which_dev == 2)
+		scheduler_tick();
+	else if (which_dev == 3)
                 scheduler_request_resched();
 
         if(scheduler_should_resched())

--- a/include/kernel_config.h
+++ b/include/kernel_config.h
@@ -20,7 +20,7 @@
 #define MAXNAME                         16
 
 /* For ms */
-#define TICK_INTERVAL                   100
+#define TICK_INTERVAL                   1
 
 #define WORKQUEUE_NAME                  "kworker"
 

--- a/include/kernel_config.h
+++ b/include/kernel_config.h
@@ -21,6 +21,7 @@
 
 /* For ms */
 #define TICK_INTERVAL                   1
+#define IDLE_TICK_INTERVAL              100
 
 #define WORKQUEUE_NAME                  "kworker"
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -2,7 +2,7 @@ EXTRA_CFLAGS := -I ./include -I ../arch/riscv/include -I ../include
 CFLAGS_file.o := 
 
 
-obj-y += string.o palloc.o spinlock.o ktime.o thread.o wait.o \
+obj-y += string.o palloc.o spinlock.o rbtree.o ktime.o thread.o wait.o \
 sleeplock.o switchto.o trampoline.o process.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o workqueue.o main.o

--- a/kernel/include/linux_uapi.h
+++ b/kernel/include/linux_uapi.h
@@ -38,6 +38,8 @@
 #define LINUX_SYS_clock_gettime     113
 #define LINUX_SYS_rt_sigaction      134
 #define LINUX_SYS_rt_sigprocmask    135
+#define LINUX_SYS_setpriority       140
+#define LINUX_SYS_getpriority       141
 #define LINUX_SYS_umask             166
 #define LINUX_SYS_prctl             167
 #define LINUX_SYS_getpid            172
@@ -315,6 +317,8 @@ struct linux_linger {
 
 #define LINUX_CLOCK_REALTIME             0
 #define LINUX_CLOCK_MONOTONIC            1
+
+#define LINUX_PRIO_PROCESS               0
 
 #define LINUX_S_IFMT             00170000
 #define LINUX_S_IFREG            0100000

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -70,6 +70,8 @@ void process_freepagedir(pagedir_t pgdir, uint64 sz);
 int process_grow(int n);
 int process_fork(uint64 child_stack);
 int process_wait(int target, uint64 status_address, int nohang);
+int process_set_nice(int pid, int nice);
+int process_get_nice(int pid, int *nice);
 
 int killed(process_t p);
 int either_copyout(int user_dst, uint64 dst, void* src, uint64 len);

--- a/kernel/include/rbtree.h
+++ b/kernel/include/rbtree.h
@@ -1,0 +1,50 @@
+#ifndef __CAFFEINIX_KERNEL_RBTREE_H
+#define __CAFFEINIX_KERNEL_RBTREE_H
+
+#include <typedefs.h>
+
+struct rb_node {
+	struct rb_node *parent;
+	struct rb_node *left;
+	struct rb_node *right;
+	uint8 red;
+};
+
+struct rb_root {
+	struct rb_node *node;
+};
+
+#define rb_entry(pointer, type, member) \
+	((type *)((char *)(pointer) - \
+	 (unsigned long)(&((type *)0)->member)))
+
+static inline void rb_root_init(struct rb_root *root)
+{
+	root->node = 0;
+}
+
+static inline void rb_node_init(struct rb_node *node)
+{
+	node->parent = 0;
+	node->left = 0;
+	node->right = 0;
+	node->red = 1;
+}
+
+static inline void rb_link_node(struct rb_node *node,
+				struct rb_node *parent,
+				struct rb_node **link)
+{
+	node->parent = parent;
+	node->left = 0;
+	node->right = 0;
+	node->red = 1;
+	*link = node;
+}
+
+void rb_insert_color(struct rb_node *node, struct rb_root *root);
+void rb_erase(struct rb_node *node, struct rb_root *root);
+struct rb_node *rb_first(const struct rb_root *root);
+struct rb_node *rb_next(const struct rb_node *node);
+
+#endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -9,6 +9,8 @@ struct device_node;
 typedef struct cpu {
         struct context context;
         thread_t current;
+	/* Picked from the runqueue but not running yet. */
+	thread_t selected;
         /* Nesting Depth */
         uint8 lock_nest_depth;
         /* Is the interrupt enabled before locking */
@@ -17,7 +19,7 @@ typedef struct cpu {
 	struct device_node *of_node;
 	volatile uint8 online;
 	uint8 idle;
-	uint8 need_resched;
+	volatile uint8 need_resched;
 }*cpu_t;
 
 uint8 cpuid(void);
@@ -30,9 +32,13 @@ void yield(void);
 void sched(void);
 void scheduler_exit(void);
 void scheduler_exit_locked(void);
-void scheduler_block_current(void);
 void scheduler_make_runnable(thread_t thread);
+void scheduler_block_current(void);
+void scheduler_inherit(thread_t child, thread_t parent);
+int scheduler_set_nice(thread_t thread, int nice);
+int scheduler_get_nice(thread_t thread);
 void scheduler_request_resched(void);
+void scheduler_tick(void);
 int scheduler_should_resched(void);
 
 #endif

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -13,6 +13,7 @@
 
 #include <typedefs.h>
 #include <list.h>
+#include <rbtree.h>
 #include <spinlock.h>
 #include <kernel_config.h>
 #include <riscv.h>
@@ -95,6 +96,18 @@ typedef struct trapframe {
 	/* 544 */ uint64 fcsr;
 }*trapframe_t;
 
+struct sched_entity {
+	struct rb_node run_node;
+	uint64 vruntime;
+	uint64 exec_start;
+	uint64 sum_exec_runtime;
+	uint64 slice_ns;
+	uint32 weight;
+	int8 nice;
+	uint8 initialized;
+	uint8 on_runqueue;
+};
+
 typedef struct thread {
         char name[MAXNAME];
         struct spinlock lock;
@@ -113,8 +126,7 @@ typedef struct thread {
 	void *kernel_argument;
 	uint8 kernel_thread;
 	int lwip_errno;
-        struct list run_node;
-        uint8 on_runqueue;
+	struct sched_entity sched;
         struct wait_queue *waiting_on;
         struct list wait_node;
         uint8 on_waitqueue;

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -373,6 +373,7 @@ int process_fork(uint64 child_stack)
 
         oldt = cur_thread();
         newt = newp->thread[0];
+	scheduler_inherit(newt, oldt);
 
 	if(vm_copy(oldp->pagetable, newp->pagetable) != 0) {
 		spinlock_release(&newt->lock);

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -523,6 +523,55 @@ int process_wait(int target, uint64 status_address, int nohang)
         }
 }
 
+static process_t process_find_locked(int pid)
+{
+	process_t process;
+	list_t entry;
+
+	if (!spinlock_holding(&wait_lock))
+		PANIC("process lookup unlocked");
+	for (entry = proc.next; entry != &proc; entry = entry->next) {
+		process = list_entry(entry, struct process, all_tag);
+		if (process->pid == pid && process->state == PROCESS_LIVE)
+			return process;
+	}
+	return 0;
+}
+
+int process_set_nice(int pid, int nice)
+{
+	process_t process;
+	thread_t thread;
+	int result = -1;
+
+	spinlock_acquire(&wait_lock);
+	process = process_find_locked(pid);
+	thread = process ? process->thread[0] : 0;
+	if (thread)
+		result = scheduler_set_nice(thread, nice);
+	spinlock_release(&wait_lock);
+	return result;
+}
+
+int process_get_nice(int pid, int *nice)
+{
+	process_t process;
+	thread_t thread;
+	int result = -1;
+
+	if (!nice)
+		return -1;
+	spinlock_acquire(&wait_lock);
+	process = process_find_locked(pid);
+	thread = process ? process->thread[0] : 0;
+	if (thread) {
+		*nice = scheduler_get_nice(thread);
+		result = 0;
+	}
+	spinlock_release(&wait_lock);
+	return result;
+}
+
 /**
  * @description: Kill a process
  * @param {int} pid of process

--- a/kernel/rbtree.c
+++ b/kernel/rbtree.c
@@ -1,0 +1,258 @@
+#include <rbtree.h>
+
+static int rb_is_red(const struct rb_node *node)
+{
+	return node && node->red;
+}
+
+static int rb_is_black(const struct rb_node *node)
+{
+	return !node || !node->red;
+}
+
+static void rb_rotate_left(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *right = node->right;
+
+	node->right = right->left;
+	if (right->left)
+		right->left->parent = node;
+	right->parent = node->parent;
+	if (!node->parent)
+		root->node = right;
+	else if (node == node->parent->left)
+		node->parent->left = right;
+	else
+		node->parent->right = right;
+	right->left = node;
+	node->parent = right;
+}
+
+static void rb_rotate_right(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *left = node->left;
+
+	node->left = left->right;
+	if (left->right)
+		left->right->parent = node;
+	left->parent = node->parent;
+	if (!node->parent)
+		root->node = left;
+	else if (node == node->parent->right)
+		node->parent->right = left;
+	else
+		node->parent->left = left;
+	left->right = node;
+	node->parent = left;
+}
+
+void rb_insert_color(struct rb_node *node, struct rb_root *root)
+{
+	while (node->parent && node->parent->red) {
+		struct rb_node *parent = node->parent;
+		struct rb_node *grandparent = parent->parent;
+
+		if (parent == grandparent->left) {
+			struct rb_node *uncle = grandparent->right;
+
+			if (rb_is_red(uncle)) {
+				parent->red = 0;
+				uncle->red = 0;
+				grandparent->red = 1;
+				node = grandparent;
+				continue;
+			}
+			if (node == parent->right) {
+				node = parent;
+				rb_rotate_left(node, root);
+				parent = node->parent;
+				grandparent = parent->parent;
+			}
+			parent->red = 0;
+			grandparent->red = 1;
+			rb_rotate_right(grandparent, root);
+		} else {
+			struct rb_node *uncle = grandparent->left;
+
+			if (rb_is_red(uncle)) {
+				parent->red = 0;
+				uncle->red = 0;
+				grandparent->red = 1;
+				node = grandparent;
+				continue;
+			}
+			if (node == parent->left) {
+				node = parent;
+				rb_rotate_right(node, root);
+				parent = node->parent;
+				grandparent = parent->parent;
+			}
+			parent->red = 0;
+			grandparent->red = 1;
+			rb_rotate_left(grandparent, root);
+		}
+	}
+	root->node->red = 0;
+}
+
+static void rb_replace_node(struct rb_root *root, struct rb_node *old,
+			    struct rb_node *new)
+{
+	if (!old->parent)
+		root->node = new;
+	else if (old == old->parent->left)
+		old->parent->left = new;
+	else
+		old->parent->right = new;
+	if (new)
+		new->parent = old->parent;
+}
+
+static struct rb_node *rb_subtree_first(struct rb_node *node)
+{
+	while (node->left)
+		node = node->left;
+	return node;
+}
+
+static void rb_erase_fixup(struct rb_root *root, struct rb_node *node,
+			   struct rb_node *parent)
+{
+	while (node != root->node && rb_is_black(node)) {
+		struct rb_node *sibling;
+
+		if (!parent)
+			break;
+		if (node == parent->left) {
+			sibling = parent->right;
+			if (rb_is_red(sibling)) {
+				sibling->red = 0;
+				parent->red = 1;
+				rb_rotate_left(parent, root);
+				sibling = parent->right;
+			}
+			if (!sibling) {
+				node = parent;
+				parent = node->parent;
+				continue;
+			}
+			if (rb_is_black(sibling->left) &&
+			    rb_is_black(sibling->right)) {
+				sibling->red = 1;
+				node = parent;
+				parent = node->parent;
+				continue;
+			}
+			if (rb_is_black(sibling->right)) {
+				if (sibling->left)
+					sibling->left->red = 0;
+				sibling->red = 1;
+				rb_rotate_right(sibling, root);
+				sibling = parent->right;
+			}
+			sibling->red = parent->red;
+			parent->red = 0;
+			if (sibling->right)
+				sibling->right->red = 0;
+			rb_rotate_left(parent, root);
+			node = root->node;
+			parent = 0;
+		} else {
+			sibling = parent->left;
+			if (rb_is_red(sibling)) {
+				sibling->red = 0;
+				parent->red = 1;
+				rb_rotate_right(parent, root);
+				sibling = parent->left;
+			}
+			if (!sibling) {
+				node = parent;
+				parent = node->parent;
+				continue;
+			}
+			if (rb_is_black(sibling->left) &&
+			    rb_is_black(sibling->right)) {
+				sibling->red = 1;
+				node = parent;
+				parent = node->parent;
+				continue;
+			}
+			if (rb_is_black(sibling->left)) {
+				if (sibling->right)
+					sibling->right->red = 0;
+				sibling->red = 1;
+				rb_rotate_left(sibling, root);
+				sibling = parent->left;
+			}
+			sibling->red = parent->red;
+			parent->red = 0;
+			if (sibling->left)
+				sibling->left->red = 0;
+			rb_rotate_right(parent, root);
+			node = root->node;
+			parent = 0;
+		}
+	}
+	if (node)
+		node->red = 0;
+}
+
+void rb_erase(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *child;
+	struct rb_node *child_parent;
+	struct rb_node *replacement = node;
+	uint8 replacement_red = replacement->red;
+
+	if (!node->left) {
+		child = node->right;
+		child_parent = node->parent;
+		rb_replace_node(root, node, node->right);
+	} else if (!node->right) {
+		child = node->left;
+		child_parent = node->parent;
+		rb_replace_node(root, node, node->left);
+	} else {
+		replacement = rb_subtree_first(node->right);
+		replacement_red = replacement->red;
+		child = replacement->right;
+		if (replacement->parent == node) {
+			child_parent = replacement;
+			if (child)
+				child->parent = replacement;
+		} else {
+			child_parent = replacement->parent;
+			rb_replace_node(root, replacement, replacement->right);
+			replacement->right = node->right;
+			replacement->right->parent = replacement;
+		}
+		rb_replace_node(root, node, replacement);
+		replacement->left = node->left;
+		replacement->left->parent = replacement;
+		replacement->red = node->red;
+	}
+	if (!replacement_red)
+		rb_erase_fixup(root, child, child_parent);
+	rb_node_init(node);
+}
+
+struct rb_node *rb_first(const struct rb_root *root)
+{
+	struct rb_node *node = root->node;
+
+	return node ? rb_subtree_first(node) : 0;
+}
+
+struct rb_node *rb_next(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (node->right)
+		return rb_subtree_first(node->right);
+	parent = node->parent;
+	while (parent && node == parent->right) {
+		node = parent;
+		parent = parent->parent;
+	}
+	return parent;
+}

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -1,217 +1,510 @@
-#include <scheduler.h>
-#include <mem_layout.h>
-#include <kernel_config.h>
-#include <riscv.h>
-#include <list.h>
-#include <debug.h>
 #include <cpu.h>
+#include <debug.h>
+#include <kernel_config.h>
+#include <ktime.h>
+#include <mem_layout.h>
+#include <rbtree.h>
+#include <riscv.h>
 #include <sbi.h>
+#include <scheduler.h>
+
+#define NICE_0_LOAD 1024U
+#define SCHED_TARGET_LATENCY_NS 48000000ULL
+#define SCHED_MIN_GRANULARITY_NS 6000000ULL
+#define SCHED_WAKEUP_GRANULARITY_NS 4000000ULL
+#define SCHED_MIN_SLICE_NS 1000000ULL
+
+static const uint32 nice_weights[40] = {
+	88761, 71755, 56483, 46273, 36291,
+	29154, 23254, 18705, 14949, 11916,
+	9548, 7620, 6100, 4904, 3906,
+	3121, 2501, 1991, 1586, 1277,
+	1024, 820, 655, 526, 423,
+	335, 272, 215, 172, 137,
+	110, 87, 70, 56, 45,
+	36, 29, 23, 18, 15,
+};
 
 extern void switchto(context_t c, context_t p);
+
 struct cpu cpus[NCPU];
 
 static struct {
-        struct spinlock lock;
-        struct list runnable;
-        uint32 count;
+	struct spinlock lock;
+	struct rb_root timeline;
+	uint64 total_weight;
+	uint64 min_vruntime;
+	uint32 count;
 } runqueue;
 
-/* Get hart id */
 uint8 cpuid(void)
 {
-        uint8 hartid = tp_r();
-        return hartid;  
+	return tp_r();
 }
 
-/* Get current cpu structure */
 cpu_t cur_cpu(void)
 {
-        uint8 hartid = cpuid();
-        cpu_t cpu = &cpus[hartid];
-        return cpu;
+	return &cpus[cpuid()];
 }
 
-/* Get current thread */
 thread_t cur_thread(void)
 {
-        return cur_cpu()->current;
+	return cur_cpu()->current;
 }
 
-/* Get current process */
 process_t cur_proc(void)
 {
-        thread_t current = cur_thread();
+	thread_t current = cur_thread();
 
-        return current ? current->home : 0;
+	return current ? current->home : 0;
 }
 
 void scheduler_init(void)
 {
-        spinlock_init(&runqueue.lock, "runqueue");
-        list_init(&runqueue.runnable);
-        runqueue.count = 0;
+	spinlock_init(&runqueue.lock, "CFS runqueue");
+	rb_root_init(&runqueue.timeline);
+	runqueue.total_weight = 0;
+	runqueue.min_vruntime = 0;
+	runqueue.count = 0;
 }
 
-static int scheduler_claim_idle_cpu(void)
+static uint64 add_saturate(uint64 left, uint64 right)
 {
-        cpu_t current = cur_cpu();
-        int logical;
+	return left > ~(uint64)0 - right ? ~(uint64)0 : left + right;
+}
 
-        if(current->idle) {
-                current->idle = 0;
-                return -1;
-        }
-        for(logical = 0; logical < cpu_count(); logical++) {
-                if(&cpus[logical] == current ||
-                   !cpus[logical].online || !cpus[logical].idle)
-                        continue;
-                cpus[logical].idle = 0;
-                return logical;
-        }
-        return -1;
+static uint64 scale_runtime(uint64 runtime, uint32 weight)
+{
+	return runtime / weight * NICE_0_LOAD +
+	       runtime % weight * NICE_0_LOAD / weight;
+}
+
+static uint64 entity_vruntime_now(thread_t thread, uint64 now)
+{
+	uint64 runtime = thread->sched.vruntime;
+
+	if (thread->state == THREAD_RUNNING && thread->sched.exec_start &&
+	    now > thread->sched.exec_start)
+		runtime = add_saturate(runtime,
+			scale_runtime(now - thread->sched.exec_start,
+				      thread->sched.weight));
+	return runtime;
+}
+
+static void account_runtime(thread_t thread, uint64 now)
+{
+	uint64 delta;
+
+	if (!thread->sched.exec_start || now <= thread->sched.exec_start) {
+		thread->sched.exec_start = now;
+		return;
+	}
+	delta = now - thread->sched.exec_start;
+	thread->sched.sum_exec_runtime =
+		add_saturate(thread->sched.sum_exec_runtime, delta);
+	thread->sched.vruntime = add_saturate(thread->sched.vruntime,
+		scale_runtime(delta, thread->sched.weight));
+	thread->sched.exec_start = now;
+}
+
+static int entity_before(thread_t left, thread_t right)
+{
+	if (left->sched.vruntime != right->sched.vruntime)
+		return left->sched.vruntime < right->sched.vruntime;
+	if (left->tid != right->tid)
+		return left->tid < right->tid;
+	return left < right;
+}
+
+static void enqueue_entity_locked(thread_t thread)
+{
+	struct rb_node **link = &runqueue.timeline.node;
+	struct rb_node *parent = 0;
+
+	while (*link) {
+		thread_t queued;
+
+		parent = *link;
+		queued = rb_entry(parent, struct thread, sched.run_node);
+		if (entity_before(thread, queued))
+			link = &parent->left;
+		else
+			link = &parent->right;
+	}
+	rb_link_node(&thread->sched.run_node, parent, link);
+	rb_insert_color(&thread->sched.run_node, &runqueue.timeline);
+	thread->sched.on_runqueue = 1;
+	runqueue.count++;
+	runqueue.total_weight += thread->sched.weight;
+}
+
+static void dequeue_entity_locked(thread_t thread)
+{
+	if (!thread->sched.on_runqueue || !runqueue.count ||
+	    runqueue.total_weight < thread->sched.weight)
+		PANIC("invalid CFS dequeue");
+	rb_erase(&thread->sched.run_node, &runqueue.timeline);
+	thread->sched.on_runqueue = 0;
+	runqueue.count--;
+	runqueue.total_weight -= thread->sched.weight;
+}
+
+static void place_entity_locked(thread_t thread)
+{
+	uint64 floor = runqueue.min_vruntime;
+
+	if (floor > SCHED_WAKEUP_GRANULARITY_NS)
+		floor -= SCHED_WAKEUP_GRANULARITY_NS;
+	else
+		floor = 0;
+	if (!thread->sched.initialized) {
+		thread->sched.vruntime = runqueue.min_vruntime;
+		thread->sched.initialized = 1;
+	} else if (thread->sched.vruntime < floor) {
+		thread->sched.vruntime = floor;
+	}
+}
+
+static void update_min_vruntime_locked(thread_t selected, uint64 now)
+{
+	struct rb_node *node = rb_first(&runqueue.timeline);
+	uint64 minimum = ~(uint64)0;
+	int logical;
+
+	if (selected)
+		minimum = selected->sched.vruntime;
+	if (node) {
+		thread_t queued = rb_entry(node, struct thread,
+					    sched.run_node);
+
+		if (queued->sched.vruntime < minimum)
+			minimum = queued->sched.vruntime;
+	}
+	for (logical = 0; logical < cpu_count(); logical++) {
+		thread_t current = cpus[logical].current;
+		thread_t pending = cpus[logical].selected;
+		uint64 vruntime;
+
+		if (current && current != selected &&
+		    current->state == THREAD_RUNNING) {
+			vruntime = entity_vruntime_now(current, now);
+			if (vruntime < minimum)
+				minimum = vruntime;
+		}
+		if (pending && pending != selected &&
+		    pending->sched.vruntime < minimum)
+			minimum = pending->sched.vruntime;
+	}
+	if (minimum != ~(uint64)0 && minimum > runqueue.min_vruntime)
+		runqueue.min_vruntime = minimum;
+}
+
+static int claim_idle_cpu_locked(void)
+{
+	cpu_t current = cur_cpu();
+	int logical;
+
+	if (current->idle) {
+		current->idle = 0;
+		return -1;
+	}
+	for (logical = 0; logical < cpu_count(); logical++) {
+		if (&cpus[logical] == current || !cpus[logical].online ||
+		    !cpus[logical].idle)
+			continue;
+		cpus[logical].idle = 0;
+		return logical;
+	}
+	return -1;
+}
+
+static int select_preempt_cpu_locked(thread_t waking, uint64 now)
+{
+	uint64 wake_vruntime = waking->sched.vruntime;
+	uint64 greatest = wake_vruntime;
+	int logical, target = -1;
+
+	for (logical = 0; logical < cpu_count(); logical++) {
+		thread_t current = cpus[logical].current;
+		uint64 current_vruntime;
+
+		if (!cpus[logical].online || !current ||
+		    current->state != THREAD_RUNNING)
+			continue;
+		current_vruntime = entity_vruntime_now(current, now);
+		if (current_vruntime <=
+		    add_saturate(wake_vruntime,
+				 SCHED_WAKEUP_GRANULARITY_NS) ||
+		    (target >= 0 && current_vruntime <= greatest))
+			continue;
+		greatest = current_vruntime;
+		target = logical;
+	}
+	if (target >= 0)
+		__atomic_store_n(&cpus[target].need_resched, 1,
+				 __ATOMIC_RELEASE);
+	return target;
+}
+
+static void wake_cpu(int target)
+{
+	if (target < 0 || target == cpuid())
+		return;
+	if (sbi_send_ipi(cpu_hart_id(target)))
+		PANIC("SBI send IPI failed");
 }
 
 static void scheduler_enqueue(thread_t thread, int wake_idle)
 {
-        int target = -1;
+	thread_state_t previous;
+	uint64 now = ktime_get_ns();
+	int target = -1;
 
-        if(!spinlock_holding(&thread->lock))
-                PANIC("runnable lock");
+	if (!spinlock_holding(&thread->lock))
+		PANIC("runnable lock");
+	previous = thread->state;
 
-        spinlock_acquire(&runqueue.lock);
-        if(thread->on_runqueue ||
-           (thread->state != THREAD_ALLOCATED &&
-            thread->state != THREAD_RUNNING &&
-            thread->state != THREAD_SLEEPING))
-                PANIC("invalid runnable thread");
-        thread->state = THREAD_RUNNABLE;
-        list_insert_before(&runqueue.runnable, &thread->run_node);
-        thread->on_runqueue = 1;
-        runqueue.count++;
-        if(wake_idle)
-                target = scheduler_claim_idle_cpu();
-        spinlock_release(&runqueue.lock);
-
-        if(target >= 0 && sbi_send_ipi(cpu_hart_id(target)))
-                PANIC("SBI send IPI failed");
+	spinlock_acquire(&runqueue.lock);
+	if (thread->sched.on_runqueue ||
+	    (previous != THREAD_ALLOCATED && previous != THREAD_RUNNING &&
+	     previous != THREAD_SLEEPING))
+		PANIC("invalid runnable thread");
+	if (previous == THREAD_RUNNING)
+		account_runtime(thread, now);
+	update_min_vruntime_locked(previous == THREAD_RUNNING ? thread : 0,
+				   now);
+	if (previous != THREAD_RUNNING)
+		place_entity_locked(thread);
+	thread->state = THREAD_RUNNABLE;
+	enqueue_entity_locked(thread);
+	if (wake_idle)
+		target = claim_idle_cpu_locked();
+	if (wake_idle && target < 0)
+		target = select_preempt_cpu_locked(thread, now);
+	spinlock_release(&runqueue.lock);
+	wake_cpu(target);
 }
 
-/* The caller must hold thread->lock. */
 void scheduler_make_runnable(thread_t thread)
 {
-        scheduler_enqueue(thread, 1);
+	scheduler_enqueue(thread, 1);
+}
+
+static uint64 calculate_slice_locked(thread_t selected)
+{
+	uint64 total_weight = runqueue.total_weight + selected->sched.weight;
+	uint32 runnable = runqueue.count + 1;
+	uint64 period, slice;
+	int logical;
+
+	for (logical = 0; logical < cpu_count(); logical++) {
+		thread_t current = cpus[logical].current;
+		thread_t pending = cpus[logical].selected;
+
+		if (current && current != selected &&
+		    current->state == THREAD_RUNNING) {
+			runnable++;
+			total_weight += current->sched.weight;
+		}
+		if (pending && pending != selected) {
+			runnable++;
+			total_weight += pending->sched.weight;
+		}
+	}
+	period = runnable * SCHED_MIN_GRANULARITY_NS;
+	if (period < SCHED_TARGET_LATENCY_NS)
+		period = SCHED_TARGET_LATENCY_NS;
+	slice = period / total_weight * selected->sched.weight +
+		period % total_weight * selected->sched.weight / total_weight;
+	return slice < SCHED_MIN_SLICE_NS ? SCHED_MIN_SLICE_NS : slice;
+}
+
+void scheduler_inherit(thread_t child, thread_t parent)
+{
+	uint64 now;
+
+	if (!child || !parent || !spinlock_holding(&child->lock) ||
+	    child->state != THREAD_ALLOCATED || child->sched.on_runqueue)
+		PANIC("invalid scheduler inheritance");
+	now = ktime_get_ns();
+	spinlock_acquire(&runqueue.lock);
+	child->sched.nice = parent->sched.nice;
+	child->sched.weight = parent->sched.weight;
+	child->sched.vruntime = entity_vruntime_now(parent, now);
+	child->sched.initialized = parent->sched.initialized;
+	spinlock_release(&runqueue.lock);
+}
+
+int scheduler_set_nice(thread_t thread, int nice)
+{
+	int logical, queued, running, target = -1;
+
+	if (!thread || nice < -20 || nice > 19)
+		return -1;
+	spinlock_acquire(&thread->lock);
+	running = thread->state == THREAD_RUNNING;
+	spinlock_acquire(&runqueue.lock);
+	if (running)
+		account_runtime(thread, ktime_get_ns());
+	queued = thread->sched.on_runqueue;
+	if (queued)
+		dequeue_entity_locked(thread);
+	thread->sched.nice = nice;
+	thread->sched.weight = nice_weights[nice + 20];
+	if (queued)
+		enqueue_entity_locked(thread);
+	if (running) {
+		for (logical = 0; logical < cpu_count(); logical++) {
+			if (cpus[logical].current != thread)
+				continue;
+			__atomic_store_n(&cpus[logical].need_resched, 1,
+					 __ATOMIC_RELEASE);
+			target = logical;
+			break;
+		}
+	}
+	spinlock_release(&runqueue.lock);
+	spinlock_release(&thread->lock);
+	wake_cpu(target);
+	return 0;
+}
+
+int scheduler_get_nice(thread_t thread)
+{
+	int nice;
+
+	if (!thread)
+		return 0;
+	spinlock_acquire(&thread->lock);
+	nice = thread->sched.nice;
+	spinlock_release(&thread->lock);
+	return nice;
 }
 
 static thread_t scheduler_next(cpu_t cpu)
 {
-        thread_t thread = 0;
-        list_t node;
+	struct rb_node *node;
+	thread_t thread = 0;
+	uint64 now = ktime_get_ns();
 
-        if(intr_status())
-                PANIC("scheduler interrupts enabled");
-        spinlock_acquire(&runqueue.lock);
-        cpu->idle = 0;
-        if(runqueue.count) {
-                node = runqueue.runnable.next;
-                if(node == &runqueue.runnable)
-                        PANIC("empty runqueue");
-                thread = list_entry(node, struct thread, run_node);
-                if(!thread->on_runqueue)
-                        PANIC("unqueued thread");
-                list_remove(node);
-                thread->on_runqueue = 0;
-                runqueue.count--;
-        } else if(runqueue.runnable.next != &runqueue.runnable) {
-                PANIC("runqueue count");
-        } else {
-                cpu->idle = 1;
-        }
-        spinlock_release(&runqueue.lock);
-        return thread;
+	if (intr_status())
+		PANIC("scheduler interrupts enabled");
+	spinlock_acquire(&runqueue.lock);
+	if (cpu->current || cpu->selected)
+		PANIC("busy scheduler CPU");
+	cpu->idle = 0;
+	node = rb_first(&runqueue.timeline);
+	if (node) {
+		thread = rb_entry(node, struct thread, sched.run_node);
+		dequeue_entity_locked(thread);
+		update_min_vruntime_locked(thread, now);
+		thread->sched.slice_ns = calculate_slice_locked(thread);
+		cpu->selected = thread;
+	} else if (runqueue.count || runqueue.total_weight) {
+		PANIC("CFS runqueue count");
+	} else {
+		cpu->idle = 1;
+	}
+	spinlock_release(&runqueue.lock);
+	return thread;
 }
 
 void scheduler(void)
 {
-        volatile cpu_t cpu = cur_cpu();
-        thread_t t;
+	volatile cpu_t cpu = cur_cpu();
+	thread_t next;
 
-        cpu->current = 0;
-        cpu->idle = 0;
+	cpu->current = 0;
+	cpu->selected = 0;
+	cpu->idle = 0;
+	for (;;) {
+		/*
+		 * Keep global interrupts disabled through WFI. An IPI arriving
+		 * after the empty check remains pending and makes WFI return.
+		 */
+		intr_off();
+		next = scheduler_next(cpu);
+		if (!next) {
+			wait_for_interrupt();
+			intr_on();
+			continue;
+		}
+		intr_on();
 
-        for(;;) {
-                /*
-                 * Keep global interrupts disabled through WFI. An IPI that
-                 * arrives after the empty check then remains pending and
-                 * makes WFI return instead of being consumed too early.
-                 */
-                intr_off();
-                t = scheduler_next(cpu);
-                if(!t) {
-                        wait_for_interrupt();
-                        intr_on();
-                        continue;
-                }
-                intr_on();
-
-                spinlock_acquire(&t->lock);
-                if(t->state != THREAD_RUNNABLE || t->on_runqueue ||
-		   (!t->home && !t->kernel_thread))
-                        PANIC("invalid scheduled thread");
-                t->state = THREAD_RUNNING;
-		if (t->home)
-			t->home->tinfo->addr = TRAPFRAME(t->id_p);
-                cpu->current = t;
-		cpu->need_resched = 0;
-                switchto(&cpu->context, &t->context);
-                cpu->current = 0;
-		if (t->state == THREAD_EXITED && t->kernel_thread)
-			kernel_thread_reap(t);
-                spinlock_release(&t->lock);
-        } 
+		spinlock_acquire(&next->lock);
+		spinlock_acquire(&runqueue.lock);
+		if (next->state != THREAD_RUNNABLE ||
+		    next->sched.on_runqueue ||
+		    (!next->home && !next->kernel_thread) ||
+		    cpu->selected != next || cpu->current)
+			PANIC("invalid scheduled thread");
+		next->state = THREAD_RUNNING;
+		next->sched.exec_start = ktime_get_ns();
+		cpu->selected = 0;
+		__atomic_store_n(&cpu->need_resched, 0, __ATOMIC_RELEASE);
+		cpu->current = next;
+		spinlock_release(&runqueue.lock);
+		if (next->home)
+			next->home->tinfo->addr = TRAPFRAME(next->id_p);
+		switchto(&cpu->context, &next->context);
+		spinlock_acquire(&runqueue.lock);
+		if (cpu->current != next || cpu->selected)
+			PANIC("invalid current thread");
+		cpu->current = 0;
+		spinlock_release(&runqueue.lock);
+		if (next->state == THREAD_EXITED && next->kernel_thread)
+			kernel_thread_reap(next);
+		spinlock_release(&next->lock);
+	}
 }
 
-/* Change the context to kernel scheduler */
 void sched(void)
 {
-        cpu_t cpu = cur_cpu();
-        thread_t current = cpu->current;
-        uint8 before_lock;
+	cpu_t cpu = cur_cpu();
+	thread_t current = cpu->current;
+	uint8 before_lock;
 
-        if(!current || !spinlock_holding(&current->lock)) {
-                PANIC("sched holding");
-        }
+	if (!current || !spinlock_holding(&current->lock))
+		PANIC("sched holding");
+	if (intr_status())
+		PANIC("sched intr open");
+	if (cpu->lock_nest_depth != 1) {
+		printf("%d->", cpu->lock_nest_depth);
+		PANIC("sched lock_nest_depth");
+	}
+	if (current->state == THREAD_RUNNING)
+		PANIC("sched running");
 
-        if(intr_status()) {
-                PANIC("sched intr open");
-        }
-
-        if(cpu->lock_nest_depth != 1) {
-                printf("%d->", cpu->lock_nest_depth);
-                PANIC("sched lock_nest_depth");
-        }
-
-        if(current->state == THREAD_RUNNING) {
-                PANIC("sched running");
-        }
-
-
-        /* Save the value of lock */
-        before_lock = cpu->before_lock;
-        /* Change the context to  kernel scheduler */
-        switchto(&current->context, &cpu->context);
+	before_lock = cpu->before_lock;
+	switchto(&current->context, &cpu->context);
 	/* A resumed thread may have migrated to another CPU. */
 	cur_cpu()->before_lock = before_lock;
 }
 
 void yield(void)
 {
-        thread_t current = cur_thread();
+	thread_t current = cur_thread();
 
-        spinlock_acquire(&current->lock);
-        scheduler_enqueue(current, 0);
-        sched();
-        spinlock_release(&current->lock);
+	spinlock_acquire(&current->lock);
+	scheduler_enqueue(current, 0);
+	sched();
+	spinlock_release(&current->lock);
 }
+
+void scheduler_block_current(void)
+{
+	thread_t current = cur_thread();
+
+	if (!current || !spinlock_holding(&current->lock) ||
+	    current->state != THREAD_RUNNING)
+		PANIC("block non-running thread");
+	spinlock_acquire(&runqueue.lock);
+	account_runtime(current, ktime_get_ns());
+	update_min_vruntime_locked(current, current->sched.exec_start);
+	current->state = THREAD_SLEEPING;
+	spinlock_release(&runqueue.lock);
+}
+
 void scheduler_exit_locked(void)
 {
 	thread_t current = cur_thread();
@@ -219,7 +512,11 @@ void scheduler_exit_locked(void)
 	if (!current || !spinlock_holding(&current->lock) ||
 	    current->state != THREAD_RUNNING)
 		PANIC("exit non-running thread");
+	spinlock_acquire(&runqueue.lock);
+	account_runtime(current, ktime_get_ns());
+	update_min_vruntime_locked(current, current->sched.exec_start);
 	current->state = THREAD_EXITED;
+	spinlock_release(&runqueue.lock);
 	sched();
 	PANIC("scheduled exited thread");
 }
@@ -234,31 +531,51 @@ void scheduler_exit(void)
 	scheduler_exit_locked();
 }
 
-void scheduler_block_current(void)
-{
-	thread_t current = cur_thread();
-
-	if (!current || !spinlock_holding(&current->lock) ||
-	    current->state != THREAD_RUNNING)
-		PANIC("block non-running thread");
-	current->state = THREAD_SLEEPING;
-}
-
 void scheduler_request_resched(void)
 {
 	cpu_t cpu = cur_cpu();
 
 	if (cpu->current)
-		cpu->need_resched = 1;
+		__atomic_store_n(&cpu->need_resched, 1, __ATOMIC_RELEASE);
+}
+
+void scheduler_tick(void)
+{
+	cpu_t cpu = cur_cpu();
+	thread_t current = cpu->current;
+	struct rb_node *node;
+	uint64 now, elapsed, current_vruntime;
+	int resched = 0;
+
+	if (!current || current->state != THREAD_RUNNING)
+		return;
+	now = ktime_get_ns();
+	elapsed = now > current->sched.exec_start ?
+		now - current->sched.exec_start : 0;
+	spinlock_acquire(&runqueue.lock);
+	node = rb_first(&runqueue.timeline);
+	if (node) {
+		thread_t leftmost;
+
+		leftmost = rb_entry(node, struct thread, sched.run_node);
+		current_vruntime = entity_vruntime_now(current, now);
+		if (elapsed >= current->sched.slice_ns ||
+		    current_vruntime > add_saturate(
+			leftmost->sched.vruntime,
+			SCHED_WAKEUP_GRANULARITY_NS))
+			resched = 1;
+	}
+	spinlock_release(&runqueue.lock);
+	if (resched)
+		__atomic_store_n(&cpu->need_resched, 1, __ATOMIC_RELEASE);
 }
 
 int scheduler_should_resched(void)
 {
-        cpu_t cpu = cur_cpu();
+	cpu_t cpu = cur_cpu();
 
-        if(!cpu->need_resched || !cpu->current ||
-           cpu->current->state != THREAD_RUNNING)
-                return 0;
-        cpu->need_resched = 0;
-        return 1;
+	if (!cpu->current || cpu->current->state != THREAD_RUNNING)
+		return 0;
+	return __atomic_exchange_n(&cpu->need_resched, 0,
+				   __ATOMIC_ACQ_REL);
 }

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -7,6 +7,7 @@
 #include <riscv.h>
 #include <sbi.h>
 #include <scheduler.h>
+#include <timer.h>
 
 #define NICE_0_LOAD 1024U
 #define SCHED_TARGET_LATENCY_NS 48000000ULL
@@ -425,10 +426,12 @@ void scheduler(void)
 		intr_off();
 		next = scheduler_next(cpu);
 		if (!next) {
+			timer_set_idle();
 			wait_for_interrupt();
 			intr_on();
 			continue;
 		}
+		timer_set_active();
 		intr_on();
 
 		spinlock_acquire(&next->lock);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -92,6 +92,8 @@ extern uint64 sys_linux_clone(void);
 extern uint64 sys_linux_clock_gettime(void);
 extern uint64 sys_linux_rt_sigaction(void);
 extern uint64 sys_linux_rt_sigprocmask(void);
+extern uint64 sys_linux_setpriority(void);
+extern uint64 sys_linux_getpriority(void);
 extern uint64 sys_linux_symlinkat(void);
 extern uint64 sys_linux_sync(void);
 extern uint64 sys_linux_umask(void);
@@ -155,6 +157,8 @@ static syscall_t linux_syscalls[LINUX_SYS_renameat2 + 1] = {
 	[LINUX_SYS_clock_gettime] = sys_linux_clock_gettime,
 	[LINUX_SYS_rt_sigaction] = sys_linux_rt_sigaction,
 	[LINUX_SYS_rt_sigprocmask] = sys_linux_rt_sigprocmask,
+	[LINUX_SYS_setpriority] = sys_linux_setpriority,
+	[LINUX_SYS_getpriority] = sys_linux_getpriority,
 	[LINUX_SYS_umask] = sys_linux_umask,
 	[LINUX_SYS_prctl] = sys_linux_prctl,
 	[LINUX_SYS_getpid] = sys_linux_getpid,

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -196,6 +196,42 @@ uint64 sys_linux_gettid(void)
 	return cur_thread()->tid;
 }
 
+uint64 sys_linux_setpriority(void)
+{
+	process_t process = cur_proc();
+	int which, who, nice;
+
+	argint(0, &which);
+	argint(1, &who);
+	argint(2, &nice);
+	if (which != LINUX_PRIO_PROCESS)
+		return -LINUX_EINVAL;
+	if (!who)
+		who = process->pid;
+	if (nice < -20)
+		nice = -20;
+	if (nice > 19)
+		nice = 19;
+	return process_set_nice(who, nice) ? -LINUX_ESRCH : 0;
+}
+
+uint64 sys_linux_getpriority(void)
+{
+	process_t process = cur_proc();
+	int nice, which, who;
+
+	argint(0, &which);
+	argint(1, &who);
+	if (which != LINUX_PRIO_PROCESS)
+		return -LINUX_EINVAL;
+	if (!who)
+		who = process->pid;
+	if (process_get_nice(who, &nice))
+		return -LINUX_ESRCH;
+	/* Linux returns 20 - nice so a negative nice value is not an error. */
+	return 20 - nice;
+}
+
 uint64 sys_linux_umask(void)
 {
 	process_t process = cur_proc();

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -22,6 +22,19 @@ struct thread thread[NTHREAD];
 static int next_tid = 1;
 static struct spinlock tid_lock;
 
+static void thread_sched_init(thread_t thread)
+{
+	rb_node_init(&thread->sched.run_node);
+	thread->sched.vruntime = 0;
+	thread->sched.exec_start = 0;
+	thread->sched.sum_exec_runtime = 0;
+	thread->sched.slice_ns = 0;
+	thread->sched.weight = 1024;
+	thread->sched.nice = 0;
+	thread->sched.initialized = 0;
+	thread->sched.on_runqueue = 0;
+}
+
 static void kernel_thread_entry(void)
 {
 	thread_t current = cur_thread();
@@ -69,8 +82,7 @@ void thread_setup(void)
                 spinlock_init(&t->lock, "thread");
                 t->kstack = KSTACK((int)(t - thread));;
                 t->state = THREAD_UNUSED;
-                t->on_runqueue = 0;
-                list_init(&t->run_node);
+		thread_sched_init(t);
                 t->waiting_on = 0;
                 t->on_waitqueue = 0;
                 list_init(&t->wait_node);
@@ -104,8 +116,7 @@ found:
 
         t->state = THREAD_ALLOCATED;
 	t->lwip_errno = 0;
-        t->on_runqueue = 0;
-        list_init(&t->run_node);
+	thread_sched_init(t);
         t->waiting_on = 0;
         t->on_waitqueue = 0;
         list_init(&t->wait_node);
@@ -166,8 +177,7 @@ found:
 	t->kernel_argument = argument;
 	t->kernel_thread = 1;
 	t->lwip_errno = 0;
-	t->on_runqueue = 0;
-	list_init(&t->run_node);
+	thread_sched_init(t);
 	t->waiting_on = 0;
 	t->on_waitqueue = 0;
 	list_init(&t->wait_node);
@@ -185,7 +195,7 @@ found:
 void kernel_thread_reap(thread_t t)
 {
 	if (!t || !spinlock_holding(&t->lock) || !t->kernel_thread ||
-	    t->state != THREAD_EXITED || t->on_runqueue ||
+	    t->state != THREAD_EXITED || t->sched.on_runqueue ||
 	    t->on_waitqueue || t->on_timeout_queue)
 		PANIC("reap kernel thread");
 	t->state = THREAD_UNUSED;
@@ -194,7 +204,7 @@ void kernel_thread_reap(thread_t t)
 	t->kernel_function = 0;
 	t->kernel_argument = 0;
 	t->lwip_errno = 0;
-	list_init(&t->run_node);
+	thread_sched_init(t);
 	list_init(&t->wait_node);
 	list_init(&t->timeout_node);
 	safe_strncpy(t->name, "thread", sizeof(t->name));
@@ -207,7 +217,7 @@ void thread_free(thread_t t)
 
         p = t->home;
 
-        if(t->on_runqueue)
+	if (t->sched.on_runqueue)
                 PANIC("thread_free runnable");
         if(t->on_waitqueue || t->waiting_on)
                 PANIC("thread_free waiting");
@@ -227,7 +237,7 @@ void thread_free(thread_t t)
                 pfree(t->trapframe);
         t->trapframe = 0;
         t->home = 0;
-        list_init(&t->run_node);
+	thread_sched_init(t);
         list_init(&t->wait_node);
 	list_init(&t->timeout_node);
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,8 +22,18 @@ virtqueue:
 		-o $(TEST_OUTPUT)/virtqueue
 	$(TEST_OUTPUT)/virtqueue
 
+.PHONY: rbtree
+rbtree:
+	mkdir -p $(TEST_OUTPUT)
+	$(CC) -std=gnu17 -Wall -Wextra -Werror -fno-builtin \
+		-I $(TOPDIR)/kernel/include \
+		-I $(TOPDIR)/arch/riscv/include \
+		$(CURDIR)/rbtree.c $(TOPDIR)/kernel/rbtree.c \
+		-o $(TEST_OUTPUT)/rbtree
+	$(TEST_OUTPUT)/rbtree
+
 .PHONY: qemu
-qemu: virtqueue
+qemu: rbtree virtqueue
 	TEST_OUTPUT="$(TEST_OUTPUT)" JOBS="$(JOBS)" \
 		$(CURDIR)/scripts/run-qemu.sh
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,13 +9,15 @@ Run the Linux RISC-V UAPI compile-time checks with:
 make -C tests uapi
 ```
 
-Run the host VirtIO split-ring test with:
+Run the host red-black-tree and VirtIO split-ring tests with:
 
 ```bash
-make -C tests virtqueue
+make -C tests rbtree virtqueue
 ```
 
-It covers scatter/gather chains, descriptor exhaustion, completion
+The tree test performs 20,000 deterministic randomized insert and erase
+operations while checking ordering and red-black invariants. The virtqueue
+test covers scatter/gather chains, descriptor exhaustion, completion
 lengths, notification, and 16-bit ring wraparound.
 
 Run the complete QEMU test with:

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,16 +29,17 @@ make -C tests qemu
 The QEMU test downloads checksum-pinned musl 1.2.6 and BusyBox 1.38.0 source
 archives, builds both outside the kernel, and creates temporary ext4 and FAT32
 images under `output/tests`. It runs boot checks with one hart and 64 MiB, two
-harts and 192 MiB, and eight harts and 256 MiB. A four-hart, 128 MiB run waits
-for BusyBox ash, runs the full guest suite, syncs storage, and exits QEMU
-through its serial monitor.
+harts and 192 MiB, four harts and 128 MiB, and eight harts and 256 MiB. A
+second eight-hart, 256 MiB run waits for BusyBox ash, runs the full guest
+suite, syncs storage, and exits QEMU through its serial monitor.
 
 Each boot requires one SBI BASE report and exactly one online and timer marker
 per logical CPU. A static check rejects machine-mode CSR operations, direct
 CLINT access, `mret`, `-bios none`, and a kernel entry other than
 `0x80200000`.
 
-The full run attaches the network device before two VirtIO block devices.
+The full eight-hart run attaches the network device before two VirtIO block
+devices.
 This verifies that transport enumeration cannot change root or data-disk
 selection. A host fixture behind QEMU user networking provides deterministic
 UDP, TCP, reverse-TCP, bulk-transfer, and HTTP replies.
@@ -47,10 +48,11 @@ The guest selftest covers:
 
 - network device registration, packet ownership, and queue state;
 - repeated fork, exec, exit, and wait cycles;
-- FIFO scheduler progress with 24 runnable processes, timer preemption, and
-  more runnable work than CPUs;
+- CFS runqueue progress with 24 runnable processes, timer preemption,
+  weighted nice values, and more runnable work than CPUs;
 - concurrent CPU, allocator, ext4, VirtIO completion, sleeplock, and process
   wait activity;
+- concurrent CFS nice classes, ext4, tmpfs, FAT, and four TCP bulk clients;
 - multiple TTY sleepers and repeated wake-all/requeue behavior;
 - devfs character devices and device numbers;
 - `/dev/ttyS0` metadata, `/dev/tty` error semantics, and terminal ioctls;
@@ -66,10 +68,10 @@ The guest selftest covers:
 - BusyBox `nc` and `wget`, including a 32 KiB transfer across packet,
   socket, pbuf, and virtqueue buffer boundaries.
 
-The one-, two-, and eight-hart smoke boots omit the NIC and exercise UDP
-loopback. A separate two-hart boot places an unsupported VirtIO device before
-the root disk and uses a socket-backed NIC without DHCP; it must still reach
-the shell and pass loopback.
+The one-, two-, four-, and eight-hart smoke boots omit the NIC and exercise
+UDP loopback. A separate two-hart boot places an unsupported VirtIO device
+before the root disk and uses a socket-backed NIC without DHCP; it must still
+reach the shell and pass loopback.
 
 After QEMU exits, the host harness recovers and checks ext4 with `e2fsck`,
 checks FAT32 with `fsck.fat`, reads persistent values from both images, and

--- a/tests/linux_uapi.c
+++ b/tests/linux_uapi.c
@@ -34,6 +34,10 @@ _Static_assert(LINUX_SYS_fsync == __NR_fsync, "fsync number");
 _Static_assert(LINUX_SYS_umask == __NR_umask, "umask number");
 _Static_assert(LINUX_SYS_rt_sigaction == __NR_rt_sigaction,
 	       "rt_sigaction number");
+_Static_assert(LINUX_SYS_setpriority == __NR_setpriority,
+	       "setpriority number");
+_Static_assert(LINUX_SYS_getpriority == __NR_getpriority,
+	       "getpriority number");
 _Static_assert(LINUX_SYS_clock_gettime == __NR_clock_gettime,
 	       "clock_gettime number");
 _Static_assert(LINUX_SYS_clone == __NR_clone, "clone number");

--- a/tests/pressure_runtime.c
+++ b/tests/pressure_runtime.c
@@ -1,0 +1,201 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define FIXTURE_ADDRESS "10.0.2.2"
+#define TCP_BULK_PORT 18083
+#define CPU_WORKERS 8
+#define IO_WORKERS 6
+#define NET_WORKERS 4
+#define WORKERS (CPU_WORKERS + IO_WORKERS + NET_WORKERS)
+#define CPU_ITERATIONS 6000000
+#define BLOCK_SIZE 4096
+#define IO_BLOCKS 24
+#define IO_ROUNDS 3
+#define NET_BLOCKS 8
+#define NET_ROUNDS 6
+
+static unsigned char buffer[BLOCK_SIZE];
+
+static int fail(const char *operation, int code)
+{
+	printf("PRESSURE_RUNTIME_FAIL %s:%d errno=%d\n",
+	       operation, code, errno);
+	return 1;
+}
+
+static int write_all(int fd, const void *data, size_t length)
+{
+	const unsigned char *bytes = data;
+	size_t offset = 0;
+
+	while (offset < length) {
+		ssize_t written = write(fd, bytes + offset, length - offset);
+
+		if (written <= 0)
+			return -1;
+		offset += written;
+	}
+	return 0;
+}
+
+static int read_all(int fd, void *data, size_t length)
+{
+	unsigned char *bytes = data;
+	size_t offset = 0;
+
+	while (offset < length) {
+		ssize_t received = read(fd, bytes + offset, length - offset);
+
+		if (received <= 0)
+			return -1;
+		offset += received;
+	}
+	return 0;
+}
+
+static void cpu_worker(int index)
+{
+	volatile uint64_t value = index + 1;
+	int iteration;
+
+	if ((index & 1) && setpriority(PRIO_PROCESS, 0, 5) < 0)
+		_exit(10);
+	for (iteration = 0; iteration < CPU_ITERATIONS; iteration++)
+		value = value * 6364136223846793005ULL + 1;
+	_exit(value == UINT64_MAX ? 11 : 0);
+}
+
+static void fill_block(int worker, int round, int block)
+{
+	int index;
+
+	for (index = 0; index < BLOCK_SIZE; index++)
+		buffer[index] = worker * 29 + round * 17 + block * 7 + index;
+}
+
+static int verify_block(int worker, int round, int block)
+{
+	int index;
+
+	for (index = 0; index < BLOCK_SIZE; index++) {
+		unsigned char expected;
+
+		expected = worker * 29 + round * 17 + block * 7 + index;
+		if (buffer[index] != expected)
+			return -1;
+	}
+	return 0;
+}
+
+static void io_worker(int index)
+{
+	static const char *directories[] = {
+		"/pressure-ext", "/pressure-ext",
+		"/tmp/pressure-tmp", "/tmp/pressure-tmp",
+		"/mnt/fat/pressure-fat", "/mnt/fat/pressure-fat",
+	};
+	char path[64];
+	int block, fd, round;
+
+	snprintf(path, sizeof(path), "%s-%d", directories[index], index);
+	for (round = 0; round < IO_ROUNDS; round++) {
+		fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+		if (fd < 0)
+			_exit(20);
+		for (block = 0; block < IO_BLOCKS; block++) {
+			fill_block(index, round, block);
+			if (write_all(fd, buffer, sizeof(buffer)))
+				_exit(21);
+		}
+		if (fsync(fd) || lseek(fd, 0, SEEK_SET) != 0)
+			_exit(22);
+		for (block = 0; block < IO_BLOCKS; block++) {
+			if (read_all(fd, buffer, sizeof(buffer)) ||
+			    verify_block(index, round, block))
+				_exit(23);
+		}
+		if (close(fd))
+			_exit(24);
+	}
+	_exit(0);
+}
+
+static void fill_network_block(int worker, int round, int block)
+{
+	int index;
+
+	for (index = 0; index < BLOCK_SIZE; index++)
+		buffer[index] = worker * 31 + round * 13 + block * 11 + index;
+}
+
+static void network_worker(int index)
+{
+	struct sockaddr_in host = {
+		.sin_family = AF_INET,
+		.sin_port = htons(TCP_BULK_PORT),
+	};
+	unsigned char expected[BLOCK_SIZE];
+	uint32_t network_length = htonl(NET_BLOCKS * BLOCK_SIZE);
+	int block, fd, round;
+
+	if (inet_pton(AF_INET, FIXTURE_ADDRESS, &host.sin_addr) != 1)
+		_exit(30);
+	for (round = 0; round < NET_ROUNDS; round++) {
+		fd = socket(AF_INET, SOCK_STREAM, 0);
+		if (fd < 0 ||
+		    connect(fd, (const struct sockaddr *)&host,
+			    sizeof(host)) < 0 ||
+		    write_all(fd, &network_length, sizeof(network_length)))
+			_exit(31);
+		for (block = 0; block < NET_BLOCKS; block++) {
+			fill_network_block(index, round, block);
+			if (write_all(fd, buffer, sizeof(buffer)))
+				_exit(32);
+		}
+		for (block = 0; block < NET_BLOCKS; block++) {
+			fill_network_block(index, round, block);
+			memcpy(expected, buffer, sizeof(expected));
+			if (read_all(fd, buffer, sizeof(buffer)) ||
+			    memcmp(buffer, expected, sizeof(buffer)))
+				_exit(33);
+		}
+		if (close(fd))
+			_exit(34);
+	}
+	_exit(0);
+}
+
+int main(void)
+{
+	pid_t children[WORKERS];
+	int index, status;
+
+	for (index = 0; index < WORKERS; index++) {
+		children[index] = fork();
+		if (children[index] < 0)
+			return fail("fork", index);
+		if (!children[index]) {
+			if (index < CPU_WORKERS)
+				cpu_worker(index);
+			if (index < CPU_WORKERS + IO_WORKERS)
+				io_worker(index - CPU_WORKERS);
+			network_worker(index - CPU_WORKERS - IO_WORKERS);
+		}
+	}
+	for (index = 0; index < WORKERS; index++) {
+		status = -1;
+		if (waitpid(children[index], &status, 0) != children[index] ||
+		    !WIFEXITED(status) || WEXITSTATUS(status))
+			return fail("worker", index * 256 + status);
+	}
+	puts("PRESSURE_RUNTIME_OK");
+	return 0;
+}

--- a/tests/rbtree.c
+++ b/tests/rbtree.c
@@ -1,0 +1,127 @@
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <rbtree.h>
+
+#define NODE_COUNT 128
+#define OPERATION_COUNT 20000
+
+struct test_node {
+	struct rb_node node;
+	int key;
+	int linked;
+};
+
+static struct rb_root tree;
+static struct test_node nodes[NODE_COUNT];
+static unsigned int random_state = 1;
+
+static unsigned int next_random(void)
+{
+	random_state = random_state * 1103515245U + 12345U;
+	return random_state;
+}
+
+static void insert_node(struct test_node *entry)
+{
+	struct rb_node **link = &tree.node;
+	struct rb_node *parent = NULL;
+
+	while (*link) {
+		struct test_node *current;
+
+		parent = *link;
+		current = rb_entry(parent, struct test_node, node);
+		if (entry->key < current->key)
+			link = &parent->left;
+		else
+			link = &parent->right;
+	}
+	rb_link_node(&entry->node, parent, link);
+	rb_insert_color(&entry->node, &tree);
+	entry->linked = 1;
+}
+
+static int validate_subtree(struct rb_node *node, struct rb_node *parent,
+			    int minimum, int maximum)
+{
+	struct test_node *entry;
+	int left_height, right_height;
+
+	if (!node)
+		return 1;
+	entry = rb_entry(node, struct test_node, node);
+	if (node->parent != parent || entry->key <= minimum ||
+	    entry->key >= maximum)
+		return -1;
+	if (node->red && ((node->left && node->left->red) ||
+			 (node->right && node->right->red)))
+		return -1;
+	left_height = validate_subtree(node->left, node, minimum, entry->key);
+	right_height = validate_subtree(node->right, node, entry->key, maximum);
+	if (left_height < 0 || right_height < 0 ||
+	    left_height != right_height)
+		return -1;
+	return left_height + !node->red;
+}
+
+static int validate_tree(void)
+{
+	struct rb_node *node;
+	int previous = -1;
+	int count = 0;
+
+	if (tree.node && tree.node->red)
+		return -1;
+	if (validate_subtree(tree.node, NULL, -1, NODE_COUNT) < 0)
+		return -1;
+	for (node = rb_first(&tree); node; node = rb_next(node)) {
+		struct test_node *entry;
+
+		entry = rb_entry(node, struct test_node, node);
+		if (entry->key <= previous)
+			return -1;
+		previous = entry->key;
+		count++;
+	}
+	for (int index = 0; index < NODE_COUNT; index++)
+		count -= nodes[index].linked;
+	return count ? -1 : 0;
+}
+
+int main(void)
+{
+	int operation;
+
+	rb_root_init(&tree);
+	for (int index = 0; index < NODE_COUNT; index++) {
+		nodes[index].key = index;
+		rb_node_init(&nodes[index].node);
+	}
+	for (operation = 0; operation < OPERATION_COUNT; operation++) {
+		struct test_node *entry = &nodes[next_random() % NODE_COUNT];
+
+		if (entry->linked) {
+			rb_erase(&entry->node, &tree);
+			entry->linked = 0;
+		} else {
+			insert_node(entry);
+		}
+		if (validate_tree()) {
+			fprintf(stderr, "rbtree validation failed at operation %d\n",
+				operation);
+			return EXIT_FAILURE;
+		}
+	}
+	for (int index = 0; index < NODE_COUNT; index++) {
+		if (!nodes[index].linked)
+			continue;
+		rb_erase(&nodes[index].node, &tree);
+		nodes[index].linked = 0;
+	}
+	if (tree.node || validate_tree())
+		return EXIT_FAILURE;
+	puts("RBTREE_OK");
+	return EXIT_SUCCESS;
+}

--- a/tests/scheduler_runtime.c
+++ b/tests/scheduler_runtime.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -13,6 +14,7 @@
 #define RUNNABLE_SMOKE_CHILDREN 12
 #define MIXED_CHILDREN 16
 #define TTY_WAITERS 8
+#define FAIRNESS_ITERATIONS 30000000
 
 static int last_wait_status;
 
@@ -200,12 +202,61 @@ static int test_tty_wait(void)
 	return 0;
 }
 
+static void fairness_child(int nice_value, int exit_status)
+{
+	volatile uint64_t value = exit_status + 1;
+	int iteration;
+
+	if (setpriority(PRIO_PROCESS, 0, nice_value) < 0 ||
+	    getpriority(PRIO_PROCESS, 0) != nice_value)
+		_exit(125);
+	for (iteration = 0; iteration < FAIRNESS_ITERATIONS; iteration++)
+		value = value * 6364136223846793005ULL + 1;
+	_exit(value == UINT64_MAX ? 126 : exit_status);
+}
+
+static int test_fairness(void)
+{
+	pid_t low, normal, result;
+	int status;
+
+	low = fork();
+	if (low < 0)
+		return fail("fair-low-fork", 50);
+	if (!low)
+		fairness_child(10, 10);
+	if (setpriority(PRIO_PROCESS, low, 10) < 0 ||
+	    getpriority(PRIO_PROCESS, low) != 10)
+		return fail("fair-child-priority", 56);
+	errno = 0;
+	if (getpriority(PRIO_PROCESS, 0x7fffffff) != -1 || errno != ESRCH)
+		return fail("fair-missing-priority", 57);
+	normal = fork();
+	if (normal < 0)
+		return fail("fair-normal-fork", 51);
+	if (!normal)
+		fairness_child(0, 11);
+	if (wait_for_child(normal, 11))
+		return fail("fair-normal-wait", 52);
+	result = waitpid(low, &status, WNOHANG);
+	if (result < 0)
+		return fail("fair-low-poll", 53);
+	if (result == low)
+		return fail("fair-weight", 54);
+	if (wait_for_child(low, 10))
+		return fail("fair-low-wait", 55);
+	pass("SCHED_CFS_FAIR_OK\n");
+	return 0;
+}
+
 int main(int argc, char **argv)
 {
 	if (argc == 2 && !strcmp(argv[1], "exec-child"))
 		return 0;
 	if (argc == 2 && !strcmp(argv[1], "tty-wait"))
 		return test_tty_wait();
+	if (argc == 2 && !strcmp(argv[1], "fairness"))
+		return test_fairness();
 	if (argc == 2 && !strcmp(argv[1], "smoke")) {
 		if (test_exec(EXEC_SMOKE_ROUNDS) ||
 		    test_runqueue(RUNNABLE_SMOKE_CHILDREN))

--- a/tests/scripts/benchmark-scheduler.py
+++ b/tests/scripts/benchmark-scheduler.py
@@ -57,8 +57,12 @@ class Guest:
     def read_until(self, marker):
         deadline = time.monotonic() + self.timeout
         while marker not in self.buffer:
-            if b"[PANIC]" in self.buffer:
-                raise RuntimeError("kernel panic during scheduler benchmark")
+            panic = self.buffer.find(b"[PANIC]")
+            if panic >= 0 and b"\n" in self.buffer[panic:]:
+                tail = self.buffer[-4096:].decode(
+                    "utf-8", errors="replace")
+                raise RuntimeError(
+                    "kernel panic during scheduler benchmark:\n" + tail)
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(f"guest did not produce {marker!r}")
@@ -83,7 +87,9 @@ class Guest:
         output = self.read_until(b"# ")
         elapsed = (time.perf_counter_ns() - start) / 1_000_000
         if b"[PANIC]" in output:
-            raise RuntimeError("kernel panic during scheduler benchmark")
+            tail = output[-4096:].decode("utf-8", errors="replace")
+            raise RuntimeError(
+                "kernel panic during scheduler benchmark:\n" + tail)
         for error in (b"Bad address", b"not found", b"No such file"):
             if error in output:
                 raise RuntimeError(

--- a/tests/scripts/build-rootfs.sh
+++ b/tests/scripts/build-rootfs.sh
@@ -192,6 +192,12 @@ install -d \
 	"$tests_dir/network_runtime.c" \
 	-o "$staging/bin/network-runtime"
 
+"$musl_cc" \
+	-static -march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror \
+	"$tests_dir/pressure_runtime.c" \
+	-o "$staging/bin/pressure-runtime"
+
 if "${cross_compile}readelf" -l "$staging/bin/fs-runtime" |
 	grep -q INTERP; then
 	echo "guest selftest must be statically linked" >&2
@@ -213,6 +219,12 @@ fi
 if "${cross_compile}readelf" -l "$staging/bin/network-runtime" |
 	grep -q INTERP; then
 	echo "network selftest must be statically linked" >&2
+	exit 1
+fi
+
+if "${cross_compile}readelf" -l "$staging/bin/pressure-runtime" |
+	grep -q INTERP; then
+	echo "pressure selftest must be statically linked" >&2
 	exit 1
 fi
 

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -80,6 +80,29 @@ expect {
 	eof { abort_test "QEMU exited after network loopback test" }
 }
 
+if {$env(QEMU_CPUS) == 1} {
+	send -- "/bin/scheduler-runtime fairness\r"
+	expect {
+		-re {\r?\nSCHED_CFS_FAIR_OK} {}
+		-re {SCHED_RUNTIME_FAIL=[^\r\n]*} {
+			abort_test "CFS fairness test reported failure"
+		}
+		-re {\[PANIC\]} {
+			abort_test "kernel panic in CFS fairness test"
+		}
+		timeout { abort_test "CFS fairness test timeout" }
+		eof { abort_test "QEMU exited during CFS fairness test" }
+	}
+	expect {
+		-re {\r?\n# $} {}
+		-re {\[PANIC\]} {
+			abort_test "kernel panic after CFS fairness test"
+		}
+		timeout { abort_test "shell prompt timeout" }
+		eof { abort_test "QEMU exited after CFS fairness test" }
+	}
+}
+
 send -- "echo OPENSBI_BOOT_OK\r"
 expect {
 	-re {\r?\nOPENSBI_BOOT_OK} {}

--- a/tests/scripts/run-qemu.exp
+++ b/tests/scripts/run-qemu.exp
@@ -77,6 +77,18 @@ expect {
 }
 expect_prompt
 
+send -- "/bin/pressure-runtime\r"
+expect {
+	-re {\r?\nPRESSURE_RUNTIME_OK} {}
+	-re {PRESSURE_RUNTIME_FAIL[^\r\n]*} {
+		abort_test "mixed pressure test reported failure"
+	}
+	-re {\[PANIC\]} { abort_test "kernel panic in mixed pressure test" }
+	timeout { abort_test "mixed pressure test timeout" }
+	eof { abort_test "QEMU exited during mixed pressure test" }
+}
+expect_prompt
+
 send -- "/usr/bin/nc 10.0.2.2 18081\r"
 send -- "tcp-request\r"
 expect {

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -149,11 +149,18 @@ run_boot_smoke()
 		exit 1
 	fi
 	check_net_device_log "$clean" 0
+	if [ "$cpus" -eq 1 ] &&
+	   [ "$(awk '$0 == "SCHED_CFS_FAIR_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "CFS fairness marker is missing" >&2
+		exit 1
+	fi
 	check_boot_log "$clean" "$cpus"
 }
 
 run_boot_smoke 1 64M
 run_boot_smoke 2 192M
+run_boot_smoke 4 128M
 run_boot_smoke 8 256M
 
 export QEMU_CPUS=2
@@ -188,8 +195,8 @@ if ! grep -q '^NETWORK_FIXTURE_READY$' "$fixture_log"; then
 	exit 1
 fi
 
-export QEMU_CPUS=4
-export QEMU_MEMORY=128M
+export QEMU_CPUS=8
+export QEMU_MEMORY=256M
 export QEMU_LOG=$qemu_log
 expect "$script_dir/run-qemu.exp"
 tr -d '\r' < "$qemu_log" > "$clean_log"
@@ -206,6 +213,7 @@ for marker in \
 	SCHED_RUNTIME_OK \
 	SCHED_TTY_WAIT_OK \
 	NETWORK_RUNTIME_OK \
+	PRESSURE_RUNTIME_OK \
 	TTY_METADATA_OK \
 	TTY_NONBLOCK_OK \
 	TTY_CANONICAL_OK \
@@ -246,7 +254,7 @@ fi
 if grep -Eq \
 	-e '\[PANIC\]|Unhandled interrupt' \
 	-e 'FS_RUNTIME_FAIL=|NETWORK_RUNTIME_FAIL' \
-	-e 'SCHED_RUNTIME_FAIL=|TTY_RUNTIME_FAIL=' \
+	-e 'PRESSURE_RUNTIME_FAIL|SCHED_RUNTIME_FAIL=|TTY_RUNTIME_FAIL=' \
 	"$clean_log"; then
 	echo "QEMU log contains a guest failure" >&2
 	exit 1


### PR DESCRIPTION
Depends on #47.

The FIFO runqueue provides progress but cannot express proportional CPU
shares. Its coarse periodic tick also wakes otherwise idle SMP guests more
often than necessary.

Replace FIFO ordering with a CFS-style weighted virtual-runtime tree, expose
Linux process nice values, and use separate active and idle timer cadences.
The design retains a single global runqueue and documents that limitation.

CI adds a host red-black-tree invariant test, one-CPU nice-weight ordering, a
four-CPU smoke boot, and an eight-CPU mixed pressure run combining CPU work,
ext4, tmpfs, FAT, and four concurrent TCP clients. Network protocol coverage
remains owned by #47.
