### PR TITLE
riscv: allocate SMP state from firmware topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ CFLAGS += -ffreestanding -fno-builtin -fno-common -nostdlib -mno-relax
 CFLAGS += -nostdinc -isystem $(shell $(CC) -print-file-name=include)
 CFLAGS += -fno-stack-protector -fno-pie
 CFLAGS += -I.
+ifeq ($(STACK_OVERFLOW_TEST),1)
+CFLAGS += -DCONFIG_STACK_OVERFLOW_TEST
+endif
 
 LDFLAGS = -z max-page-size=4096
 export CFLAGS LDFLAGS

--- a/arch/riscv/boot/entry.S
+++ b/arch/riscv/boot/entry.S
@@ -1,5 +1,4 @@
 #include <boot.h>
-#include <kernel_config.h>
 
 .section .text
 .global _entry
@@ -13,16 +12,9 @@ _entry:
 	tail setup
 
 secondary_entry:
-	li t0, NCPU
-	bgeu a1, t0, .Lsecondary_park
-	la sp, secondary_stacks
-	slli t0, a1, 12
-	add sp, sp, t0
-	li t0, 4096
-	add sp, sp, t0
-	mv tp, a1
+	# The HSM opaque value points at this hart's scheduler stack.
+	mv t0, a1
+	ld tp, 0(t0)
+	li t1, PGSIZE
+	add sp, t0, t1
 	tail secondary_setup
-
-.Lsecondary_park:
-	wfi
-	j .Lsecondary_park

--- a/arch/riscv/boot/entry.S
+++ b/arch/riscv/boot/entry.S
@@ -12,9 +12,14 @@ _entry:
 	tail setup
 
 secondary_entry:
-	# The HSM opaque value points at this hart's scheduler stack.
+	# The HSM opaque value points at this hart's temporary boot stack.
 	mv t0, a1
 	ld tp, 0(t0)
 	li t1, PGSIZE
 	add sp, t0, t1
 	tail secondary_setup
+
+.global cpu_enter_stack
+cpu_enter_stack:
+	mv sp, a0
+	jr a1

--- a/arch/riscv/boot/entry.S
+++ b/arch/riscv/boot/entry.S
@@ -1,3 +1,4 @@
+#include <boot.h>
 #include <kernel_config.h>
 
 .section .text
@@ -7,7 +8,7 @@
 _entry:
 	# OpenSBI passes the boot hart ID in a0 and the DTB address in a1.
 	la sp, boot_stack
-	li t0, 4096
+	li t0, BOOT_STACK_SIZE
 	add sp, sp, t0
 	tail setup
 

--- a/arch/riscv/boot/setup.c
+++ b/arch/riscv/boot/setup.c
@@ -11,13 +11,11 @@
 #include <riscv.h>
 #include <boot.h>
 #include <cpu.h>
-#include <kernel_config.h>
 
 extern void main(void);
 
 /* OpenSBI starts only the boot hart before SBI HSM is used. */
 __attribute__((aligned(16))) int8 boot_stack[BOOT_STACK_SIZE];
-__attribute__((aligned(16))) int8 secondary_stacks[4096 * NCPU];
 uint64 boot_dtb_address;
 uint64 boot_hart_id;
 
@@ -35,12 +33,13 @@ void setup(uint64 hart_id, uint64 dtb_address)
 		;
 }
 
-void secondary_setup(uint64 hart_id, uint64 logical_id)
+void secondary_setup(uint64 hart_id, uint64 stack_address)
 {
+	uint64 logical_id = tp_r();
+
 	satp_w(0);
 	sfence_vma();
-	tp_w(logical_id);
-	cpu_secondary_validate(hart_id, logical_id);
+	cpu_secondary_validate(hart_id, logical_id, stack_address);
 	main();
 	for (;;)
 		;

--- a/arch/riscv/boot/setup.c
+++ b/arch/riscv/boot/setup.c
@@ -16,7 +16,7 @@
 extern void main(void);
 
 /* OpenSBI starts only the boot hart before SBI HSM is used. */
-__attribute__((aligned(16))) int8 boot_stack[4096];
+__attribute__((aligned(16))) int8 boot_stack[BOOT_STACK_SIZE];
 __attribute__((aligned(16))) int8 secondary_stacks[4096 * NCPU];
 uint64 boot_dtb_address;
 uint64 boot_hart_id;

--- a/arch/riscv/cpu.c
+++ b/arch/riscv/cpu.c
@@ -1,6 +1,5 @@
 #include <cpu.h>
 #include <debug.h>
-#include <kernel_config.h>
 #include <of.h>
 #include <palloc.h>
 #include <printf.h>
@@ -11,7 +10,6 @@
 
 #define CPU_START_TIMEOUT_SECONDS 5
 
-extern struct cpu cpus[NCPU];
 extern void secondary_entry(void);
 
 static int logical_cpu_count;
@@ -19,32 +17,45 @@ static int logical_cpu_count;
 void cpu_topology_init(uint64 boot_hart_id)
 {
 	struct device_node *node;
+	cpu_t *table;
 	uint64 hart_id;
-	int boot_count = 0, count, index, logical;
+	int boot_count = 0, count, index, logical, logical_count = 1;
 
 	count = of_cpu_count();
-	if (count < 1 || count > NCPU)
+	if (count < 1)
 		PANIC("unsupported CPU count");
-	logical_cpu_count = 1;
-	cpus[0].hart_id = boot_hart_id;
+	table = calloc(count, sizeof(*table));
+	if (!table)
+		PANIC("allocate CPU table");
+	table[0] = cpus[0];
+	for (logical = 1; logical < count; logical++) {
+		table[logical] = calloc(1, sizeof(*table[logical]));
+		if (!table[logical])
+			PANIC("allocate CPU state");
+	}
+	table[0]->hart_id = boot_hart_id;
 	for (index = 0; index < count; index++) {
 		if (of_cpu_get(index, &node, &hart_id) < 0)
 			PANIC("invalid CPU node");
 		if (hart_id == boot_hart_id) {
-			cpus[0].of_node = node;
+			table[0]->of_node = node;
 			boot_count++;
 			continue;
 		}
-		for (logical = 1; logical < logical_cpu_count; logical++) {
-			if (cpus[logical].hart_id == hart_id)
+		for (logical = 1; logical < logical_count; logical++) {
+			if (table[logical]->hart_id == hart_id)
 				PANIC("duplicate hart ID");
 		}
-		logical = logical_cpu_count++;
-		cpus[logical].hart_id = hart_id;
-		cpus[logical].of_node = node;
+		if (logical_count >= count)
+			PANIC("boot hart missing from DT");
+		logical = logical_count++;
+		table[logical]->hart_id = hart_id;
+		table[logical]->of_node = node;
 	}
-	if (boot_count != 1 || logical_cpu_count != count)
+	if (boot_count != 1 || logical_count != count)
 		PANIC("boot hart missing from DT");
+	cpus = table;
+	logical_cpu_count = count;
 }
 
 int cpu_count(void)
@@ -56,22 +67,22 @@ uint64 cpu_hart_id(int logical_id)
 {
 	if (logical_id < 0 || logical_id >= logical_cpu_count)
 		PANIC("invalid logical CPU");
-	return cpus[logical_id].hart_id;
+	return cpus[logical_id]->hart_id;
 }
 
 struct device_node *cpu_of_node(int logical_id)
 {
 	if (logical_id < 0 || logical_id >= logical_cpu_count)
 		return 0;
-	return cpus[logical_id].of_node;
+	return cpus[logical_id]->of_node;
 }
 
 void cpu_secondary_validate(uint64 hart_id, uint64 logical_id,
 			    uint64 stack_address)
 {
 	if (!logical_id || logical_id >= (uint64)logical_cpu_count ||
-	    cpus[logical_id].hart_id != hart_id ||
-	    cpus[logical_id].scheduler_stack != (void *)stack_address)
+	    cpus[logical_id]->hart_id != hart_id ||
+	    cpus[logical_id]->scheduler_stack != (void *)stack_address)
 		PANIC("invalid secondary hart handoff");
 }
 
@@ -99,10 +110,10 @@ void cpu_start_secondary_harts(void)
 			       cpu_hart_id(logical), (int)status);
 			PANIC("secondary hart is not stopped");
 		}
