### PR TITLE
printk: add timestamped boot diagnostics

### DIFF
--- a/arch/riscv/boot/Makefile
+++ b/arch/riscv/boot/Makefile
@@ -1,4 +1,5 @@
-EXTRA_CFLAGS := -I ../../../include -I ../include
+EXTRA_CFLAGS := -I ../../../include -I ../../../kernel/include \
+	-I ../include
 CFLAGS_file.o := 
 
 

--- a/arch/riscv/boot/setup.c
+++ b/arch/riscv/boot/setup.c
@@ -11,6 +11,7 @@
 #include <riscv.h>
 #include <boot.h>
 #include <cpu.h>
+#include <ktime.h>
 
 extern void main(void);
 
@@ -24,6 +25,7 @@ void setup(uint64 hart_id, uint64 dtb_address)
 	/* The standard next-stage contract enters with paging disabled. */
 	satp_w(0);
 	sfence_vma();
+	ktime_boot_init(time_r());
 	boot_hart_id = hart_id;
 	boot_dtb_address = dtb_address;
 	/* Caffeinix uses tp as a dense logical CPU ID. */

--- a/arch/riscv/cpu.c
+++ b/arch/riscv/cpu.c
@@ -4,7 +4,7 @@
 #include <mem_layout.h>
 #include <of.h>
 #include <palloc.h>
-#include <printf.h>
+#include <printk.h>
 #include <riscv.h>
 #include <sbi.h>
 #include <scheduler.h>
@@ -184,7 +184,7 @@ void cpu_secondary_boot_stack_release(void)
 
 static void cpu_start_failed(int logical_id, int64 error)
 {
-	printf("CPU: logical=%d hart=%p SBI error=%d\n", logical_id,
+	pr_err("CPU: logical=%d hart=%p SBI error=%d", logical_id,
 	       cpu_hart_id(logical_id), (int)error);
 	PANIC("secondary hart start failed");
 }
@@ -202,7 +202,7 @@ void cpu_start_secondary_harts(void)
 		if (error)
 			cpu_start_failed(logical, error);
 		if (status != SBI_HSM_STATE_STOPPED) {
-			printf("CPU: logical=%d hart=%p HSM state=%d\n", logical,
+			pr_err("CPU: logical=%d hart=%p HSM state=%d", logical,
 			       cpu_hart_id(logical), (int)status);
 			PANIC("secondary hart is not stopped");
 		}
@@ -234,8 +234,8 @@ void cpu_mark_online(void)
 	__sync_synchronize();
 	cpus[logical]->online = 1;
 	__sync_synchronize();
-	printf("CPU: logical=%d hart=%p online\n", logical,
-	       cpus[logical]->hart_id);
+	pr_info("CPU: logical=%d hart=%p online", logical,
+		cpus[logical]->hart_id);
 }
 
 void cpu_wait_for_secondary_harts(void)
@@ -253,7 +253,7 @@ void cpu_wait_for_secondary_harts(void)
 			return;
 		if (time_r() - start < timeout)
 			continue;
-		printf("CPU: logical=%d hart=%p online timeout\n", logical,
+		pr_err("CPU: logical=%d hart=%p online timeout", logical,
 		       cpu_hart_id(logical));
 		PANIC("secondary hart online timeout");
 	}

--- a/arch/riscv/include/timer.h
+++ b/arch/riscv/include/timer.h
@@ -3,6 +3,7 @@
 
 #include <typedefs.h>
 
+void timer_early_init(void);
 void timer_init(void);
 void timer_init_hart(void);
 void timer_wait_for_interrupt(void);

--- a/arch/riscv/sbi.c
+++ b/arch/riscv/sbi.c
@@ -1,5 +1,5 @@
 #include <debug.h>
-#include <printf.h>
+#include <printk.h>
 #include <sbi.h>
 
 #define SBI_EXT_BASE 0x10
@@ -99,8 +99,8 @@ void sbi_report(void)
 	uint64 major = (sbi_spec_version >> 24) & 0x7f;
 	uint64 minor = sbi_spec_version & 0xffffff;
 
-	printf("SBI: spec=%d.%d implementation=%d version=%p\n",
-	       (int)major, (int)minor, (int)sbi_impl_id, sbi_impl_version);
+	pr_info("SBI: spec=%d.%d implementation=%d version=%p",
+		(int)major, (int)minor, (int)sbi_impl_id, sbi_impl_version);
 }
 
 int64 sbi_set_timer(uint64 deadline)