-		if (cpus[logical].scheduler_stack)
+		if (cpus[logical]->scheduler_stack)
 			PANIC("secondary hart stack already allocated");
 		stack = palloc();
-		cpus[logical].scheduler_stack = stack;
+		cpus[logical]->scheduler_stack = stack;
 		/* entry.S reads the logical CPU ID before using the stack. */
 		*(uint64 *)stack = logical;
 		__sync_synchronize();
@@ -110,7 +121,7 @@ void cpu_start_secondary_harts(void)
 		                       (uint64)secondary_entry,
 		                       (uint64)stack);
 		if (error) {
-			cpus[logical].scheduler_stack = 0;
+			cpus[logical]->scheduler_stack = 0;
 			pfree(stack);
 			cpu_start_failed(logical, error);
 		}
@@ -121,13 +132,14 @@ void cpu_mark_online(void)
 {
 	int logical = cpuid();
 
-	if (logical < 0 || logical >= logical_cpu_count || cpus[logical].online)
+	if (logical < 0 || logical >= logical_cpu_count ||
+	    cpus[logical]->online)
 		PANIC("duplicate CPU online");
 	__sync_synchronize();
-	cpus[logical].online = 1;
+	cpus[logical]->online = 1;
 	__sync_synchronize();
 	printf("CPU: logical=%d hart=%p online\n", logical,
-	       cpus[logical].hart_id);
+	       cpus[logical]->hart_id);
 }
 
 void cpu_wait_for_secondary_harts(void)
@@ -138,7 +150,7 @@ void cpu_wait_for_secondary_harts(void)
 
 	for (;;) {
 		for (logical = 1; logical < logical_cpu_count; logical++) {
-			if (!cpus[logical].online)
+			if (!cpus[logical]->online)
 				break;
 		}
 		if (logical == logical_cpu_count)

--- a/arch/riscv/cpu.c
+++ b/arch/riscv/cpu.c
@@ -2,6 +2,7 @@
 #include <debug.h>
 #include <kernel_config.h>
 #include <of.h>
+#include <palloc.h>
 #include <printf.h>
 #include <riscv.h>
 #include <sbi.h>
@@ -65,10 +66,12 @@ struct device_node *cpu_of_node(int logical_id)
 	return cpus[logical_id].of_node;
 }
 
-void cpu_secondary_validate(uint64 hart_id, uint64 logical_id)
+void cpu_secondary_validate(uint64 hart_id, uint64 logical_id,
+			    uint64 stack_address)
 {
 	if (!logical_id || logical_id >= (uint64)logical_cpu_count ||
-	    cpus[logical_id].hart_id != hart_id)
+	    cpus[logical_id].hart_id != hart_id ||
+	    cpus[logical_id].scheduler_stack != (void *)stack_address)
 		PANIC("invalid secondary hart handoff");
 }
 
@@ -86,6 +89,8 @@ void cpu_start_secondary_harts(void)
 	int logical;
 
 	for (logical = 1; logical < logical_cpu_count; logical++) {
+		void *stack;
+
 		error = sbi_hart_get_status(cpu_hart_id(logical), &status);
 		if (error)
 			cpu_start_failed(logical, error);
@@ -94,10 +99,21 @@ void cpu_start_secondary_harts(void)
 			       cpu_hart_id(logical), (int)status);
 			PANIC("secondary hart is not stopped");
 		}
+		if (cpus[logical].scheduler_stack)
+			PANIC("secondary hart stack already allocated");
+		stack = palloc();
+		cpus[logical].scheduler_stack = stack;
+		/* entry.S reads the logical CPU ID before using the stack. */
+		*(uint64 *)stack = logical;
+		__sync_synchronize();
 		error = sbi_hart_start(cpu_hart_id(logical),
-		                       (uint64)secondary_entry, logical);
-		if (error)
+		                       (uint64)secondary_entry,
+		                       (uint64)stack);
+		if (error) {
+			cpus[logical].scheduler_stack = 0;
+			pfree(stack);
 			cpu_start_failed(logical, error);
+		}
 	}
 }
 

--- a/arch/riscv/cpu.c
+++ b/arch/riscv/cpu.c
@@ -1,5 +1,7 @@
 #include <cpu.h>
 #include <debug.h>
+#include <kernel_config.h>
+#include <mem_layout.h>
 #include <of.h>
 #include <palloc.h>
 #include <printf.h>
@@ -7,12 +9,16 @@
 #include <sbi.h>
 #include <scheduler.h>
 #include <timer.h>
+#include <vm.h>
 
 #define CPU_START_TIMEOUT_SECONDS 5
 
 extern void secondary_entry(void);
 
 static int logical_cpu_count;
+
+/* Used directly by the trap entry before it can safely use a C stack. */
+uint64 *cpu_overflow_stack_tops;
 
 void cpu_topology_init(uint64 boot_hart_id)
 {
@@ -77,13 +83,103 @@ struct device_node *cpu_of_node(int logical_id)
 	return cpus[logical_id]->of_node;
 }
 
+static void cpu_map_kernel_stack(pagedir_t pgdir, int logical_id)
+{
+	uint64 address = SCHED_STACK(logical_id);
+	uint64 physical;
+	int page;
+
+	if (cpus[logical_id]->scheduler_stack)
+		PANIC("CPU stack already mapped");
+	for (page = 0; page < KSTACK_PAGES; page++) {
+		physical = (uint64)palloc();
+		if (vm_map(pgdir, address + page * PGSIZE, physical,
+		           PGSIZE, PTE_R | PTE_W) < 0)
+			PANIC("map CPU stack");
+	}
+	cpus[logical_id]->scheduler_stack = (void *)address;
+	physical = (uint64)palloc();
+	cpu_overflow_stack_tops[logical_id] = physical + PGSIZE;
+}
+
+void cpu_map_kernel_stacks(pagedir_t pgdir)
+{
+	int logical;
+
+	if (cpu_overflow_stack_tops)
+		PANIC("CPU stacks already initialized");
+	cpu_overflow_stack_tops =
+		calloc(logical_cpu_count, sizeof(*cpu_overflow_stack_tops));
+	if (!cpu_overflow_stack_tops)
+		PANIC("allocate overflow stack table");
+	for (logical = 0; logical < logical_cpu_count; logical++)
+		cpu_map_kernel_stack(pgdir, logical);
+}
+
+static int cpu_stack_slot_valid(uint64 address)
+{
+	int page;
+
+	if (address & (KSTACK_ALIGN - 1))
+		return 0;
+	if (kvm_va2pa(address - PGSIZE) ||
+	    kvm_va2pa(address + KSTACK_SIZE))
+		return 0;
+	for (page = 0; page < KSTACK_PAGES; page++) {
+		if (!kvm_va2pa(address + page * PGSIZE))
+			return 0;
+	}
+	return 1;
+}
+
+int cpu_kernel_stack_selftest(void)
+{
+	uint64 address, overflow_top;
+	int logical, thread_id;
+
+	for (thread_id = 0; thread_id < NTHREAD; thread_id++) {
+		if (!cpu_stack_slot_valid(KSTACK(thread_id)))
+			return -1;
+	}
+	for (logical = 0; logical < logical_cpu_count; logical++) {
+		address = (uint64)cpus[logical]->scheduler_stack;
+		overflow_top = cpu_overflow_stack_tops[logical];
+		if (address != SCHED_STACK(logical) ||
+		    !cpu_stack_slot_valid(address) ||
+		    !overflow_top || !kvm_va2pa(overflow_top - PGSIZE))
+			return -1;
+	}
+	return 0;
+}
+
+uint64 cpu_scheduler_stack_top(void)
+{
+	uint64 stack = (uint64)cur_cpu()->scheduler_stack;
+
+	if (!stack)
+		PANIC("missing CPU stack");
+	return stack + KSTACK_SIZE;
+}
+
 void cpu_secondary_validate(uint64 hart_id, uint64 logical_id,
 			    uint64 stack_address)
 {
 	if (!logical_id || logical_id >= (uint64)logical_cpu_count ||
 	    cpus[logical_id]->hart_id != hart_id ||
-	    cpus[logical_id]->scheduler_stack != (void *)stack_address)
+	    cpus[logical_id]->secondary_boot_stack !=
+		(void *)stack_address)
 		PANIC("invalid secondary hart handoff");
+}
+
+void cpu_secondary_boot_stack_release(void)
+{
+	cpu_t cpu = cur_cpu();
+	void *stack = cpu->secondary_boot_stack;
+
+	if (!stack)
+		PANIC("missing secondary boot stack");
+	cpu->secondary_boot_stack = 0;
+	pfree(stack);
 }
 
 static void cpu_start_failed(int logical_id, int64 error)
@@ -110,10 +206,10 @@ void cpu_start_secondary_harts(void)
 			       cpu_hart_id(logical), (int)status);
 			PANIC("secondary hart is not stopped");
 		}
-		if (cpus[logical]->scheduler_stack)
-			PANIC("secondary hart stack already allocated");
+		if (cpus[logical]->secondary_boot_stack)
+			PANIC("secondary boot stack already allocated");
 		stack = palloc();
-		cpus[logical]->scheduler_stack = stack;
+		cpus[logical]->secondary_boot_stack = stack;
 		/* entry.S reads the logical CPU ID before using the stack. */
 		*(uint64 *)stack = logical;
 		__sync_synchronize();
@@ -121,7 +217,7 @@ void cpu_start_secondary_harts(void)
 		                       (uint64)secondary_entry,
 		                       (uint64)stack);
 		if (error) {
-			cpus[logical]->scheduler_stack = 0;
+			cpus[logical]->secondary_boot_stack = 0;
 			pfree(stack);
 			cpu_start_failed(logical, error);
 		}

--- a/arch/riscv/include/boot.h
+++ b/arch/riscv/include/boot.h
@@ -1,9 +1,16 @@
 #ifndef __CAFFEINIX_ARCH_RISCV_BOOT_H
 #define __CAFFEINIX_ARCH_RISCV_BOOT_H
 
+#include <riscv.h>
+
+#define BOOT_STACK_PAGES 4
+#define BOOT_STACK_SIZE (BOOT_STACK_PAGES * PGSIZE)
+
+#ifndef __ASSEMBLER__
 #include <typedefs.h>
 
 extern uint64 boot_dtb_address;
 extern uint64 boot_hart_id;
+#endif
 
 #endif

--- a/arch/riscv/include/cpu.h
+++ b/arch/riscv/include/cpu.h
@@ -9,7 +9,8 @@ void cpu_topology_init(uint64 boot_hart_id);
 int cpu_count(void);
 uint64 cpu_hart_id(int logical_id);
 struct device_node *cpu_of_node(int logical_id);
-void cpu_secondary_validate(uint64 hart_id, uint64 logical_id);
+void cpu_secondary_validate(uint64 hart_id, uint64 logical_id,
+			    uint64 stack_address);
 void cpu_start_secondary_harts(void);
 void cpu_mark_online(void);
 void cpu_wait_for_secondary_harts(void);

--- a/arch/riscv/include/cpu.h
+++ b/arch/riscv/include/cpu.h
@@ -1,6 +1,7 @@
 #ifndef __CAFFEINIX_ARCH_RISCV_CPU_H
 #define __CAFFEINIX_ARCH_RISCV_CPU_H
 
+#include <riscv.h>
 #include <typedefs.h>
 
 struct device_node;
@@ -9,8 +10,14 @@ void cpu_topology_init(uint64 boot_hart_id);
 int cpu_count(void);
 uint64 cpu_hart_id(int logical_id);
 struct device_node *cpu_of_node(int logical_id);
+void cpu_map_kernel_stacks(pagedir_t pgdir);
+int cpu_kernel_stack_selftest(void);
+uint64 cpu_scheduler_stack_top(void);
+void cpu_enter_stack(uint64 stack_top, void (*entry)(void))
+	__attribute__((noreturn));
 void cpu_secondary_validate(uint64 hart_id, uint64 logical_id,
 			    uint64 stack_address);
+void cpu_secondary_boot_stack_release(void);
 void cpu_start_secondary_harts(void);
 void cpu_mark_online(void);
 void cpu_wait_for_secondary_harts(void);

--- a/arch/riscv/include/mem_layout.h
+++ b/arch/riscv/include/mem_layout.h
@@ -11,6 +11,8 @@
 #ifndef __CAFFEINIX_ARCH_RISCV_MEM_LAYOUT_H
 #define __CAFFEINIX_ARCH_RISCV_MEM_LAYOUT_H
 
+#include <kernel_config.h>
+
 /* OpenSBI remains resident at the start of RAM on QEMU virt. */
 #define KERNEL_BASE     0x80200000L
 /* 
@@ -26,14 +28,20 @@
 #define USER_STACK_SIZE  (64 * PGSIZE)
 #define USER_STACK_BASE  (USER_STACK_TOP - USER_STACK_SIZE)
 #define USER_MMAP_TOP    (USER_STACK_BASE - PGSIZE)
-/* 
-        map kernel stacks beneath the trampoline,
-        each surrounded by invalid guard pages.
+/*
+ * Put each runtime kernel stack in the lower half of an aligned slot.
+ * The unused upper half and the preceding slot's upper half guard both
+ * ends, while KSTACK_SHIFT identifies an overflow at trap entry.
  */
-#define KSTACK_PAGES 4
-#define KSTACK_SIZE (KSTACK_PAGES * PGSIZE)
+#define KSTACK_SHIFT 14
+#define KSTACK_SIZE (1 << KSTACK_SHIFT)
+#define KSTACK_PAGES (KSTACK_SIZE / PGSIZE)
+#define KSTACK_ALIGN (2 * KSTACK_SIZE)
+#define KSTACK_REGION_TOP (TRAMPOLINE & ~(KSTACK_ALIGN - 1))
 #define KSTACK(p) \
-	(TRAMPOLINE - ((p) + 1) * (KSTACK_PAGES + 1) * PGSIZE)
+	(KSTACK_REGION_TOP - ((p) + 1) * KSTACK_ALIGN)
+#define SCHED_STACK(cpu) \
+	(KSTACK_REGION_TOP - (NTHREAD + (cpu) + 1) * KSTACK_ALIGN)
 
 /* qemu puts platform-level interrupt controller (PLIC) here. */
 #define PLIC 0x0c000000L