--- a/arch/riscv/timer.c
+++ b/arch/riscv/timer.c
@@ -20,7 +20,7 @@ struct timer_cpu_state {
 
 static struct timer_cpu_state *timer_cpus;
 
-void timer_init(void)
+void timer_early_init(void)
 {
 	struct device_node *cpus = of_find_node_by_path("/cpus");
 	uint32 frequency;
@@ -34,6 +34,12 @@ void timer_init(void)
 	idle_tick_interval = clock_frequency * IDLE_TICK_INTERVAL / 1000;
 	if (!tick_interval || !idle_tick_interval)
 		PANIC("invalid timer interval");
+}
+
+void timer_init(void)
+{
+	if (!clock_frequency)
+		PANIC("timer clocksource is not initialized");
 	timer_cpus = calloc(cpu_count(), sizeof(*timer_cpus));
 	if (!timer_cpus)
 		PANIC("allocate timer CPU state");

--- a/arch/riscv/timer.c
+++ b/arch/riscv/timer.c
@@ -3,7 +3,7 @@
 #include <kernel_config.h>
 #include <of.h>
 #include <palloc.h>
-#include <printf.h>
+#include <printk.h>
 #include <riscv.h>
 #include <sbi.h>
 #include <scheduler.h>
@@ -82,7 +82,7 @@ void timer_interrupt(void)
 		PANIC("SBI timer rearm failed");
 	if (!timer_cpus[logical].seen) {
 		timer_cpus[logical].seen = 1;
-		printf("CPU: logical=%d timer active\n", logical);
+		pr_info("CPU: logical=%d timer active", logical);
 	}
 }
 

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -5,6 +5,7 @@
 #include <scheduler.h>
 #include <printf.h>
 #include <plic.h>
+#include <printk.h>
 #include <timer.h>
 #include <wait.h>
 
@@ -39,9 +40,9 @@ static int dev_intr(uint64 scause)
         else if((scause & 0x8000000000000000L) &&
                 (scause & 0xff) == 9) {
                 /* Get interrupt number from PLIC */
-                irq = plic_claim();
+		irq = plic_claim();
 		if (irq && irq_dispatch(irq) != IRQ_HANDLED)
-			printf("Unhandled interrupt irq=%d\n", irq);
+			pr_err("irq: unhandled interrupt %d", irq);
                 if(irq) {
                         /* Clear the interrupt flag */
                         plic_complete(irq);

--- a/drivers/block/virtio_blk.c
+++ b/drivers/block/virtio_blk.c
@@ -2,6 +2,7 @@
 #include <debug.h>
 #include <mystring.h>
 #include <palloc.h>
+#include <printk.h>
 #include <spinlock.h>
 #include <virtio.h>
 #include <virtio_ring.h>
@@ -180,6 +181,9 @@ static int virtio_blk_probe(struct virtio_device *device)
 		goto failed;
 	disk->name[10] = '0' + disk->block.id - 1;
 	dev_set_drvdata(&device->device, disk);
+	pr_info("%s: %lu sectors (%lu MiB)", disk->name,
+		disk->block.sector_count,
+		disk->block.sector_count / 2048);
 	return DRIVER_OK;
 
 failed:

--- a/drivers/net/virtio_net.c
+++ b/drivers/net/virtio_net.c
@@ -2,7 +2,7 @@
 #include <mystring.h>
 #include <netdevice.h>
 #include <palloc.h>
-#include <printf.h>
+#include <printk.h>
 #include <virtio.h>
 #include <virtio_ring.h>
 #include <workqueue.h>
@@ -290,7 +290,11 @@ static int virtio_net_probe(struct virtio_device *device)
 	if (net_device_register(&network->netdev) < 0)
 		goto failed;
 	dev_set_drvdata(&device->device, network);
-	printf("virtio-net: registered %s\n", network->netdev.name);
+	pr_info("%s: virtio-net MAC %02x:%02x:%02x:%02x:%02x:%02x",
+		network->netdev.name, network->netdev.address[0],
+		network->netdev.address[1], network->netdev.address[2],
+		network->netdev.address[3], network->netdev.address[4],
+		network->netdev.address[5]);
 	return DRIVER_OK;
 
 failed:

--- a/drivers/of/core.c
+++ b/drivers/of/core.c
@@ -111,6 +111,21 @@ struct device_node *of_root_node(void)
 	return of_node_count ? &of_nodes[0] : 0;
 }
 
+const char *of_machine_model(void)
+{
+	struct device_node *root = of_root_node();
+	const char *property;
+	int length;
+
+	property = of_get_property(root, "model", &length);
+	if (property && length > 1 && property[length - 1] == 0)
+		return property;
+	property = of_get_property(root, "compatible", &length);
+	if (property && length > 1 && memchr(property, 0, length))
+		return property;
+	return 0;
+}
+
 struct device_node *of_next_node(struct device_node *node)
 {
 	if (!of_node_count)

--- a/drivers/tty/serial/uart.c
+++ b/drivers/tty/serial/uart.c
@@ -4,6 +4,7 @@
 #include <device_model.h>
 #include <irq.h>
 #include <mystring.h>
+#include <printk.h>
 #include <spinlock.h>
 #include <tty.h>
 #include <uart.h>
@@ -134,6 +135,9 @@ int uart_add_one_port(struct uart_port *port)
 	status = console_register(&port->console);
 	if (status < 0)
 		goto free_interrupt;
+	if (port->of_node)
+		pr_info("console: %s at %p irq=%u", port->tty.name,
+			port->mapbase, port->irq);
 	return DRIVER_OK;
 
 free_interrupt:

--- a/drivers/virtio/mmio.c
+++ b/drivers/virtio/mmio.c
@@ -5,6 +5,7 @@
 #include <of.h>
 #include <palloc.h>
 #include <platform_device.h>
+#include <printk.h>
 #include <resource.h>
 #include <virtio.h>
 #include <virtio_ring.h>
@@ -325,6 +326,8 @@ static int virtio_mmio_probe(struct platform_device *platform)
 			     device->name);
 	if (status < 0)
 		goto invalid;
+	pr_info("virtio-mmio: %s id=%u at %p irq=%u", device->name, id,
+		resource->start, device->irq);
 	dev_set_drvdata(&platform->device, device);
 	status = virtio_device_register(&device->virtio);
 	if (status < 0) {

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -2,7 +2,8 @@ EXTRA_CFLAGS := -I ./include -I ../arch/riscv/include -I ../include
 CFLAGS_file.o := 
 
 
-obj-y += string.o palloc.o spinlock.o rbtree.o ktime.o thread.o wait.o \
+obj-y += string.o palloc.o spinlock.o rbtree.o ktime.o timeconv.o \
+printk.o thread.o wait.o \
 sleeplock.o switchto.o trampoline.o process.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o workqueue.o main.o

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -4,6 +4,7 @@
 #include <ktime.h>
 #include <mystring.h>
 #include <palloc.h>
+#include <printk.h>
 #include <process.h>
 #include <scheduler.h>
 #include <spinlock.h>
@@ -390,6 +391,8 @@ int vfs_mount_root(const char *filesystem, struct block_device *device,
 	spinlock_acquire(&vfs.lock);
 	vfs.root = mount;
 	spinlock_release(&vfs.lock);
+	pr_info("VFS: mounted root (%s) on %s", filesystem,
+		device ? device->name : "none");
 	return VFS_OK;
 }
 
@@ -704,6 +707,7 @@ int vfs_mount(const char *filesystem, struct block_device *device,
 	mount->root = root;
 	mount->parent = mountpoint.mount;
 	mount->mountpoint = mountpoint;
+	pr_info("VFS: mounted %s on %s", filesystem, target);
 	return VFS_OK;
 }
 

--- a/kernel/include/ktime.h
+++ b/kernel/include/ktime.h
@@ -3,9 +3,14 @@
 
 #include <typedefs.h>
 
+#define NSEC_PER_SEC 1000000000ULL
+
+void ktime_boot_init(uint64 ticks);
 uint64 ktime_get_ticks(void);
 uint64 ktime_get_ms(void);
 uint64 ktime_get_ns(void);
+uint64 ktime_get_boot_ns(void);
+uint64 ktime_ticks_to_ns(uint64 ticks, uint32 frequency);
 uint64 ktime_ms_to_ticks(uint64 milliseconds);
 
 #endif

--- a/kernel/include/of.h
+++ b/kernel/include/of.h
@@ -23,6 +23,7 @@ struct device_node {
 int of_init(const void *fdt);
 const void *of_fdt(void);
 struct device_node *of_root_node(void);
+const char *of_machine_model(void);
 struct device_node *of_next_node(struct device_node *node);
 struct device_node *of_find_node_by_path(const char *path);
 struct device_node *of_stdout_node(void);

--- a/kernel/include/palloc.h
+++ b/kernel/include/palloc.h
@@ -12,6 +12,7 @@ int palloc_memory_range_count(void);
 int palloc_memory_range_get(int index, uint64 *start, uint64 *end);
 int palloc_page_usable(uint64 address);
 uint64 palloc_heap_start(void);
+uint64 palloc_usable_bytes(void);
 
 void* malloc(uint64 size);
 void* calloc(size_t count, size_t size);

--- a/kernel/include/printf.h
+++ b/kernel/include/printf.h
@@ -1,11 +1,16 @@
 #ifndef __CAFFEINIX_KERNEL_PRINTF_H
 #define __CAFFEINIX_KERNEL_PRINTF_H
 
+#include <stdarg.h>
 #include <typedefs.h>
 #include <console.h>
 
+typedef void (*printf_emit_t)(int character, void *context);
+
 void printf_init(void);
 void printf(char* fmt, ...);
+void vprintf_emit(printf_emit_t emit, void *context, const char *fmt,
+		  va_list arguments);
 void printf_enter_panic(void);
 
 #endif

--- a/kernel/include/printk.h
+++ b/kernel/include/printk.h
@@ -1,0 +1,56 @@
+#ifndef __CAFFEINIX_KERNEL_PRINTK_H
+#define __CAFFEINIX_KERNEL_PRINTK_H
+
+#include <typedefs.h>
+
+#define PRINTK_TEXT_MAX 192
+#define PRINTK_RECORD_MAX 128
+
+enum printk_level {
+	PRINTK_EMERG = 0,
+	PRINTK_ALERT,
+	PRINTK_CRIT,
+	PRINTK_ERR,
+	PRINTK_WARN,
+	PRINTK_NOTICE,
+	PRINTK_INFO,
+	PRINTK_DEBUG,
+	PRINTK_LEVEL_COUNT,
+};
+
+struct printk_record {
+	uint64 sequence;
+	uint64 timestamp_ns;
+	uint16 length;
+	uint8 level;
+	char text[PRINTK_TEXT_MAX];
+};
+
+void printk_init(void);
+void printk(enum printk_level level, const char *format, ...);
+void printk_enter_panic(void);
+void printk_set_console_level(enum printk_level level);
+enum printk_level printk_get_console_level(void);
+const char *printk_level_name(enum printk_level level);
+uint64 printk_first_sequence(void);
+uint64 printk_next_sequence(void);
+int printk_read_record(uint64 sequence, struct printk_record *record);
+
+#define pr_emerg(format, ...) \
+	printk(PRINTK_EMERG, format, ##__VA_ARGS__)
+#define pr_alert(format, ...) \
+	printk(PRINTK_ALERT, format, ##__VA_ARGS__)
+#define pr_crit(format, ...) \
+	printk(PRINTK_CRIT, format, ##__VA_ARGS__)
+#define pr_err(format, ...) \
+	printk(PRINTK_ERR, format, ##__VA_ARGS__)
+#define pr_warn(format, ...) \
+	printk(PRINTK_WARN, format, ##__VA_ARGS__)
+#define pr_notice(format, ...) \
+	printk(PRINTK_NOTICE, format, ##__VA_ARGS__)
+#define pr_info(format, ...) \
+	printk(PRINTK_INFO, format, ##__VA_ARGS__)
+#define pr_debug(format, ...) \
+	printk(PRINTK_DEBUG, format, ##__VA_ARGS__)
+
+#endif

--- a/kernel/ktime.c
+++ b/kernel/ktime.c
@@ -2,8 +2,14 @@
 #include <riscv.h>
 #include <timer.h>
 
-#define NSEC_PER_SEC 1000000000ULL
 #define MSEC_PER_SEC 1000ULL
+
+static uint64 boot_ticks;
+
+void ktime_boot_init(uint64 ticks)
+{
+	boot_ticks = ticks;
+}
 
 uint64 ktime_get_ticks(void)
 {
@@ -21,11 +27,13 @@ uint64 ktime_get_ms(void)
 
 uint64 ktime_get_ns(void)
 {
-	uint64 ticks = time_r();
-	uint64 frequency = timer_frequency();
+	return ktime_ticks_to_ns(time_r(), timer_frequency());
+}
 
-	return ticks / frequency * NSEC_PER_SEC +
-	       ticks % frequency * NSEC_PER_SEC / frequency;
+uint64 ktime_get_boot_ns(void)
+{
+	return ktime_ticks_to_ns(time_r() - boot_ticks,
+				 timer_frequency());
 }
 
 uint64 ktime_ms_to_ticks(uint64 milliseconds)

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -98,13 +98,13 @@ static void main_boot(void)
 	tmpfs_init();
 	userinit();
 
-	printf("Hello! Caffeinix\n");
 	timer_wait_for_interrupt();
 	cpu_mark_online();
 	cpu_start_secondary_harts();
 	__sync_synchronize();
 	start = 1;
 	cpu_wait_for_secondary_harts();
+	pr_info("smp: brought up %d CPUs", cpu_count());
 	scheduler();
 	for (;;)
 		;
@@ -127,6 +127,7 @@ void main(void)
 {
 	if (cpuid() == 0) {
 		int of_status = of_init((void *)boot_dtb_address);
+		const char *machine;
 
 		console_early_init();
 		if (of_status < 0)
@@ -134,10 +135,22 @@ void main(void)
 		timer_early_init();
 		printf_init();
 		printk_init();
+		pr_info("Caffeinix RISC-V 64-bit");
+		machine = of_machine_model();
+		if (machine)
+			pr_info("OF: machine: %s", machine);
+		else
+			pr_warn("OF: machine model is unavailable");
+		pr_info("clocksource: riscv timer at %lu MHz",
+			timer_frequency() / 1000000);
 		palloc_init();
 		cpu_topology_init(boot_hart_id);
 		sbi_init(cpu_count());
 		timer_init();
+		sbi_report();
+		pr_info("memory: %lu MiB usable",
+			palloc_usable_bytes() / (1024 * 1024));
+		pr_info("smp: detected %d CPUs", cpu_count());
 		file_init();
 		vfs_init();
 		irq_init();
@@ -145,11 +158,11 @@ void main(void)
 		plic_init_hart();
 		char_device_init();
 		tty_init();
-		sbi_report();
 		kvm_create();
 		if (kvm_map_mmio(earlycon_address(), earlycon_size()) < 0)
 			PANIC("map early console");
 		kvm_init();
+		pr_info("mmu: Sv39 enabled");
 		if (cpu_kernel_stack_selftest() < 0)
 			PANIC("kernel stack guards");
 		cpu_enter_stack(cpu_scheduler_stack_top(), main_boot);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -16,6 +16,7 @@
 #include <scheduler.h>
 #include <trap.h>
 #include <printf.h>
+#include <printk.h>
 #include <plic.h>
 #include <process.h>
 #include <block_device.h>
@@ -130,6 +131,9 @@ void main(void)
 		console_early_init();
 		if (of_status < 0)
 			PANIC("invalid boot DTB");
+		timer_early_init();
+		printf_init();
+		printk_init();
 		palloc_init();
 		cpu_topology_init(boot_hart_id);
 		sbi_init(cpu_count());
@@ -141,7 +145,6 @@ void main(void)
 		plic_init_hart();
 		char_device_init();
 		tty_init();
-		printf_init();
 		sbi_report();
 		kvm_create();
 		if (kvm_map_mmio(earlycon_address(), earlycon_size()) < 0)

--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -74,6 +74,7 @@ static struct palloc_range reserved_ranges[PALLOC_RESERVED_RANGE_MAX];
 static int memory_range_count;
 static int reserved_range_count;
 static uint64 heap_start;
+static uint64 usable_bytes;
 
 _Static_assert((MALLOC_ALIGNMENT & (MALLOC_ALIGNMENT - 1)) == 0,
 	       "malloc alignment must be a power of two");
@@ -138,6 +139,11 @@ uint64 palloc_heap_start(void)
 	return heap_start;
 }
 
+uint64 palloc_usable_bytes(void)
+{
+	return usable_bytes;
+}
+
 static void palloc_discover_memory(void)
 {
 	struct of_memory_range range;
@@ -197,6 +203,7 @@ void palloc_init(void)
 	}
 	if (!pages)
 		PANIC("no usable memory");
+	usable_bytes = (uint64)pages * PGSIZE;
 	palloc_heap_alignment_selftest();
 }
 

--- a/kernel/plic.c
+++ b/kernel/plic.c
@@ -4,6 +4,7 @@
 #include <irq.h>
 #include <of.h>
 #include <palloc.h>
+#include <printk.h>
 #include <scheduler.h>
 
 #define RISCV_IRQ_S_EXT 9
@@ -95,6 +96,7 @@ void plic_init(void)
 
 	for (irq = 1; irq < IRQ_MAX; irq++)
 		*(uint32 *)(PLIC + irq * 4) = 0;
+	pr_info("irq: PLIC configured for %d CPUs", cpu_count());
 }
 
 void plic_init_hart(void)

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -3,8 +3,6 @@
 #include <spinlock.h>
 #include <debug.h>
 
-volatile uint8 paniced = 0;
-
 static const char digits[] = "0123456789abcdef";
 static struct {
         struct spinlock lock;
@@ -12,108 +10,134 @@ static struct {
         uint8 locking;
 }pf;
 
-/* Print a integer */
-static void print_int(uint32 number, uint8 base, uint8 sign)
+static void console_emit(int character, void *context)
 {
-        char buf[16];
-        int i, negative;
-        uint32 num;
-
-        negative = sign && (int32)number < 0;
-        num = negative ? -number : number;
-
-        i = 0;
-        /* Get each digit into the buffer 'buf' */
-        do {
-                buf[i++] = digits[num % base];
-        } while((num /= base) != 0);
-        /* We should add a negative symbol at the end if the sign == 1 */
-        if(negative)
-                buf[i++] = '-';
-        /* Inverted output */
-        while(--i >= 0)
-                console_putc(buf[i]);
+	(void)context;
+	console_putc(character);
 }
 
-/* Print a pointer */
-static void print_ptr(uint64 ptr)
+static void emit_number(printf_emit_t emit, void *context, uint64 number,
+			uint8 base, int negative, int width, int zero_pad)
+{
+	char buffer[32];
+	int length = 0;
+	int padding;
+
+        do {
+		buffer[length++] = digits[number % base];
+	} while ((number /= base) != 0);
+	padding = width - length - negative;
+	if (negative && zero_pad)
+		emit('-', context);
+	while (padding-- > 0)
+		emit(zero_pad ? '0' : ' ', context);
+	if (negative && !zero_pad)
+		emit('-', context);
+	while (--length >= 0)
+		emit(buffer[length], context);
+}
+
+static void emit_pointer(printf_emit_t emit, void *context, uint64 pointer)
 {
         int i;
-        console_putc('0');
-        console_putc('x');
-        /* Output every 4 bits as a number */
-        for (i = 0; i < (sizeof(uint64) * 2); i++, ptr <<= 4)
-                console_putc(digits[ptr >> (sizeof(uint64) * 8 - 4)]);
+
+	emit('0', context);
+	emit('x', context);
+	for (i = 0; i < 16; i++, pointer <<= 4)
+		emit(digits[pointer >> (sizeof(uint64) * 8 - 4)], context);
+}
+
+void vprintf_emit(printf_emit_t emit, void *context, const char *fmt,
+		  va_list arguments)
+{
+	int c, i;
+	char *s;
+
+	if (!emit || !fmt)
+		PANIC("printf format");
+	for (i = 0; (c = fmt[i] & 0xff) != 0; i++) {
+		int is_long = 0;
+		int width = 0;
+		int zero_pad = 0;
+
+		if (c != '%') {
+			emit(c, context);
+			continue;
+		}
+		c = fmt[++i] & 0xff;
+		if (c == '0') {
+			zero_pad = 1;
+			c = fmt[++i] & 0xff;
+		}
+		while (c >= '0' && c <= '9') {
+			width = width * 10 + c - '0';
+			c = fmt[++i] & 0xff;
+		}
+		if (c == 'l') {
+			is_long = 1;
+			c = fmt[++i] & 0xff;
+		}
+		switch (c) {
+		case 'd': {
+			int64 value = is_long ? va_arg(arguments, int64) :
+				va_arg(arguments, int);
+			int negative = value < 0;
+			uint64 magnitude = negative ? 0 - (uint64)value :
+				(uint64)value;
+
+			emit_number(emit, context, magnitude, 10, negative,
+				    width, zero_pad);
+			break;
+		}
+		case 'u':
+			emit_number(emit, context,
+				    is_long ? va_arg(arguments, uint64) :
+				    va_arg(arguments, uint32),
+				    10, 0, width, zero_pad);
+			break;
+		case 'x':
+			emit_number(emit, context,
+				    is_long ? va_arg(arguments, uint64) :
+				    va_arg(arguments, uint32),
+				    16, 0, width, zero_pad);
+			break;
+		case 'p':
+			emit_pointer(emit, context, va_arg(arguments, uint64));
+			break;
+		case 's':
+			s = va_arg(arguments, char *);
+			if (!s)
+				s = "(null)";
+			while (*s)
+				emit(*s++, context);
+			break;
+		case '%':
+			emit('%', context);
+			break;
+		case 'c':
+			emit(va_arg(arguments, int), context);
+			break;
+		default:
+			emit('%', context);
+			emit(c, context);
+			break;
+		}
+        }
 }
 
 void printf(char* fmt, ...)
 {
-        va_list ap;
-        int i, c, locking;
-        char *s;
+	va_list arguments;
+	int locking = pf.locking;
 
-        locking = pf.locking;
-        if(locking)
-                spinlock_acquire(&pf.lock);
+	if (locking)
+		spinlock_acquire(&pf.lock);
+	va_start(arguments, fmt);
+	vprintf_emit(console_emit, 0, fmt, arguments);
+	va_end(arguments);
 
-        if(fmt == 0)
-                PANIC("printf");
-
-        va_start(ap, fmt);
-        for(i = 0; (c = fmt[i] & 0xff) != 0; i++) {
-                /* We directly output if no converting symbol */
-                if(c != '%'){
-                        console_putc(c);
-                        continue;
-                }
-                /* Get next character if converting symbol */
-                c = fmt[++i] & 0xff;
-                switch(c) {
-                        /* Dec */
-                        case 'd':
-                                print_int(va_arg(ap, int), 10, 1);
-                                break;
-                        /* Hex */
-                        case 'x':
-                                print_int(va_arg(ap, uint32), 16, 0);
-                                break;
-                        /* Pointer */
-                        case 'p':
-                                print_ptr(va_arg(ap, uint64));
-                                break;
-                        /* String */
-                        case 's':
-                                if((s = va_arg(ap, char*)) == 0)
-                                s = "(null)";
-                                for(; *s; s++)
-                                        console_putc(*s);
-                                break;
-                        /* % */
-                        case '%':
-                                console_putc('%');
-                                break;
-                        case 'c':
-                                console_putc(va_arg(ap, int));
-                                break;
-                        /* Unknown converting symbol */
-                        default:     
-                                console_putc('%');
-                                console_putc(c);
-                                break;   
-                }
-        }
-        va_end(ap);
-
-        if(locking)
-                spinlock_release(&pf.lock);
-}
-
-void panic(char* s)
-{
-	printf_enter_panic();
-        printf("[PANIC]: %s\n", s);
-        paniced = 1;
-        for(;;);
+	if (locking)
+		spinlock_release(&pf.lock);
 }
 
 void printf_enter_panic(void)

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -1,0 +1,213 @@
+#include <debug.h>
+#include <ktime.h>
+#include <mystring.h>
+#include <printf.h>
+#include <printk.h>
+#include <spinlock.h>
+#include <stdarg.h>
+
+volatile uint8 paniced;
+
+static const char *const printk_level_names[] = {
+	"emerg", "alert", "crit", "err",
+	"warn", "notice", "info", "debug",
+};
+
+static struct {
+	struct spinlock lock;
+	struct printk_record records[PRINTK_RECORD_MAX];
+	uint64 next_sequence;
+	uint64 last_timestamp_ns;
+	enum printk_level console_level;
+	uint8 initialized;
+	uint8 locking;
+} printk_state;
+
+struct printk_buffer {
+	char *text;
+	uint32 capacity;
+	uint32 length;
+};
+
+static int printk_lock(void)
+{
+	int locking = printk_state.locking;
+
+	if (locking)
+		spinlock_acquire(&printk_state.lock);
+	return locking;
+}
+
+static void printk_unlock(int locking)
+{
+	if (locking)
+		spinlock_release(&printk_state.lock);
+}
+
+static uint64 printk_first_sequence_locked(void)
+{
+	uint64 next = printk_state.next_sequence;
+
+	return next > PRINTK_RECORD_MAX ? next - PRINTK_RECORD_MAX : 0;
+}
+
+static void printk_buffer_emit(int character, void *context)
+{
+	struct printk_buffer *buffer = context;
+
+	if (buffer->length + 1 < buffer->capacity)
+		buffer->text[buffer->length++] = character;
+}
+
+static void printk_format(struct printk_record *record, const char *format,
+			  va_list arguments)
+{
+	struct printk_buffer buffer = {
+		.text = record->text,
+		.capacity = sizeof(record->text),
+	};
+
+	vprintf_emit(printk_buffer_emit, &buffer, format, arguments);
+	if (!buffer.length || buffer.text[buffer.length - 1] != '\n') {
+		if (buffer.length + 1 < buffer.capacity)
+			buffer.text[buffer.length++] = '\n';
+		else
+			buffer.text[buffer.length - 1] = '\n';
+	}
+	buffer.text[buffer.length] = 0;
+	record->length = buffer.length;
+}
+
+static void printk_store(const struct printk_record *record)
+{
+	printk_state.records[record->sequence % PRINTK_RECORD_MAX] = *record;
+}
+
+static void printk_console(const struct printk_record *record)
+{
+	uint64 seconds = record->timestamp_ns / NSEC_PER_SEC;
+	uint64 microseconds = record->timestamp_ns % NSEC_PER_SEC / 1000;
+
+	printf("[%5lu.%06lu] %s", seconds, microseconds, record->text);
+}
+
+void printk_init(void)
+{
+	memset(&printk_state, 0, sizeof(printk_state));
+	spinlock_init(&printk_state.lock, "printk");
+	printk_state.console_level = PRINTK_INFO;
+	printk_state.locking = 1;
+	printk_state.initialized = 1;
+}
+
+void printk(enum printk_level level, const char *format, ...)
+{
+	struct printk_record record = { 0 };
+	va_list arguments;
+	int locking;
+
+	if (level < PRINTK_EMERG || level >= PRINTK_LEVEL_COUNT)
+		level = PRINTK_ERR;
+	va_start(arguments, format);
+	printk_format(&record, format, arguments);
+	va_end(arguments);
+	if (!printk_state.initialized) {
+		printf("%s", record.text);
+		return;
+	}
+	locking = printk_lock();
+	record.sequence = printk_state.next_sequence++;
+	record.timestamp_ns = ktime_get_boot_ns();
+	if (record.timestamp_ns < printk_state.last_timestamp_ns)
+		record.timestamp_ns = printk_state.last_timestamp_ns;
+	else
+		printk_state.last_timestamp_ns = record.timestamp_ns;
+	record.level = level;
+	printk_store(&record);
+	if (level <= printk_state.console_level)
+		printk_console(&record);
+	printk_unlock(locking);
+}
+
+void panic(char *message)
+{
+	paniced = 1;
+	printk_enter_panic();
+	pr_emerg("[PANIC]: %s", message);
+	for (;;)
+		;
+}
+
+void printk_enter_panic(void)
+{
+	printk_state.locking = 0;
+	printf_enter_panic();
+}
+
+void printk_set_console_level(enum printk_level level)
+{
+	int locking;
+
+	if (level < PRINTK_EMERG || level >= PRINTK_LEVEL_COUNT)
+		return;
+	locking = printk_lock();
+	printk_state.console_level = level;
+	printk_unlock(locking);
+}
+
+enum printk_level printk_get_console_level(void)
+{
+	enum printk_level level;
+	int locking = printk_lock();
+
+	level = printk_state.console_level;
+	printk_unlock(locking);
+	return level;
+}
+
+const char *printk_level_name(enum printk_level level)
+{
+	if (level < PRINTK_EMERG || level >= PRINTK_LEVEL_COUNT)
+		return "unknown";
+	return printk_level_names[level];
+}
+
+uint64 printk_first_sequence(void)
+{
+	uint64 sequence;
+	int locking = printk_lock();
+
+	sequence = printk_first_sequence_locked();
+	printk_unlock(locking);
+	return sequence;
+}
+
+uint64 printk_next_sequence(void)
+{
+	uint64 sequence;
+	int locking = printk_lock();
+
+	sequence = printk_state.next_sequence;
+	printk_unlock(locking);
+	return sequence;
+}
+
+int printk_read_record(uint64 sequence, struct printk_record *record)
+{
+	uint64 first;
+	int result = -1;
+	int locking;
+
+	if (!record || !printk_state.initialized)
+		return -1;
+	locking = printk_lock();
+	first = printk_first_sequence_locked();
+	if (sequence >= first && sequence < printk_state.next_sequence &&
+	    printk_state.records[sequence % PRINTK_RECORD_MAX].sequence ==
+		sequence) {
+		*record = printk_state.records[sequence % PRINTK_RECORD_MAX];
+		result = 0;
+	}
+	printk_unlock(locking);
+	return result;
+}

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -17,6 +17,7 @@
 #include <mystring.h>
 #include <file.h>
 #include <block_device.h>
+#include <printk.h>
 #include <vfs.h>
 
 /* From trampoline.S */
@@ -64,13 +65,18 @@ static struct block_device *mount_root_device(void)
 static void mount_fat_device(struct block_device *root)
 {
 	struct block_device *device;
+	int status;
 	uint32 id;
 
 	for (id = 1; id < BLOCK_DEVICE_MAX; id++) {
 		device = block_device_get(id);
-		if (device && device != root &&
-		    vfs_mount("fat", device, "/mnt/fat", 0) == VFS_OK)
+		if (!device || device == root)
+			continue;
+		status = vfs_mount("fat", device, "/mnt/fat", 0);
+		if (status == VFS_OK)
 			return;
+		pr_warn("VFS: cannot mount %s as fat: %d", device->name,
+			status);
 	}
 }
 
@@ -166,24 +172,42 @@ static void proc_first_start(void)
 	process_t process = cur_proc();
 
         /* The function scheduler will acquire the lock */
-        spinlock_release(&cur_thread()->lock);
+	spinlock_release(&cur_thread()->lock);
 	if (!fs_started) {
+		int status;
+
 		fs_started = 1;
 		root_device = mount_root_device();
-		if (!root_device)
+		if (!root_device) {
+			pr_err("VFS: cannot mount root filesystem %s",
+				ROOT_FILESYSTEM);
 			PANIC("mount root");
+		}
 		if (vfs_get_root(&process->root) < 0)
 			PANIC("process root");
 		vfs_path_copy(&process->cwd, &process->root);
-		if (vfs_mount("devfs", 0, "/dev", 0) < 0)
+		status = vfs_mount("devfs", 0, "/dev", 0);
+		if (status < 0) {
+			pr_err("VFS: cannot mount devfs on /dev: %d", status);
 			PANIC("mount devfs");
-		if (vfs_mount("tmpfs", 0, "/tmp", 0) < 0)
+		}
+		status = vfs_mount("tmpfs", 0, "/tmp", 0);
+		if (status < 0) {
+			pr_err("VFS: cannot mount tmpfs on /tmp: %d", status);
 			PANIC("mount tmpfs");
+		}
 		mount_fat_device(root_device);
-		if (setup_stdio() < 0)
+		status = setup_stdio();
+		if (status < 0) {
+			pr_err("init: cannot configure standard I/O: %d", status);
 			PANIC("stdio setup");
-		if (exec_linux(INIT_PATH, argv, envp) < 0)
+		}
+		pr_info("init: starting %s", INIT_PATH);
+		status = exec_linux(INIT_PATH, argv, envp);
+		if (status < 0) {
+			pr_err("init: cannot execute %s: %d", INIT_PATH, status);
 			PANIC("exec init");
+		}
 	}
         extern void user_trap_ret(void);
         user_trap_ret();

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1,7 +1,7 @@
 #include <debug.h>
 #include <linux_uapi.h>
 #include <mystring.h>
-#include <printf.h>
+#include <printk.h>
 #include <scheduler.h>
 #include <syscall.h>
 #include <vm.h>
@@ -205,7 +205,7 @@ void syscall(void)
 		return;
 	}
 
-	printf("Unsupported Linux syscall %d from pid %d (%s)\n",
-	       nr, p->pid, p->name);
+	pr_warn("syscall: unsupported Linux call %lu from pid %d (%s)",
+		nr, p->pid, p->name);
 	current->trapframe->a0 = -LINUX_ENOSYS;
 }

--- a/kernel/timeconv.c
+++ b/kernel/timeconv.c
@@ -1,0 +1,16 @@
+#include <ktime.h>
+
+uint64 ktime_ticks_to_ns(uint64 ticks, uint32 frequency)
+{
+	uint64 seconds;
+	uint64 nanoseconds;
+
+	if (!frequency)
+		return 0;
+	seconds = ticks / frequency;
+	if (seconds > ~(uint64)0 / NSEC_PER_SEC)
+		return ~(uint64)0;
+	nanoseconds = seconds * NSEC_PER_SEC;
+	nanoseconds += ticks % frequency * NSEC_PER_SEC / frequency;
+	return nanoseconds;
+}

--- a/net/lwip/port/netif.c
+++ b/net/lwip/port/netif.c
@@ -8,7 +8,7 @@
 #include <mystring.h>
 #include <netdevice.h>
 #include <network_stack.h>
-#include <printf.h>
+#include <printk.h>
 #include <scheduler.h>
 #include <workqueue.h>
 
@@ -220,7 +220,7 @@ static void lwip_detach_device(struct net_device *device)
 			lwip_choose_default_interface();
 		lwip_set_default_interface(lwip_network.default_interface);
 	}
-	printf("lwIP: detached %s\n", device->name);
+	pr_notice("lwIP: detached %s", device->name);
 }
 
 static void lwip_device_state_work(struct work_struct *work)
@@ -275,9 +275,9 @@ static void lwip_status_changed(struct netif *interface)
 	    !netif_is_up(interface) || ip4_addr_isany_val(*address))
 		return;
 	value = lwip_ntohl(ip4_addr_get_u32(address));
-	printf("%s: IPv4 %d.%d.%d.%d\n", adapter->device->name,
-	       (value >> 24) & 0xff, (value >> 16) & 0xff,
-	       (value >> 8) & 0xff, value & 0xff);
+	pr_info("%s: IPv4 %d.%d.%d.%d", adapter->device->name,
+		(value >> 24) & 0xff, (value >> 16) & 0xff,
+		(value >> 8) & 0xff, value & 0xff);
 }
 
 static int lwip_attach_device(struct net_device *device)
@@ -314,7 +314,7 @@ static int lwip_attach_device(struct net_device *device)
 	netif_set_status_callback(interface, lwip_status_changed);
 	netif_set_up(interface);
 	lwip_apply_device_state(adapter);
-	printf("lwIP: attached %s\n", device->name);
+	pr_info("lwIP: attached %s", device->name);
 	if (device->loopback)
 		return 0;
 	if (!lwip_network.default_interface) {
@@ -322,13 +322,14 @@ static int lwip_attach_device(struct net_device *device)
 		netif_set_default(interface);
 	}
 	if (dhcp_start(interface) != ERR_OK)
-		printf("lwIP: DHCP start failed on %s\n", device->name);
+		pr_warn("lwIP: DHCP start failed on %s", device->name);
 	return 0;
 }
 
 static void lwip_tcpip_ready(void *argument)
 {
 	struct net_device *device;
+	int external_devices = 0;
 	uint32 index;
 
 	(void)argument;
@@ -337,24 +338,29 @@ static void lwip_tcpip_ready(void *argument)
 		work_init(&lwip_network.state_work[index],
 			  lwip_device_state_work);
 	if (net_receive_register(lwip_receive, &lwip_network) < 0) {
-		printf("lwIP: cannot register receive path\n");
+		pr_err("lwIP: cannot register receive path");
 		return;
 	}
 	if (net_state_register(lwip_device_state, &lwip_network) < 0) {
 		net_receive_unregister(lwip_receive, &lwip_network);
-		printf("lwIP: cannot register device state\n");
+		pr_err("lwIP: cannot register device state");
 		return;
 	}
 	for (index = 1; index < NET_DEVICE_MAX; index++) {
 		device = net_device_get(index);
 		if (device) {
-			if (lwip_attach_device(device) < 0)
-				printf("lwIP: cannot add %s\n", device->name);
+			if (lwip_attach_device(device) < 0) {
+				pr_warn("lwIP: cannot add %s", device->name);
+			} else if (!device->loopback) {
+				external_devices++;
+			}
 			net_device_put(device);
 		}
 	}
 	if (!lwip_network.count)
-		printf("lwIP: no network device\n");
+		pr_notice("lwIP: no network device");
+	else if (!external_devices)
+		pr_notice("lwIP: no external network device");
 	else if (!lwip_network.default_interface) {
 		lwip_network.default_interface =
 			lwip_choose_default_interface();

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,8 +32,19 @@ rbtree:
 		-o $(TEST_OUTPUT)/rbtree
 	$(TEST_OUTPUT)/rbtree
 
+.PHONY: printk
+printk:
+	mkdir -p $(TEST_OUTPUT)
+	$(CC) -std=gnu17 -Wall -Wextra -Werror -fno-builtin \
+		-I $(TOPDIR)/kernel/include \
+		-I $(TOPDIR)/arch/riscv/include \
+		$(CURDIR)/printk.c $(TOPDIR)/kernel/printf.c \
+		$(TOPDIR)/kernel/printk.c $(TOPDIR)/kernel/timeconv.c \
+		-o $(TEST_OUTPUT)/printk
+	$(TEST_OUTPUT)/printk
+
 .PHONY: qemu
-qemu: rbtree virtqueue
+qemu: printk rbtree virtqueue
 	TEST_OUTPUT="$(TEST_OUTPUT)" JOBS="$(JOBS)" \
 		$(CURDIR)/scripts/run-qemu.sh
 

--- a/tests/printk.c
+++ b/tests/printk.c
@@ -1,0 +1,208 @@
+#include <string.h>
+#include <unistd.h>
+
+#include <ktime.h>
+#include <printk.h>
+#include <printf.h>
+#include <spinlock.h>
+
+#define CONSOLE_OUTPUT_MAX 1024
+
+static char console_output[CONSOLE_OUTPUT_MAX];
+static uint32 console_output_length;
+static uint32 lock_acquisitions;
+static uint64 test_time_ns;
+
+void console_putc(int character)
+{
+	if (console_output_length + 1 < sizeof(console_output))
+		console_output[console_output_length++] = character;
+	console_output[console_output_length] = 0;
+}
+
+uint64 ktime_get_boot_ns(void)
+{
+	return test_time_ns;
+}
+
+void spinlock_init(spinlock_t lock, const char *name)
+{
+	memset(lock, 0, sizeof(*lock));
+	lock->name = name;
+}
+
+void spinlock_acquire(spinlock_t lock)
+{
+	if (lock->locked)
+		_exit(2);
+	lock->locked = 1;
+	lock_acquisitions++;
+}
+
+void spinlock_release(spinlock_t lock)
+{
+	if (!lock->locked)
+		_exit(2);
+	lock->locked = 0;
+}
+
+int spinlock_holding(spinlock_t lock)
+{
+	return lock->locked;
+}
+
+static void console_clear(void)
+{
+	console_output_length = 0;
+	console_output[0] = 0;
+}
+
+static int fail(const char *message)
+{
+	write(STDERR_FILENO, message, strlen(message));
+	write(STDERR_FILENO, "\n", 1);
+	return 1;
+}
+
+static int test_levels(void)
+{
+	static const char *const names[] = {
+		"emerg", "alert", "crit", "err",
+		"warn", "notice", "info", "debug",
+	};
+	int level;
+
+	for (level = 0; level < PRINTK_LEVEL_COUNT; level++) {
+		if (strcmp(printk_level_name(level), names[level]))
+			return -1;
+	}
+	return strcmp(printk_level_name(PRINTK_LEVEL_COUNT), "unknown") ?
+		-1 : 0;
+}
+
+static int test_format_and_filter(void)
+{
+	struct printk_record record;
+
+	test_time_ns = 12345678;
+	pr_info("boot %d", 7);
+	if (strcmp(console_output, "[    0.012345] boot 7\n") ||
+	    printk_read_record(0, &record) ||
+	    record.sequence != 0 || record.timestamp_ns != test_time_ns ||
+	    record.level != PRINTK_INFO || strcmp(record.text, "boot 7\n"))
+		return -1;
+
+	console_clear();
+	printk_set_console_level(PRINTK_WARN);
+	test_time_ns++;
+	pr_info("hidden");
+	test_time_ns++;
+	pr_warn("number=%05d long=%lu hex=%04x", -7,
+		123456789UL, 0xabU);
+	if (strcmp(console_output,
+		   "[    0.012345] number=-0007 long=123456789 hex=00ab\n"))
+		return -1;
+	if (printk_read_record(1, &record) ||
+	    strcmp(record.text, "hidden\n") || record.level != PRINTK_INFO)
+		return -1;
+	return 0;
+}
+
+static int test_monotonic_timestamp(void)
+{
+	struct printk_record first, second;
+	uint64 sequence = printk_next_sequence();
+
+	test_time_ns = 90000000;
+	pr_debug("later");
+	test_time_ns = 80000000;
+	pr_debug("earlier clock value");
+	if (printk_read_record(sequence, &first) ||
+	    printk_read_record(sequence + 1, &second))
+		return -1;
+	return first.timestamp_ns == 90000000 &&
+	       second.timestamp_ns == first.timestamp_ns ? 0 : -1;
+}
+
+static int test_ring_wrap(void)
+{
+	struct printk_record record;
+	uint64 old_first = printk_first_sequence();
+	uint64 sequence;
+	int index;
+
+	printk_set_console_level(PRINTK_EMERG);
+	for (index = 0; index < PRINTK_RECORD_MAX + 5; index++)
+		pr_debug("wrap %d", index);
+	sequence = printk_next_sequence();
+	if (printk_first_sequence() != sequence - PRINTK_RECORD_MAX ||
+	    !printk_read_record(old_first, &record) ||
+	    printk_read_record(sequence - 1, &record) ||
+	    record.sequence != sequence - 1)
+		return -1;
+	return 0;
+}
+
+static int test_truncation(void)
+{
+	struct printk_record record;
+	char message[PRINTK_TEXT_MAX + 64];
+	uint64 sequence = printk_next_sequence();
+	uint32 index;
+
+	for (index = 0; index < sizeof(message) - 1; index++)
+		message[index] = 'x';
+	message[index] = 0;
+	pr_debug("%s", message);
+	if (printk_read_record(sequence, &record) ||
+	    record.length != PRINTK_TEXT_MAX - 1 ||
+	    record.text[PRINTK_TEXT_MAX - 2] != '\n' ||
+	    record.text[PRINTK_TEXT_MAX - 1])
+		return -1;
+	return 0;
+}
+
+static int test_time_conversion(void)
+{
+	if (ktime_ticks_to_ns(12345678, 10000000) != 1234567800ULL ||
+	    ktime_ticks_to_ns(1, 0) != 0 ||
+	    ktime_ticks_to_ns(~(uint64)0, 1) != ~(uint64)0)
+		return -1;
+	return 0;
+}
+
+static int test_emergency_output(void)
+{
+	uint32 acquisitions = lock_acquisitions;
+
+	console_clear();
+	test_time_ns = 100000000;
+	printk_enter_panic();
+	pr_emerg("panic-safe");
+	if (lock_acquisitions != acquisitions ||
+	    strcmp(console_output, "[    0.100000] panic-safe\n"))
+		return -1;
+	return 0;
+}
+
+int main(void)
+{
+	printf_init();
+	printk_init();
+	if (test_levels())
+		return fail("printk level validation failed");
+	if (test_format_and_filter())
+		return fail("printk formatting validation failed");
+	if (test_monotonic_timestamp())
+		return fail("printk monotonic timestamp validation failed");
+	if (test_ring_wrap())
+		return fail("printk ring validation failed");
+	if (test_truncation())
+		return fail("printk truncation validation failed");
+	if (test_time_conversion())
+		return fail("printk time conversion validation failed");
+	if (test_emergency_output())
+		return fail("printk emergency output validation failed");
+	write(STDOUT_FILENO, "PRINTK_OK\n", 10);
+	return 0;
+}

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -60,6 +60,52 @@ export QEMU_TIMEOUT=${QEMU_TIMEOUT:-60}
 
 make -C "$topdir" check-opensbi
 
+normalize_kernel_log()
+{
+	local input=$1
+	local output=$2
+	local timestamped=$output.timestamped
+
+	tr -d '\r' < "$input" > "$timestamped"
+	if ! awk '
+		/^\[[[:space:]]*[0-9]+\.[0-9][0-9][0-9][0-9][0-9][0-9]\] / {
+			stamp = $0
+			sub(/^\[[[:space:]]*/, "", stamp)
+			sub(/\].*$/, "", stamp)
+			split(stamp, fields, ".")
+			seconds = fields[1] + 0
+			microseconds = substr(fields[2], 1, 6) + 0
+			now = seconds * 1000000 + microseconds
+			if (seen && now < previous)
+				bad = 1
+			previous = now
+			seen++
+		}
+		END { exit seen < 10 || bad }
+	' "$timestamped"; then
+		echo "kernel timestamps are missing or non-monotonic" >&2
+		exit 1
+	fi
+	if grep -Eq \
+		-e '^(Caffeinix |OF: machine:|SBI: spec=|memory: )' \
+		-e '^(clocksource: |smp: |irq: PLIC|mmu: |CPU: )' \
+		"$timestamped"; then
+		echo "kernel message without a timestamp" >&2
+		exit 1
+	fi
+	if grep -Eq \
+		-e '^\[[[:space:]]*[0-9]+\.[0-9]{6}\] OPENSBI_BOOT_OK' \
+		-e '^\[[[:space:]]*[0-9]+\.[0-9]{6}\] (SCHED_|NETWORK_)' \
+		-e '^\[[[:space:]]*[0-9]+\.[0-9]{6}\] (BUSYBOX_|FS_|TTY_)' \
+		"$timestamped"; then
+		echo "userspace output received a kernel timestamp" >&2
+		exit 1
+	fi
+	sed -E \
+		's/^\[[[:space:]]*[0-9]+\.[0-9]{6}\] //' \
+		"$timestamped" > "$output"
+}
+
 check_boot_log()
 {
 	local clean=$1
@@ -75,6 +121,23 @@ check_boot_log()
 		echo "missing or duplicate OpenSBI BASE report" >&2
 		exit 1
 	fi
+	for marker in \
+		'^Caffeinix RISC-V 64-bit$' \
+		'^OF: machine: .+$' \
+		'^clocksource: riscv timer at [0-9]+ MHz$' \
+		'^memory: [0-9]+ MiB usable$' \
+		"^smp: detected $cpus CPUs$" \
+		"^irq: PLIC configured for $cpus CPUs$" \
+		'^mmu: Sv39 enabled$' \
+		"^smp: brought up $cpus CPUs$"; do
+		marker_count=$(awk -v marker="$marker" \
+			'$0 ~ marker { count++ } END { print count + 0 }' \
+			"$clean")
+		if [ "$marker_count" -ne 1 ]; then
+			echo "unexpected boot summary count: $marker=$marker_count" >&2
+			exit 1
+		fi
+	done
 	for logical in $(seq 0 $((cpus - 1))); do
 		marker_count=$(awk -v logical="$logical" \
 			'$0 ~ "^CPU: logical=" logical " hart=.* online$" {
@@ -132,7 +195,7 @@ run_boot_smoke()
 	export QEMU_MEMORY=$memory
 	export QEMU_LOG=$log
 	expect "$script_dir/run-boot.exp"
-	tr -d '\r' < "$log" > "$clean"
+	normalize_kernel_log "$log" "$clean"
 	if [ "$(awk '$0 == "OPENSBI_BOOT_OK" { count++ }
 		END { print count + 0 }' "$clean")" -ne 1 ]; then
 		echo "OpenSBI BusyBox smoke marker is missing" >&2
@@ -170,7 +233,7 @@ export QEMU_MEMORY=128M
 export QEMU_LOG=$test_output/qemu-network-offline.log
 expect "$script_dir/run-network-offline.exp"
 offline_clean=$test_output/qemu-network-offline.clean.log
-tr -d '\r' < "$QEMU_LOG" > "$offline_clean"
+normalize_kernel_log "$QEMU_LOG" "$offline_clean"
 if [ "$(awk '$0 == "NETWORK_OFFLINE_BOOT_OK" { count++ }
 	END { print count + 0 }' "$offline_clean")" -ne 1 ]; then
 	echo "offline network boot marker is missing" >&2
@@ -201,7 +264,7 @@ export QEMU_CPUS=8
 export QEMU_MEMORY=256M
 export QEMU_LOG=$qemu_log
 expect "$script_dir/run-qemu.exp"
-tr -d '\r' < "$qemu_log" > "$clean_log"
+normalize_kernel_log "$qemu_log" "$clean_log"
 check_net_device_log "$clean_log" 1
 check_boot_log "$clean_log" "$QEMU_CPUS"
 
@@ -254,7 +317,7 @@ if ! grep -Fq $'abc\b \bd' "$qemu_log"; then
 fi
 
 if grep -Eq \
-	-e '\[PANIC\]|Unhandled interrupt' \
+	-e '\[PANIC\]|Unhandled interrupt|irq: unhandled interrupt' \
 	-e 'FS_RUNTIME_FAIL=|NETWORK_RUNTIME_FAIL' \
 	-e 'PRESSURE_RUNTIME_FAIL|SCHED_RUNTIME_FAIL=|TTY_RUNTIME_FAIL=' \
 	"$clean_log"; then

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -88,7 +88,9 @@ normalize_kernel_log()
 	fi
 	if grep -Eq \
 		-e '^(Caffeinix |OF: machine:|SBI: spec=|memory: )' \
-		-e '^(clocksource: |smp: |irq: PLIC|mmu: |CPU: )' \
+		-e '^(clocksource: |smp: |irq: PLIC|mmu: |console: )' \
+		-e '^(virtio-mmio: |virtio-blk|eth[0-9]+: virtio-net)' \
+		-e '^(CPU: |lwIP: )' \
 		"$timestamped"; then
 		echo "kernel message without a timestamp" >&2
 		exit 1
@@ -110,6 +112,7 @@ check_boot_log()
 {
 	local clean=$1
 	local cpus=$2
+	local block_devices=${3:-1}
 	local logical
 	local marker_count
 
@@ -129,6 +132,7 @@ check_boot_log()
 		"^smp: detected $cpus CPUs$" \
 		"^irq: PLIC configured for $cpus CPUs$" \
 		'^mmu: Sv39 enabled$' \
+		'^console: ttyS0 at 0x[0-9a-f]+ irq=[0-9]+$' \
 		"^smp: brought up $cpus CPUs$"; do
 		marker_count=$(awk -v marker="$marker" \
 			'$0 ~ marker { count++ } END { print count + 0 }' \
@@ -138,6 +142,14 @@ check_boot_log()
 			exit 1
 		fi
 	done
+	marker_count=$(awk \
+		'$0 ~ /^virtio-blk[0-9]+: [0-9]+ sectors \([0-9]+ MiB\)$/ {
+			count++
+		} END { print count + 0 }' "$clean")
+	if [ "$marker_count" -ne "$block_devices" ]; then
+		echo "unexpected block device count: $marker_count" >&2
+		exit 1
+	fi
 	for logical in $(seq 0 $((cpus - 1))); do
 		marker_count=$(awk -v logical="$logical" \
 			'$0 ~ "^CPU: logical=" logical " hart=.* online$" {
@@ -175,11 +187,21 @@ check_net_device_log()
 	local clean=$1
 	local expected=$2
 	local count
+	local absent
 
-	count=$(awk '$0 == "virtio-net: registered eth0" { count++ }
+	count=$(awk \
+		'$0 ~ /^eth0: virtio-net MAC ([0-9a-f][0-9a-f]:){5}/ &&
+		 $0 ~ /[0-9a-f][0-9a-f]$/ { count++ }
 		END { print count + 0 }' "$clean")
 	if [ "$count" -ne "$expected" ]; then
 		echo "unexpected VirtIO network device count: $count" >&2
+		exit 1
+	fi
+	absent=$(awk '$0 == "lwIP: no external network device" { count++ }
+		END { print count + 0 }' "$clean")
+	if { [ "$expected" -eq 0 ] && [ "$absent" -ne 1 ]; } ||
+	   { [ "$expected" -ne 0 ] && [ "$absent" -ne 0 ]; }; then
+		echo "unexpected absent network device count: $absent" >&2
 		exit 1
 	fi
 }
@@ -266,7 +288,7 @@ export QEMU_LOG=$qemu_log
 expect "$script_dir/run-qemu.exp"
 normalize_kernel_log "$qemu_log" "$clean_log"
 check_net_device_log "$clean_log" 1
-check_boot_log "$clean_log" "$QEMU_CPUS"
+check_boot_log "$clean_log" "$QEMU_CPUS" 2
 
 for marker in \
 	BUSYBOX_SHELL_OK \

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -90,7 +90,7 @@ normalize_kernel_log()
 		-e '^(Caffeinix |OF: machine:|SBI: spec=|memory: )' \
 		-e '^(clocksource: |smp: |irq: PLIC|mmu: |console: )' \
 		-e '^(virtio-mmio: |virtio-blk|eth[0-9]+: virtio-net)' \
-		-e '^(CPU: |lwIP: )' \
+		-e '^(CPU: |lwIP: |VFS: |init: )' \
 		"$timestamped"; then
 		echo "kernel message without a timestamp" >&2
 		exit 1
@@ -113,6 +113,7 @@ check_boot_log()
 	local clean=$1
 	local cpus=$2
 	local block_devices=${3:-1}
+	local fat_mounts=0
 	local logical
 	local marker_count
 
@@ -133,7 +134,11 @@ check_boot_log()
 		"^irq: PLIC configured for $cpus CPUs$" \
 		'^mmu: Sv39 enabled$' \
 		'^console: ttyS0 at 0x[0-9a-f]+ irq=[0-9]+$' \
-		"^smp: brought up $cpus CPUs$"; do
+		"^smp: brought up $cpus CPUs$" \
+		'^VFS: mounted root [(]ext4[)] on virtio-blk[0-9]+$' \
+		'^VFS: mounted devfs on /dev$' \
+		'^VFS: mounted tmpfs on /tmp$' \
+		'^init: starting /bin/sh$'; do
 		marker_count=$(awk -v marker="$marker" \
 			'$0 ~ marker { count++ } END { print count + 0 }' \
 			"$clean")
@@ -148,6 +153,15 @@ check_boot_log()
 		} END { print count + 0 }' "$clean")
 	if [ "$marker_count" -ne "$block_devices" ]; then
 		echo "unexpected block device count: $marker_count" >&2
+		exit 1
+	fi
+	if [ "$block_devices" -gt 1 ]; then
+		fat_mounts=1
+	fi
+	marker_count=$(awk '$0 == "VFS: mounted fat on /mnt/fat" { count++ }
+		END { print count + 0 }' "$clean")
+	if [ "$marker_count" -ne "$fat_mounts" ]; then
+		echo "unexpected FAT mount count: $marker_count" >&2
 		exit 1
 	fi
 	for logical in $(seq 0 $((cpus - 1))); do


### PR DESCRIPTION
Introduce a kernel logging path that preserves severity and boot-relative
timestamps, serializes complete records across CPUs, and retains messages
in a bounded static ring. Keep panic output independent of the normal
printk and console locks.

Use the new interface to report validated boot state, discovered console
and VirtIO devices, network attachment, mounted filesystems, and the init
selection. Successful milestones are emitted once, while failures retain
the underlying status needed to identify the failing stage.

Extend host coverage for formatting, filtering, timestamp conversion,
ring wraparound, truncation, and emergency output. Extend the QEMU matrix
to verify monotonic timestamp prefixes and exact boot-record counts across
CPU, memory, device, and filesystem configurations.

Tested with:

- `make clean && make -j"$(nproc)"`
- `make -C tests uapi opensbi`
- `make -C tests qemu`