--- a/arch/riscv/kernel_vec.S
+++ b/arch/riscv/kernel_vec.S
@@ -1,9 +1,19 @@
+#include <mem_layout.h>
+
 .global kernel_trap
+.global kernel_stack_overflow
 .global kernel_vec
 .align 4
 kernel_vec:
-        # make room to save registers.
+	/* Preserve t0 while checking the aligned stack slot. */
+	csrw sscratch, t0
+
+	/* Make room to save registers. */
         addi sp, sp, -256
+	srli t0, sp, KSTACK_SHIFT
+	andi t0, t0, 1
+	bnez t0, .Lkernel_stack_overflow
+	csrr t0, sscratch
 
         # save the registers.
         sd ra, 0(sp)
@@ -79,3 +89,21 @@ kernel_vec:
 
         # return to whatever we were doing in the kernel.
         sret
+
+.Lkernel_stack_overflow:
+	/* Report from the per-CPU emergency stack, not the failed stack. */
+	addi a0, sp, 256
+	la t0, cpu_overflow_stack_tops
+	ld t0, 0(t0)
+	slli t1, tp, 3
+	add t0, t0, t1
+	ld sp, 0(t0)
+	tail kernel_stack_overflow
+
+#ifdef CONFIG_STACK_OVERFLOW_TEST
+.global kernel_stack_overflow_test
+kernel_stack_overflow_test:
+	addi sp, sp, -2048
+	sd zero, 0(sp)
+	j kernel_stack_overflow_test
+#endif

--- a/arch/riscv/timer.c
+++ b/arch/riscv/timer.c
@@ -1,6 +1,8 @@
+#include <cpu.h>
 #include <debug.h>
 #include <kernel_config.h>
 #include <of.h>
+#include <palloc.h>
 #include <printf.h>
 #include <riscv.h>
 #include <sbi.h>
@@ -10,8 +12,13 @@
 static uint64 clock_frequency;
 static uint64 tick_interval;
 static uint64 idle_tick_interval;
-static volatile uint8 timer_seen[NCPU];
-static volatile uint8 timer_idle[NCPU];
+
+struct timer_cpu_state {
+	volatile uint8 seen;
+	volatile uint8 idle;
+};
+
+static struct timer_cpu_state *timer_cpus;
 
 void timer_init(void)
 {
@@ -27,6 +34,9 @@ void timer_init(void)
 	idle_tick_interval = clock_frequency * IDLE_TICK_INTERVAL / 1000;
 	if (!tick_interval || !idle_tick_interval)
 		PANIC("invalid timer interval");
+	timer_cpus = calloc(cpu_count(), sizeof(*timer_cpus));
+	if (!timer_cpus)
+		PANIC("allocate timer CPU state");
 }
 
 void timer_init_hart(void)
@@ -41,10 +51,10 @@ void timer_wait_for_interrupt(void)
 	uint64 start = time_r();
 	int logical = cpuid();
 
-	if (logical < 0 || logical >= NCPU)
+	if (logical < 0 || logical >= cpu_count())
 		PANIC("invalid timer CPU");
 	intr_on();
-	while (!timer_seen[logical]) {
+	while (!timer_cpus[logical].seen) {
 		if (time_r() - start > clock_frequency * 2) {
 			intr_off();
 			PANIC("supervisor timer timeout");
@@ -58,13 +68,14 @@ void timer_interrupt(void)
 	int logical = cpuid();
 	uint64 interval;
 
-	if (logical < 0 || logical >= NCPU)
+	if (logical < 0 || logical >= cpu_count())
 		PANIC("invalid timer CPU");
-	interval = timer_idle[logical] ? idle_tick_interval : tick_interval;
+	interval = timer_cpus[logical].idle ? idle_tick_interval :
+		   tick_interval;
 	if (sbi_set_timer(time_r() + interval))
 		PANIC("SBI timer rearm failed");
-	if (!timer_seen[logical]) {
-		timer_seen[logical] = 1;
+	if (!timer_cpus[logical].seen) {
+		timer_cpus[logical].seen = 1;
 		printf("CPU: logical=%d timer active\n", logical);
 	}
 }
@@ -73,9 +84,9 @@ void timer_set_active(void)
 {
 	int logical = cpuid();
 
-	if (logical < 0 || logical >= NCPU)
+	if (logical < 0 || logical >= cpu_count())
 		PANIC("invalid timer CPU");
-	if (!__atomic_exchange_n(&timer_idle[logical], 0,
+	if (!__atomic_exchange_n(&timer_cpus[logical].idle, 0,
 				 __ATOMIC_ACQ_REL))
 		return;
 	if (sbi_set_timer(time_r() + tick_interval))
@@ -86,10 +97,10 @@ void timer_set_idle(void)
 {
 	int logical = cpuid();
 
-	if (logical < 0 || logical >= NCPU)
+	if (logical < 0 || logical >= cpu_count())
 		PANIC("invalid timer CPU");
 	/* CPU0 retains the fine tick that expires global timed waits. */
-	if (!logical || __atomic_exchange_n(&timer_idle[logical], 1,
+	if (!logical || __atomic_exchange_n(&timer_cpus[logical].idle, 1,
 					    __ATOMIC_ACQ_REL))
 		return;
 	if (sbi_set_timer(time_r() + idle_tick_interval))

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -91,6 +91,19 @@ void kernel_trap(void)
 }
 
 extern void exit(int cause);
+
+__attribute__((noreturn)) void kernel_stack_overflow(uint64 stack_pointer)
+{
+	printf_enter_panic();
+	printf("kernel stack overflow: CPU=%d sp=%p\n", cpuid(),
+	       stack_pointer);
+	printf("scause=%p sepc=%p stval=%p\n", scause_r(), sepc_r(),
+	       stval_r());
+	PANIC("kernel stack overflow");
+	for (;;)
+		;
+}
+
 void user_trap_entry(void)
 {
         int which_dev = 0;

--- a/arch/riscv/vm.c
+++ b/arch/riscv/vm.c
@@ -15,6 +15,7 @@
 #include <debug.h>
 #include <process.h>
 #include <printf.h>
+#include <cpu.h>
 
 /* Defination in kernel.ld */
 extern char etext[];
@@ -154,6 +155,7 @@ static pagedir_t kernel_pagedir_t_create(void)
 	}
 
         map_kernel_stack(pgdir);
+	cpu_map_kernel_stacks(pgdir);
         return pgdir;
 }
 

--- a/include/kernel_config.h
+++ b/include/kernel_config.h
@@ -11,7 +11,6 @@
 #ifndef __CAFFEINIX_KERNEL_CONFIG_H
 #define __CAFFEINIX_KERNEL_CONFIG_H
 
-#define NCPU                            8
 #define NPROC                           64
 
 #define NTHREAD                         64

--- a/kernel/include/netdevice.h
+++ b/kernel/include/netdevice.h
@@ -61,7 +61,7 @@ struct net_device {
 	uint32 transmit_active;
 	uint32 state_pending;
 	uint32 transmit_threads[NTHREAD];
-	uint32 transmit_cpus[NCPU];
+	uint32 *transmit_cpus;
 	struct net_device *next_state;
 	uint8 registered;
 	uint8 up;

--- a/kernel/include/printf.h
+++ b/kernel/include/printf.h
@@ -6,5 +6,6 @@
 
 void printf_init(void);
 void printf(char* fmt, ...);
+void printf_enter_panic(void);
 
 #endif

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -23,7 +23,9 @@ typedef struct cpu {
 	volatile uint8 need_resched;
 }*cpu_t;
 
-uint8 cpuid(void);
+extern cpu_t *cpus;
+
+int cpuid(void);
 cpu_t cur_cpu(void);
 thread_t cur_thread(void);
 process_t cur_proc(void);

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -18,6 +18,7 @@ typedef struct cpu {
 	uint64 hart_id;
 	struct device_node *of_node;
 	void *scheduler_stack;
+	void *secondary_boot_stack;
 	volatile uint8 online;
 	uint8 idle;
 	volatile uint8 need_resched;

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -17,6 +17,7 @@ typedef struct cpu {
         uint8 before_lock;
 	uint64 hart_id;
 	struct device_node *of_node;
+	void *scheduler_stack;
 	volatile uint8 online;
 	uint8 idle;
 	volatile uint8 need_resched;

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -48,9 +48,83 @@
 volatile static uint8 start = 0;
 extern char end[];
 
+#ifdef CONFIG_STACK_OVERFLOW_TEST
+extern void kernel_stack_overflow_test(void);
+#endif
+
+static void main_boot(void)
+{
+	thread_setup();
+	scheduler_init();
+	wait_queue_timeout_init();
+	workqueue_init();
+	trap_init_lock();
+	trap_init();
+#ifdef CONFIG_STACK_OVERFLOW_TEST
+	kernel_stack_overflow_test();
+#endif
+	timer_init_hart();
+	process_init();
+	driver_core_init();
+	if (driver_core_selftest())
+		PANIC("driver core selftest");
+	platform_bus_init();
+	virtio_bus_init();
+	if (platform_core_selftest() < 0)
+		PANIC("platform core selftest");
+	if (of_platform_populate() < 0)
+		PANIC("populate platform devices");
+	if (ns16550_init() < 0)
+		PANIC("register NS16550 driver");
+	if (uart_core_selftest() < 0)
+		PANIC("UART core selftest");
+	block_device_init();
+	net_device_init();
+	if (net_core_selftest() < 0)
+		PANIC("network core selftest");
+	if (net_loopback_init() < 0)
+		PANIC("register loopback device");
+	if (virtio_blk_init() < 0)
+		PANIC("register virtio-blk driver");
+	if (virtio_net_init() < 0)
+		PANIC("register virtio-net driver");
+	if (virtio_mmio_init() < 0)
+		PANIC("register virtio-mmio driver");
+	network_stack_init();
+	ext4fs_init();
+	fatfs_init();
+	devfs_init();
+	tmpfs_init();
+	userinit();
+
+	printf("Hello! Caffeinix\n");
+	timer_wait_for_interrupt();
+	cpu_mark_online();
+	cpu_start_secondary_harts();
+	__sync_synchronize();
+	start = 1;
+	cpu_wait_for_secondary_harts();
+	scheduler();
+	for (;;)
+		;
+}
+
+static void main_secondary(void)
+{
+	cpu_secondary_boot_stack_release();
+	plic_init_hart();
+	trap_init();
+	timer_init_hart();
+	timer_wait_for_interrupt();
+	cpu_mark_online();
+	scheduler();
+	for (;;)
+		;
+}
+
 void main(void)
 {
-        if(cpuid() == 0) {
+	if (cpuid() == 0) {
 		int of_status = of_init((void *)boot_dtb_address);
 
 		console_early_init();
@@ -67,77 +141,20 @@ void main(void)
 		plic_init_hart();
 		char_device_init();
 		tty_init();
-                printf_init();
+		printf_init();
 		sbi_report();
-                // printf("%p\n", end);
-                kvm_create();
+		kvm_create();
 		if (kvm_map_mmio(earlycon_address(), earlycon_size()) < 0)
 			PANIC("map early console");
-                kvm_init();
-                thread_setup();
-                scheduler_init();
-		wait_queue_timeout_init();
-		workqueue_init();
-                trap_init_lock();
-                trap_init();
-		timer_init_hart();
-                process_init();
-		driver_core_init();
-		if (driver_core_selftest())
-			PANIC("driver core selftest");
-		platform_bus_init();
-		virtio_bus_init();
-		if (platform_core_selftest() < 0)
-			PANIC("platform core selftest");
-		if (of_platform_populate() < 0)
-			PANIC("populate platform devices");
-		if (ns16550_init() < 0)
-			PANIC("register NS16550 driver");
-		if (uart_core_selftest() < 0)
-			PANIC("UART core selftest");
-                block_device_init();
-		net_device_init();
-		if (net_core_selftest() < 0)
-			PANIC("network core selftest");
-		if (net_loopback_init() < 0)
-			PANIC("register loopback device");
-		if (virtio_blk_init() < 0)
-			PANIC("register virtio-blk driver");
-		if (virtio_net_init() < 0)
-			PANIC("register virtio-net driver");
-		if (virtio_mmio_init() < 0)
-			PANIC("register virtio-mmio driver");
-		network_stack_init();
-		ext4fs_init();
-		fatfs_init();
-		devfs_init();
-		tmpfs_init();
-		userinit();
+		kvm_init();
+		if (cpu_kernel_stack_selftest() < 0)
+			PANIC("kernel stack guards");
+		cpu_enter_stack(cpu_scheduler_stack_top(), main_boot);
+	}
 
-                printf("Hello! Caffeinix\n");
-                // thread_test();
-		timer_wait_for_interrupt();
-		cpu_mark_online();
-		cpu_start_secondary_harts();
-
-                __sync_synchronize();
-                start = 1;
-                
-        } else {
-                while(start == 0)
-                        ;
-                __sync_synchronize();
-                kvm_init();
-                plic_init_hart();
-                trap_init();
-		timer_init_hart();
-		timer_wait_for_interrupt();
-		cpu_mark_online();
-        }
-
-	if (cpuid() == 0)
-		cpu_wait_for_secondary_harts();
-        scheduler();
-
-        while(1);
+	while (start == 0)
+		;
+	__sync_synchronize();
+	kvm_init();
+	cpu_enter_stack(cpu_scheduler_stack_top(), main_secondary);
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -56,10 +56,10 @@ void main(void)
 		console_early_init();
 		if (of_status < 0)
 			PANIC("invalid boot DTB");
+		palloc_init();
 		cpu_topology_init(boot_hart_id);
 		sbi_init(cpu_count());
 		timer_init();
-                palloc_init();
 		file_init();
 		vfs_init();
 		irq_init();

--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -18,6 +18,11 @@
 #define MIN_SIZE                                (1)
 #define USE_BLOCK(x)                            (((x) / MIN_SIZE) + (((x) % MIN_SIZE) ? 1 : 0))
 #define INFO_BLOCK                              USE_BLOCK(sizeof(struct block_info))
+#define MALLOC_ALIGNMENT                        16
+#define MALLOC_ALIGNMENT_BLOCKS                 USE_BLOCK(MALLOC_ALIGNMENT)
+#define ALIGN_BLOCKS(x) \
+	(((x) + MALLOC_ALIGNMENT_BLOCKS - 1) & \
+	 ~(MALLOC_ALIGNMENT_BLOCKS - 1))
 #define PAGE_BLOCK                              512
 #define BITMAP_SIZE                             ((4096 - PAGE_BLOCK) / 8)
 
@@ -70,8 +75,15 @@ static int memory_range_count;
 static int reserved_range_count;
 static uint64 heap_start;
 
+_Static_assert((MALLOC_ALIGNMENT & (MALLOC_ALIGNMENT - 1)) == 0,
+	       "malloc alignment must be a power of two");
+_Static_assert(PAGE_BLOCK % MALLOC_ALIGNMENT == 0,
+	       "heap payload must be aligned");
+
 /* Defination is in kernel.ld */
 extern char end[];
+
+static void palloc_heap_alignment_selftest(void);
 
 static int palloc_range_contains(const struct palloc_range *range,
 				 uint64 start, uint64 finish)
@@ -185,6 +197,7 @@ void palloc_init(void)
 	}
 	if (!pages)
 		PANIC("no usable memory");
+	palloc_heap_alignment_selftest();
 }
 
 /* Free the physical memory */
@@ -237,7 +250,7 @@ void* palloc(void)
 static uint64 malloc_core(page_t page, uint64 blocks)
 {
         int i, j, mask;
-        uint64 count = 0, start = 0, k;
+        uint64 count = 0, start = 0, k, offset;
 
         if(!page)
                 return -1;
@@ -246,8 +259,13 @@ static uint64 malloc_core(page_t page, uint64 blocks)
                 mask = 0x80;
                 for(j = 0; j < 8; j++) {
                         if((page->bitmap[i] & mask) == 0) {
+				offset = i * 8 + j;
                                 if(count == 0) {
-                                        start = i * 8 + j;
+					if (offset % MALLOC_ALIGNMENT_BLOCKS) {
+						mask >>= 1;
+						continue;
+					}
+					start = offset;
                                 }
                                 count++;
                                 if(count == blocks) {
@@ -342,21 +360,26 @@ static page_t malloc_page(void)
  */
 void* malloc(uint64 size)
 {
-        int use_blocks, re_count = 0;
+	uint64 allocation_blocks, use_blocks;
+	int re_count = 0;
         block_info_t info;
         page_t page;
         void* p;
         uint64 ret;
 
-        if(size == 0)
-                return 0;
+	if(size == 0)
+		return 0;
 
-	spinlock_acquire(&heap_lock);
         use_blocks = USE_BLOCK(size);
+	if (use_blocks > (uint64)-1 - INFO_BLOCK -
+	    (MALLOC_ALIGNMENT_BLOCKS - 1))
+		return 0;
+	allocation_blocks = ALIGN_BLOCKS(use_blocks + INFO_BLOCK);
+	spinlock_acquire(&heap_lock);
 
         page = pool.list;
 re:
-        ret = malloc_core(page, use_blocks + INFO_BLOCK);
+	ret = malloc_core(page, allocation_blocks);
         if(ret == -1 && re_count != 1) {
                 re_count++;
                 page = malloc_page();
@@ -376,7 +399,7 @@ re:
         p = (void*)((uint64)info + INFO_BLOCK * MIN_SIZE); 
 
         /* Change information */
-        info->used = use_blocks;
+	info->used = allocation_blocks - INFO_BLOCK;
         info->magic = MAGIC_NUMBER;
         info->addr = p;
         info->parent = page;
@@ -427,4 +450,20 @@ void free(void* p)
 
         free_core(page, (char*)info, INFO_BLOCK + info->used);
 	spinlock_release(&heap_lock);
+}
+
+static void palloc_heap_alignment_selftest(void)
+{
+	static const uint64 sizes[] = { 1, 3, 7, 15, 17, 31, 33, 127 };
+	void *allocations[sizeof(sizes) / sizeof(sizes[0])];
+	size_t index;
+
+	for (index = 0; index < sizeof(sizes) / sizeof(sizes[0]); index++) {
+		allocations[index] = malloc(sizes[index]);
+		if (!allocations[index] ||
+		    (uint64)allocations[index] % MALLOC_ALIGNMENT)
+			PANIC("unaligned heap allocation");
+	}
+	for (; index > 0; index--)
+		free(allocations[index - 1]);
 }

--- a/kernel/plic.c
+++ b/kernel/plic.c
@@ -2,13 +2,13 @@
 #include <cpu.h>
 #include <debug.h>
 #include <irq.h>
-#include <kernel_config.h>
 #include <of.h>
+#include <palloc.h>
 #include <scheduler.h>
 
 #define RISCV_IRQ_S_EXT 9
 
-static int plic_contexts[NCPU];
+static int *plic_contexts;
 
 static struct device_node *plic_node(void)
 {
@@ -84,6 +84,9 @@ void plic_init(void)
 
 	if (!node)
 		PANIC("missing PLIC node");
+	plic_contexts = calloc(cpu_count(), sizeof(*plic_contexts));
+	if (!plic_contexts)
+		PANIC("allocate PLIC CPU contexts");
 	for (logical = 0; logical < cpu_count(); logical++) {
 		plic_contexts[logical] = plic_context_for_cpu(node, logical);
 		if (plic_contexts[logical] < 0)

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -110,10 +110,15 @@ void printf(char* fmt, ...)
 
 void panic(char* s)
 {
-        pf.locking = 0;
+	printf_enter_panic();
         printf("[PANIC]: %s\n", s);
         paniced = 1;
         for(;;);
+}
+
+void printf_enter_panic(void)
+{
+	pf.locking = 0;
 }
 
 void printf_init(void)

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -295,21 +295,10 @@ static void process_free(process_t p)
 
 void process_init(void)
 {
-        // process_t p = proc;
-        // int i;
-        /* Init the spinlock */
-        spinlock_init(&pid_lock, "pid_lock");
-        spinlock_init(&wait_lock, "wait_lock");
-        list_init(&proc);
-        /* Set the state and starting kernel stack address of each process */
-        // for(; p <= &proc[NCPU - 1]; p++) {
-        //         spinlock_init(&p->lock, "proc");
-        //         p->state = UNUSED;
-        //         p->tnums = 0;
-        //         for(i = 0; i < PROC_MAXTHREAD; i++) {
-        //                 p->thread[i] = 0;
-        //         }
-        // }
+	/* Init the spinlock */
+	spinlock_init(&pid_lock, "pid_lock");
+	spinlock_init(&wait_lock, "wait_lock");
+	list_init(&proc);
 }
 
 void userinit(void)

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -1,6 +1,5 @@
 #include <cpu.h>
 #include <debug.h>
-#include <kernel_config.h>
 #include <ktime.h>
 #include <mem_layout.h>
 #include <rbtree.h>
@@ -28,7 +27,9 @@ static const uint32 nice_weights[40] = {
 
 extern void switchto(context_t c, context_t p);
 
-struct cpu cpus[NCPU];
+static struct cpu boot_cpu;
+static cpu_t boot_cpu_table[] = { &boot_cpu };
+cpu_t *cpus = boot_cpu_table;
 
 static struct {
 	struct spinlock lock;
@@ -38,14 +39,14 @@ static struct {
 	uint32 count;
 } runqueue;
 
-uint8 cpuid(void)
+int cpuid(void)
 {
-	return tp_r();
+	return (int)tp_r();
 }
 
 cpu_t cur_cpu(void)
 {
-	return &cpus[cpuid()];
+	return cpus[cpuid()];
 }
 
 thread_t cur_thread(void)
@@ -182,8 +183,8 @@ static void update_min_vruntime_locked(thread_t selected, uint64 now)
 			minimum = queued->sched.vruntime;
 	}
 	for (logical = 0; logical < cpu_count(); logical++) {
-		thread_t current = cpus[logical].current;
-		thread_t pending = cpus[logical].selected;
+		thread_t current = cpus[logical]->current;
+		thread_t pending = cpus[logical]->selected;
 		uint64 vruntime;
 
 		if (current && current != selected &&
@@ -210,10 +211,10 @@ static int claim_idle_cpu_locked(void)
 		return -1;
 	}
 	for (logical = 0; logical < cpu_count(); logical++) {
-		if (&cpus[logical] == current || !cpus[logical].online ||
-		    !cpus[logical].idle)
+		if (cpus[logical] == current || !cpus[logical]->online ||
+		    !cpus[logical]->idle)
 			continue;
-		cpus[logical].idle = 0;
+		cpus[logical]->idle = 0;
 		return logical;
 	}
 	return -1;
@@ -226,10 +227,10 @@ static int select_preempt_cpu_locked(thread_t waking, uint64 now)
 	int logical, target = -1;
 
 	for (logical = 0; logical < cpu_count(); logical++) {
-		thread_t current = cpus[logical].current;
+		thread_t current = cpus[logical]->current;
 		uint64 current_vruntime;
 
-		if (!cpus[logical].online || !current ||
+		if (!cpus[logical]->online || !current ||
 		    current->state != THREAD_RUNNING)
 			continue;
 		current_vruntime = entity_vruntime_now(current, now);
@@ -242,7 +243,7 @@ static int select_preempt_cpu_locked(thread_t waking, uint64 now)
 		target = logical;
 	}
 	if (target >= 0)
-		__atomic_store_n(&cpus[target].need_resched, 1,
+		__atomic_store_n(&cpus[target]->need_resched, 1,
 				 __ATOMIC_RELEASE);
 	return target;
 }
@@ -299,8 +300,8 @@ static uint64 calculate_slice_locked(thread_t selected)
 	int logical;
 
 	for (logical = 0; logical < cpu_count(); logical++) {
-		thread_t current = cpus[logical].current;
-		thread_t pending = cpus[logical].selected;
+		thread_t current = cpus[logical]->current;
+		thread_t pending = cpus[logical]->selected;
 
 		if (current && current != selected &&
 		    current->state == THREAD_RUNNING) {
@@ -356,9 +357,9 @@ int scheduler_set_nice(thread_t thread, int nice)
 		enqueue_entity_locked(thread);
 	if (running) {
 		for (logical = 0; logical < cpu_count(); logical++) {
-			if (cpus[logical].current != thread)
+			if (cpus[logical]->current != thread)
 				continue;
-			__atomic_store_n(&cpus[logical].need_resched, 1,
+			__atomic_store_n(&cpus[logical]->need_resched, 1,
 					 __ATOMIC_RELEASE);
 			target = logical;
 			break;

--- a/net/core/device.c
+++ b/net/core/device.c
@@ -1,7 +1,9 @@
+#include <cpu.h>
 #include <debug.h>
 #include <kernel_config.h>
 #include <mystring.h>
 #include <netdevice.h>
+#include <palloc.h>
 #include <scheduler.h>
 #include <thread.h>
 #include <wait.h>
@@ -19,7 +21,7 @@ static struct {
 	void *receive_argument;
 	uint32 receive_active;
 	uint32 receive_threads[NTHREAD];
-	uint32 receive_cpus[NCPU];
+	uint32 *receive_cpus;
 	uint8 receive_draining;
 	uint8 receive_dispatching;
 	struct net_packet *receive_head;
@@ -29,7 +31,7 @@ static struct {
 	void *state_argument;
 	uint32 state_active;
 	uint32 state_threads[NTHREAD];
-	uint32 state_cpus[NCPU];
+	uint32 *state_cpus;
 	uint8 state_draining;
 	struct net_device *state_head;
 	struct net_device *state_tail;
@@ -91,13 +93,16 @@ static struct net_callback_slot net_callback_slot(void)
 {
 	struct net_callback_slot slot = { .thread = -1, .cpu = -1 };
 	thread_t current = cur_thread();
+	int logical;
 
 	if (current) {
 		slot.thread = current - thread;
 		if (slot.thread < 0 || slot.thread >= NTHREAD)
 			slot.thread = -1;
-	} else if (cpuid() < NCPU) {
-		slot.cpu = cpuid();
+	} else {
+		logical = cpuid();
+		if (logical >= 0 && logical < cpu_count())
+			slot.cpu = logical;
 	}
 	return slot;
 }
@@ -176,6 +181,12 @@ static int net_device_assign_name_locked(struct net_device *device)
 
 void net_device_init(void)
 {
+	network.receive_cpus = calloc(cpu_count(),
+				      sizeof(*network.receive_cpus));
+	network.state_cpus = calloc(cpu_count(),
+				    sizeof(*network.state_cpus));
+	if (!network.receive_cpus || !network.state_cpus)
+		PANIC("allocate network CPU state");
 	spinlock_init(&network.lock, "network devices");
 	wait_queue_init(&network.receive_wait, "network receive callbacks");
 	wait_queue_init(&network.state_wait, "network state callbacks");
@@ -185,28 +196,29 @@ void net_device_init(void)
 
 int net_device_register(struct net_device *device)
 {
+	uint32 *transmit_cpus;
 	uint32 free_index = 0, index;
 
 	if (!device || !device->operations ||
 	    !device->operations->start_xmit || !device->mtu ||
 	    device->mtu > NET_PACKET_SIZE - NET_ETH_HEADER_LENGTH)
 		return -1;
+	transmit_cpus = calloc(cpu_count(), sizeof(*transmit_cpus));
+	if (!transmit_cpus)
+		return -1;
 	spinlock_acquire(&network.lock);
 	if (device->registered) {
-		spinlock_release(&network.lock);
-		return -1;
+		goto failed;
 	}
 	if (net_device_assign_name_locked(device) < 0) {
-		spinlock_release(&network.lock);
-		return -1;
+		goto failed;
 	}
 	for (index = 1; index < NET_DEVICE_MAX; index++) {
 		if (!network.devices[index] && !free_index)
 			free_index = index;
 	}
 	if (!free_index) {
-		spinlock_release(&network.lock);
-		return -1;
+		goto failed;
 	}
 	index = free_index;
 	device->index = index;
@@ -218,7 +230,7 @@ int net_device_register(struct net_device *device)
 	device->transmit_active = 0;
 	memset(device->transmit_threads, 0,
 	       sizeof(device->transmit_threads));
-	memset(device->transmit_cpus, 0, sizeof(device->transmit_cpus));
+	device->transmit_cpus = transmit_cpus;
 	device->lifecycle_transition = 0;
 	device->stop_pending = 0;
 	device->state_pending = 0;
@@ -230,10 +242,16 @@ int net_device_register(struct net_device *device)
 	network.devices[index] = device;
 	spinlock_release(&network.lock);
 	return 0;
+
+failed:
+	spinlock_release(&network.lock);
+	free(transmit_cpus);
+	return -1;
 }
 
 int net_device_unregister(struct net_device *device)
 {
+	uint32 *transmit_cpus;
 	int was_up;
 
 	if (!device)
@@ -299,9 +317,12 @@ int net_device_unregister(struct net_device *device)
 	spinlock_acquire(&device->lock);
 	device->state_pending++;
 	device->lifecycle_transition = 0;
+	transmit_cpus = device->transmit_cpus;
+	device->transmit_cpus = 0;
 	wait_queue_wake_all(&device->lifecycle_wait);
 	spinlock_release(&device->lock);
 	net_state_notify_pending(device);
+	free(transmit_cpus);
 	return 0;
 }
 

--- a/net/lwip/port/sys_arch.c
+++ b/net/lwip/port/sys_arch.c
@@ -38,7 +38,7 @@ struct lwip_sys_mbox {
 
 static struct {
 	struct spinlock lock;
-	uint32 depth[NCPU];
+	uint32 *depth;
 } lightweight_protection;
 
 static struct spinlock random_lock;
@@ -64,9 +64,11 @@ void sys_init(void)
 {
 	uint32 index;
 
+	lightweight_protection.depth = calloc(
+		cpu_count(), sizeof(*lightweight_protection.depth));
+	if (!lightweight_protection.depth)
+		PANIC("allocate lwIP CPU state");
 	spinlock_init(&lightweight_protection.lock, "lwIP protect");
-	memset(lightweight_protection.depth, 0,
-	       sizeof(lightweight_protection.depth));
 	spinlock_init(&random_lock, "lwIP random");
 	for (index = 0; index < NTHREAD; index++) {
 		struct lwip_sys_sem *semaphore =
@@ -363,12 +365,12 @@ u32_t sys_now(void)
 
 sys_prot_t sys_arch_protect(void)
 {
-	uint32 cpu;
 	uint32 previous;
+	int cpu;
 
 	enter_critical();
 	cpu = cpuid();
-	if (cpu >= NCPU)
+	if (cpu < 0 || cpu >= cpu_count())
 		PANIC("invalid lwIP protect CPU");
 	previous = lightweight_protection.depth[cpu];
 	if (!previous)
@@ -380,11 +382,11 @@ sys_prot_t sys_arch_protect(void)
 
 void sys_arch_unprotect(sys_prot_t previous)
 {
-	uint32 cpu;
+	int cpu;
 
 	enter_critical();
 	cpu = cpuid();
-	if (cpu >= NCPU ||
+	if (cpu < 0 || cpu >= cpu_count() ||
 	    lightweight_protection.depth[cpu] != previous + 1)
 		PANIC("unbalanced lwIP protection");
 	lightweight_protection.depth[cpu] = previous;

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,9 +29,10 @@ make -C tests qemu
 The QEMU test downloads checksum-pinned musl 1.2.6 and BusyBox 1.38.0 source
 archives, builds both outside the kernel, and creates temporary ext4 and FAT32
 images under `output/tests`. It runs boot checks with one hart and 64 MiB, two
-harts and 192 MiB, four harts and 128 MiB, and eight harts and 256 MiB. A
-second eight-hart, 256 MiB run waits for BusyBox ash, runs the full guest
-suite, syncs storage, and exits QEMU through its serial monitor.
+harts and 192 MiB, three harts and 96 MiB, four harts and 128 MiB, and eight
+harts and 256 MiB. A second eight-hart, 256 MiB run waits for BusyBox ash,
+runs the full guest suite, syncs storage, and exits QEMU through its serial
+monitor.
 
 Each boot requires one SBI BASE report and exactly one online and timer marker
 per logical CPU. A static check rejects machine-mode CSR operations, direct

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,8 @@ harts and 192 MiB, three harts and 96 MiB, four harts and 128 MiB, and eight
 harts and 256 MiB, plus a nine-hart boot that exceeds the old static CPU
 limit. A second eight-hart, 256 MiB run waits for BusyBox ash, runs the full
 guest suite, syncs storage, and exits QEMU through its serial monitor.
+Finally, a test-only kernel deliberately crosses an unmapped kernel-stack
+guard and must report the overflow from its per-CPU emergency stack.
 
 Each boot requires one SBI BASE report and exactly one online and timer marker
 per logical CPU. A static check rejects machine-mode CSR operations, direct

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,9 +30,9 @@ The QEMU test downloads checksum-pinned musl 1.2.6 and BusyBox 1.38.0 source
 archives, builds both outside the kernel, and creates temporary ext4 and FAT32
 images under `output/tests`. It runs boot checks with one hart and 64 MiB, two
 harts and 192 MiB, three harts and 96 MiB, four harts and 128 MiB, and eight
-harts and 256 MiB. A second eight-hart, 256 MiB run waits for BusyBox ash,
-runs the full guest suite, syncs storage, and exits QEMU through its serial
-monitor.
+harts and 256 MiB, plus a nine-hart boot that exceeds the old static CPU
+limit. A second eight-hart, 256 MiB run waits for BusyBox ash, runs the full
+guest suite, syncs storage, and exits QEMU through its serial monitor.
 
 Each boot requires one SBI BASE report and exactly one online and timer marker
 per logical CPU. A static check rejects machine-mode CSR operations, direct

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -163,6 +163,7 @@ run_boot_smoke 2 192M
 run_boot_smoke 3 96M
 run_boot_smoke 4 128M
 run_boot_smoke 8 256M
+run_boot_smoke 9 256M
 
 export QEMU_CPUS=2
 export QEMU_MEMORY=128M

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -160,6 +160,7 @@ run_boot_smoke()
 
 run_boot_smoke 1 64M
 run_boot_smoke 2 192M
+run_boot_smoke 3 96M
 run_boot_smoke 4 128M
 run_boot_smoke 8 256M
 

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -307,4 +307,11 @@ fi
 	--output "$test_output/scheduler-benchmark.json" \
 	--check
 
+make -C "$topdir" clean
+make -C "$topdir" -j"$jobs" STACK_OVERFLOW_TEST=1
+export QEMU_LOG=$test_output/qemu-stack-overflow.log
+expect "$script_dir/run-stack-overflow.exp"
+make -C "$topdir" clean
+make -C "$topdir" -j"$jobs"
+
 echo QEMU_RUNTIME_OK

--- a/tests/scripts/run-stack-overflow.exp
+++ b/tests/scripts/run-stack-overflow.exp
@@ -1,0 +1,46 @@
+#!/usr/bin/expect -f
+
+proc abort_test {message} {
+	puts stderr "Kernel stack guard test failed: $message"
+	catch {close}
+	exit 1
+}
+
+foreach variable {QEMU SBI_FIRMWARE KERNEL QEMU_LOG} {
+	if {![info exists env($variable)] || $env($variable) eq ""} {
+		puts stderr "missing environment variable: $variable"
+		exit 1
+	}
+}
+
+set timeout 30
+log_file -noappend $env(QEMU_LOG)
+set command [list \
+	$env(QEMU) \
+	-machine virt \
+	-bios $env(SBI_FIRMWARE) \
+	-kernel $env(KERNEL) \
+	-m 64M \
+	-smp 1 \
+	-nographic]
+
+spawn -noecho {*}$command
+expect {
+	-re {kernel stack overflow: CPU=0 sp=0x[0-9a-f]+} {}
+	-re {\[PANIC\]} { abort_test "unexpected panic" }
+	timeout { abort_test "overflow diagnostic timeout" }
+	eof { abort_test "QEMU exited before the overflow diagnostic" }
+}
+expect {
+	-re {\[PANIC\]: kernel stack overflow} {}
+	timeout { abort_test "overflow panic timeout" }
+	eof { abort_test "QEMU exited before the overflow panic" }
+}
+
+send -- "\001x"
+expect {
+	eof {}
+	timeout { abort_test "QEMU exit timeout" }
+}
+
+puts "KERNEL_STACK_GUARD_OK"


### PR DESCRIPTION
The RISC-V port reserves secondary stacks and per-CPU state using a
compile-time CPU limit. This rejects larger firmware topologies and
wastes memory on smaller systems. Runtime scheduler stacks also remain
on directly mapped boot storage, so an overflow can corrupt adjacent
memory.

Build the CPU topology from the device tree and allocate scheduler,
timer, PLIC, network, and lwIP state for the discovered harts. Use the
SBI HSM opaque argument for a temporary secondary boot stack, then
switch each hart to an aligned Sv39 stack with unmapped guard regions.
Detect overflow before saving trap registers and report it from a
per-CPU emergency stack.

Keep the boot-stack overflow and heap-alignment fixes exposed by
removing the static arrays as separate patches.

Tested with clean builds, Linux UAPI and OpenSBI checks, QEMU boots with
1, 2, 3, 4, 8, and 9 harts across 64 MiB to 256 MiB, the full guest
runtime suite, the CFS performance benchmark, and a deliberate
kernel-stack guard fault.