### PR TITLE
sched: prevent stale CPU lookup after migration

### DIFF
--- a/arch/riscv/include/riscv.h
+++ b/arch/riscv/include/riscv.h
@@ -161,6 +161,31 @@ static inline void intr_off(void)
         sstatus_w(sstatus_r() & ~SSTATUS_SIE);
 }
 
+static inline uint64 intr_save(void)
+{
+	uint64 status;
+
+	asm volatile("csrrc %0, sstatus, %1"
+		     : "=r"(status)
+		     : "r"(SSTATUS_SIE)
+		     : "memory");
+	return status;
+}
+
+static inline void intr_restore(uint64 status)
+{
+	if (status & SSTATUS_SIE)
+		asm volatile("csrs sstatus, %0"
+			     :
+			     : "r"(SSTATUS_SIE)
+			     : "memory");
+	else
+		asm volatile("csrc sstatus, %0"
+			     :
+			     : "r"(SSTATUS_SIE)
+			     : "memory");
+}
+
 static inline void stvec_w(uint64 v)
 {
         asm volatile("csrw stvec, %0" : : "r"(v));

--- a/drivers/block/virtio_blk.c
+++ b/drivers/block/virtio_blk.c
@@ -42,6 +42,38 @@ struct virtio_blk {
 	char name[16];
 };
 
+static struct virtio_blk *debug_disks[BLOCK_DEVICE_MAX];
+static uint32 debug_readers;
+
+void virtio_blk_debug_dump(void)
+{
+	struct virtio_blk *disk;
+	struct virtqueue *queue;
+	uint16 available, used;
+	int found = 0;
+	uint32 id;
+
+	__atomic_add_fetch(&debug_readers, 1, __ATOMIC_SEQ_CST);
+	for (id = 1; id < BLOCK_DEVICE_MAX; id++) {
+		disk = __atomic_load_n(&debug_disks[id], __ATOMIC_SEQ_CST);
+		if (!disk || !(queue = disk->queue))
+			continue;
+		found = 1;
+		available = __atomic_load_n(&queue->available->index,
+					    __ATOMIC_RELAXED);
+		used = __atomic_load_n(&queue->used->index,
+				       __ATOMIC_RELAXED);
+		printf_emergency("%s avail=%u avail_shadow=%u used=%u "
+				 "used_shadow=%u free=%u size=%u\n", disk->name,
+				 available, queue->available_shadow, used,
+				 queue->used_shadow, queue->free_count,
+				 queue->size);
+	}
+	if (!found)
+		printf_emergency("virtio-blk unavailable\n");
+	__atomic_sub_fetch(&debug_readers, 1, __ATOMIC_SEQ_CST);
+}
+
 static int virtio_blk_submit(struct virtio_blk *disk, uint32 type,
 			     uint64 sector, void *buffer, uint32 length)
 {
@@ -180,6 +212,8 @@ static int virtio_blk_probe(struct virtio_device *device)
 	if (block_device_register(&disk->block) < 0)
 		goto failed;
 	disk->name[10] = '0' + disk->block.id - 1;
+	__atomic_store_n(&debug_disks[disk->block.id], disk,
+			 __ATOMIC_SEQ_CST);
 	dev_set_drvdata(&device->device, disk);
 	pr_info("%s: %lu sectors (%lu MiB)", disk->name,
 		disk->block.sector_count,
@@ -201,6 +235,9 @@ static void virtio_blk_remove(struct virtio_device *device)
 		return;
 	if (!wait_queue_empty(&disk->descriptor_wait))
 		PANIC("remove busy virtio-blk");
+	__atomic_store_n(&debug_disks[disk->block.id], 0, __ATOMIC_SEQ_CST);
+	while (__atomic_load_n(&debug_readers, __ATOMIC_SEQ_CST))
+		;
 	block_device_unregister(&disk->block);
 	dev_set_drvdata(&device->device, 0);
 	free(disk);

--- a/drivers/tty/serial/ns16550.c
+++ b/drivers/tty/serial/ns16550.c
@@ -23,11 +23,14 @@
 #define UART_LCR_8N1 0x03
 #define UART_LCR_DLAB 0x80
 #define UART_LSR_DATA_READY 0x01
+#define UART_LSR_BREAK 0x10
 #define UART_LSR_THRE 0x20
 
 struct ns16550_device {
 	struct uart_port port;
 	struct platform_device *platform;
+	struct spinlock lsr_lock;
+	uint8 break_pending;
 	int used;
 };
 
@@ -58,6 +61,17 @@ static void ns16550_write(struct uart_port *port, uint32 number,
 		writeb(value, address);
 }
 
+static uint8 ns16550_read_lsr(struct uart_port *port)
+{
+	struct ns16550_device *device = port->private;
+	uint8 status = ns16550_read(port, UART_LSR);
+
+	/* Reading LSR clears the break bit, including from TX polling. */
+	if (status & UART_LSR_BREAK)
+		device->break_pending = 1;
+	return status;
+}
+
 static int ns16550_startup(struct uart_port *port)
 {
 	uint32 divisor = port->clock / (16 * 38400);
@@ -82,7 +96,13 @@ static void ns16550_shutdown(struct uart_port *port)
 
 static int ns16550_tx_ready(struct uart_port *port)
 {
-	return ns16550_read(port, UART_LSR) & UART_LSR_THRE;
+	struct ns16550_device *device = port->private;
+	uint8 status;
+
+	spinlock_acquire(&device->lsr_lock);
+	status = ns16550_read_lsr(port);
+	spinlock_release(&device->lsr_lock);
+	return status & UART_LSR_THRE;
 }
 
 static void ns16550_put_char(struct uart_port *port, int character)
@@ -92,9 +112,22 @@ static void ns16550_put_char(struct uart_port *port, int character)
 
 static int ns16550_get_char(struct uart_port *port)
 {
-	if (!(ns16550_read(port, UART_LSR) & UART_LSR_DATA_READY))
-		return -1;
-	return ns16550_read(port, UART_RX);
+	struct ns16550_device *device = port->private;
+	uint8 status;
+	int character = -1;
+
+	spinlock_acquire(&device->lsr_lock);
+	status = ns16550_read_lsr(port);
+	if (device->break_pending) {
+		device->break_pending = 0;
+		if (status & UART_LSR_DATA_READY)
+			(void)ns16550_read(port, UART_RX);
+		character = UART_RX_BREAK;
+	} else if (status & UART_LSR_DATA_READY) {
+		character = ns16550_read(port, UART_RX);
+	}
+	spinlock_release(&device->lsr_lock);
+	return character;
 }
 
 static void ns16550_update_ier(struct uart_port *port, uint8 mask,
@@ -165,6 +198,7 @@ static int ns16550_probe(struct platform_device *platform)
 	device->port.operations = &ns16550_operations;
 	device->port.of_node = node;
 	device->port.private = device;
+	spinlock_init(&device->lsr_lock, "ns16550 LSR");
 	if (of_property_read_u32(node, "reg-shift", &value) == 0)
 		device->port.reg_shift = value;
 	if (of_property_read_u32(node, "reg-io-width", &value) == 0)

--- a/drivers/tty/serial/uart.c
+++ b/drivers/tty/serial/uart.c
@@ -284,6 +284,15 @@ int uart_core_selftest(void)
 	    ports[0].tty.commit_position != 1 ||
 	    ports[1].tty.commit_position != 0)
 		goto fail;
+	if (tty_get_console() == &ports[1].tty)
+		goto fail;
+	states[1].receive = UART_RX_BREAK;
+	states[1].receive_pending = 1;
+	if (uart_handle_irq(&ports[1]) != IRQ_HANDLED ||
+	    ports[1].tty.edit_position != 1 ||
+	    ports[1].tty.commit_position != 0 ||
+	    ports[1].tty.input[0] != '\0')
+		goto fail;
 	uart_remove_one_port(&ports[1]);
 	uart_remove_one_port(&ports[0]);
 	if (tty_get(first_line) || tty_get(second_line) ||

--- a/drivers/tty/serial/uart.c
+++ b/drivers/tty/serial/uart.c
@@ -81,8 +81,16 @@ int uart_handle_irq(struct uart_port *port)
 
 	if (!port || !port->registered)
 		return IRQ_NONE;
-	while ((character = port->operations->get_char(port)) >= 0)
-		tty_receive_char(&port->tty, character);
+	while ((character = port->operations->get_char(port)) >= 0) {
+		if (character == UART_RX_BREAK) {
+			if (tty_get_console() == &port->tty)
+				debug_dump_state();
+			else
+				tty_receive_char(&port->tty, '\0');
+		} else {
+			tty_receive_char(&port->tty, character);
+		}
+	}
 	spinlock_acquire(&port->lock);
 	uart_start_transmit_locked(port);
 	spinlock_release(&port->lock);

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -2,8 +2,8 @@ EXTRA_CFLAGS := -I ./include -I ../arch/riscv/include -I ../include
 CFLAGS_file.o := 
 
 
-obj-y += string.o memrange.o buddy.o palloc.o spinlock.o rbtree.o vma.o \
-elf.o \
+obj-y += debug.o string.o memrange.o buddy.o palloc.o spinlock.o rbtree.o \
+vma.o elf.o \
 ktime.o \
 timeconv.o \
 printk.o thread.o wait.o \

--- a/kernel/debug.c
+++ b/kernel/debug.c
@@ -1,0 +1,81 @@
+#include <block_device.h>
+#include <cpu.h>
+#include <debug.h>
+#include <ext4fs.h>
+#include <printf.h>
+#include <scheduler.h>
+#include <thread.h>
+#include <wait.h>
+
+static volatile uint8 dumping;
+
+static int thread_pointer_valid(thread_t candidate)
+{
+	uint64 address = (uint64)candidate;
+	uint64 start = (uint64)&thread[0];
+	uint64 end = (uint64)&thread[NTHREAD];
+
+	return address >= start && address < end &&
+	       !((address - start) % sizeof(*candidate));
+}
+
+static int thread_id(thread_t candidate)
+{
+	return thread_pointer_valid(candidate) ? candidate->tid : -1;
+}
+
+static const char *thread_state_name(thread_state_t state)
+{
+	switch (state) {
+	case THREAD_UNUSED:
+		return "unused";
+	case THREAD_ALLOCATED:
+		return "allocated";
+	case THREAD_RUNNABLE:
+		return "runnable";
+	case THREAD_RUNNING:
+		return "running";
+	case THREAD_SLEEPING:
+		return "sleeping";
+	case THREAD_EXITED:
+		return "exited";
+	default:
+		return "invalid";
+	}
+}
+
+void debug_dump_state(void)
+{
+	thread_t current, selected;
+	int index;
+
+	if (__sync_lock_test_and_set(&dumping, 1))
+		return;
+	printf_emergency("DEBUG_STATE_BEGIN cpu=%d tp=%p\n", cpuid(),
+			 tp_r());
+	for (index = 0; index < cpu_count(); index++) {
+		current = cpus[index]->current;
+		selected = cpus[index]->selected;
+		printf_emergency("cpu=%d hart=%p current=%p tid=%d "
+				 "selected=%p selected_tid=%d idle=%d locks=%d\n",
+				 index, cpus[index]->hart_id, (uint64)current,
+				 thread_id(current), (uint64)selected,
+				 thread_id(selected), cpus[index]->idle,
+				 cpus[index]->lock_nest_depth);
+	}
+	for (index = 0; index < NTHREAD; index++) {
+		if (thread[index].state == THREAD_UNUSED)
+			continue;
+		printf_emergency("thread=%d tid=%d name=%s state=%s rq=%d "
+				 "wait=%p timeout=%d\n", index,
+				 thread[index].tid, thread[index].name,
+				 thread_state_name(thread[index].state),
+				 thread[index].sched.on_runqueue,
+				 (uint64)thread[index].waiting_on,
+				 thread[index].on_timeout_queue);
+	}
+	ext4fs_debug_dump();
+	virtio_blk_debug_dump();
+	printf_emergency("DEBUG_STATE_END\n");
+	__sync_lock_release(&dumping);
+}

--- a/kernel/fs/lwext4/caffeinix.c
+++ b/kernel/fs/lwext4/caffeinix.c
@@ -59,6 +59,21 @@ static const struct vfs_inode_operations ext4fs_inode_operations;
 static const struct vfs_file_operations ext4fs_file_operations;
 static const struct vfs_file_operations ext4fs_directory_operations;
 
+void ext4fs_debug_dump(void)
+{
+	thread_t owner = __atomic_load_n(&ext4fs_lock_owner,
+					 __ATOMIC_RELAXED);
+	thread_t sleep_owner = __atomic_load_n(&ext4fs_lock.owner,
+					       __ATOMIC_RELAXED);
+
+	printf_emergency("ext4 locked=%d owner=%p owner_tid=%d depth=%u "
+			 "sleep_owner=%p sleep_owner_tid=%d\n",
+			 ext4fs_lock.locked, (uint64)owner,
+			 owner ? owner->tid : -1, ext4fs_lock_depth,
+			 (uint64)sleep_owner,
+			 sleep_owner ? sleep_owner->tid : -1);
+}
+
 static int ext4fs_is_orphan_directory(const char *directory,
 				      const char *name)
 {

--- a/kernel/include/block_device.h
+++ b/kernel/include/block_device.h
@@ -34,5 +34,6 @@ int block_device_write(struct block_device *device, uint64 sector,
 		       const void *buffer, uint32 count);
 int block_device_flush(struct block_device *device);
 int virtio_blk_init(void);
+void virtio_blk_debug_dump(void);
 
 #endif

--- a/kernel/include/debug.h
+++ b/kernel/include/debug.h
@@ -18,6 +18,7 @@
 #ifdef DEBUG
 
 extern void panic(char* s);
+void debug_dump_state(void);
 #define PANIC(s) do {           \
     panic(s);                   \
 } while (0)

--- a/kernel/include/ext4fs.h
+++ b/kernel/include/ext4fs.h
@@ -2,5 +2,6 @@
 #define __CAFFEINIX_KERNEL_EXT4FS_H
 
 void ext4fs_init(void);
+void ext4fs_debug_dump(void);
 
 #endif

--- a/kernel/include/printf.h
+++ b/kernel/include/printf.h
@@ -9,6 +9,7 @@ typedef void (*printf_emit_t)(int character, void *context);
 
 void printf_init(void);
 void printf(char* fmt, ...);
+void printf_emergency(char *fmt, ...);
 void vprintf_emit(printf_emit_t emit, void *context, const char *fmt,
 		  va_list arguments);
 void printf_enter_panic(void);

--- a/kernel/include/uart.h
+++ b/kernel/include/uart.h
@@ -7,6 +7,7 @@
 #include <typedefs.h>
 
 #define UART_TX_BUFFER_SIZE 128
+#define UART_RX_BREAK 0x100
 
 struct device_node;
 struct uart_port;

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -6,8 +6,7 @@
 static const char digits[] = "0123456789abcdef";
 static struct {
         struct spinlock lock;
-        /* This flag for panic */
-        uint8 locking;
+	uint8 locking;
 }pf;
 
 static void console_emit(int character, void *context)
@@ -140,6 +139,15 @@ void printf(char* fmt, ...)
 		spinlock_release(&pf.lock);
 }
 
+void printf_emergency(char *fmt, ...)
+{
+	va_list arguments;
+
+	va_start(arguments, fmt);
+	vprintf_emit(console_emit, 0, fmt, arguments);
+	va_end(arguments);
+}
+
 void printf_enter_panic(void)
 {
 	pf.locking = 0;
@@ -148,6 +156,5 @@ void printf_enter_panic(void)
 void printf_init(void)
 {
         spinlock_init(&pf.lock, "printf");
-        /* No panic */
-        pf.locking = 1;
+	pf.locking = 1;
 }

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -51,7 +51,14 @@ cpu_t cur_cpu(void)
 
 thread_t cur_thread(void)
 {
-	return cur_cpu()->current;
+	thread_t current;
+	uint64 status;
+
+	/* A timer interrupt may reschedule this thread on another CPU. */
+	status = intr_save();
+	current = cur_cpu()->current;
+	intr_restore(status);
+	return current;
 }
 
 process_t cur_proc(void)

--- a/tests/dynamic_runtime.c
+++ b/tests/dynamic_runtime.c
@@ -149,13 +149,30 @@ static void test_exec_pressure(void)
 		    !WIFEXITED(status) || WEXITSTATUS(status))
 			fail("pressure wait");
 	}
-	puts("DYNAMIC_EXEC_PRESSURE_OK");
+}
+
+static unsigned int pressure_iterations(const char *argument)
+{
+	char *end;
+	unsigned long iterations;
+
+	errno = 0;
+	iterations = strtoul(argument, &end, 10);
+	if (errno || !argument[0] || *end || !iterations ||
+	    iterations > 10000)
+		fail("pressure iterations");
+	return iterations;
 }
 
 int main(int argc, char **argv)
 {
-	if (argc == 2 && !strcmp(argv[1], "pressure")) {
-		test_exec_pressure();
+	if ((argc == 2 || argc == 3) && !strcmp(argv[1], "pressure")) {
+		unsigned int iterations = argc == 3 ?
+			pressure_iterations(argv[2]) : 1;
+
+		while (iterations--)
+			test_exec_pressure();
+		puts("DYNAMIC_EXEC_PRESSURE_OK");
 		return 0;
 	}
 	if (constructor_value != 11)
@@ -168,6 +185,7 @@ int main(int argc, char **argv)
 	test_relro();
 	test_exec_cloexec();
 	test_exec_pressure();
+	puts("DYNAMIC_EXEC_PRESSURE_OK");
 	puts("DYNAMIC_RUNTIME_OK");
 	return 0;
 }

--- a/tests/printk.c
+++ b/tests/printk.c
@@ -171,6 +171,21 @@ static int test_time_conversion(void)
 	return 0;
 }
 
+static int test_emergency_printf(void)
+{
+	uint32 acquisitions = lock_acquisitions;
+
+	console_clear();
+	printf_emergency("emergency ");
+	if (lock_acquisitions != acquisitions)
+		return -1;
+	printf("normal");
+	if (lock_acquisitions != acquisitions + 1 ||
+	    strcmp(console_output, "emergency normal"))
+		return -1;
+	return 0;
+}
+
 static int test_emergency_output(void)
 {
 	uint32 acquisitions = lock_acquisitions;
@@ -201,6 +216,8 @@ int main(void)
 		return fail("printk truncation validation failed");
 	if (test_time_conversion())
 		return fail("printk time conversion validation failed");
+	if (test_emergency_printf())
+		return fail("printf emergency output validation failed");
 	if (test_emergency_output())
 		return fail("printk emergency output validation failed");
 	write(STDOUT_FILENO, "PRINTK_OK\n", 10);

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -20,6 +20,11 @@ set timeout 60
 if {[info exists env(QEMU_TIMEOUT)] && $env(QEMU_TIMEOUT) ne ""} {
 	set timeout $env(QEMU_TIMEOUT)
 }
+set pressure_iterations 1
+if {[info exists env(DYNAMIC_PRESSURE_ITERATIONS)] &&
+    $env(DYNAMIC_PRESSURE_ITERATIONS) ne ""} {
+	set pressure_iterations $env(DYNAMIC_PRESSURE_ITERATIONS)
+}
 
 log_file -noappend $env(QEMU_LOG)
 set command [list \
@@ -66,7 +71,7 @@ expect {
 	eof { abort_test "QEMU exited after dynamic musl hello" }
 }
 
-send -- "/bin/dynamic-runtime pressure\r"
+send -- "/bin/dynamic-runtime pressure $pressure_iterations\r"
 expect {
 	-re {\r?\nDYNAMIC_EXEC_PRESSURE_OK} {}
 	-re {DYNAMIC_RUNTIME_FAIL[^\r\n]*} {

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -2,8 +2,22 @@
 
 proc abort_test {message} {
 	puts stderr "OpenSBI boot test failed: $message"
+	catch {send -- "\001x"}
+	set saved_timeout $::timeout
+	set ::timeout 5
+	catch {expect eof}
+	set ::timeout $saved_timeout
 	catch {close}
 	exit 1
+}
+
+proc abort_with_dump {message} {
+	set saved_timeout $::timeout
+	catch {send -- "\001b"}
+	set ::timeout 5
+	catch {expect -re {DEBUG_STATE_END}}
+	set ::timeout $saved_timeout
+	abort_test $message
 }
 
 foreach variable {
@@ -80,7 +94,7 @@ expect {
 	-re {\[PANIC\]} {
 		abort_test "kernel panic in dynamic exec pressure test"
 	}
-	timeout { abort_test "dynamic exec pressure test timeout" }
+	timeout { abort_with_dump "dynamic exec pressure test timeout" }
 	eof { abort_test "QEMU exited during dynamic exec pressure test" }
 }
 expect {

--- a/tests/scripts/run-debug-dump.exp
+++ b/tests/scripts/run-debug-dump.exp
@@ -1,0 +1,104 @@
+#!/usr/bin/expect -f
+
+proc abort_test {message} {
+	puts stderr "kernel state dump test failed: $message"
+	catch {send -- "\001x"}
+	set saved_timeout $::timeout
+	set ::timeout 5
+	catch {expect eof}
+	set ::timeout $saved_timeout
+	catch {close}
+	exit 1
+}
+
+foreach variable {
+	MAKE_COMMAND TEST_TOPDIR QEMU SBI_FIRMWARE ROOT_IMAGE FAT_IMAGE QEMU_LOG
+} {
+	if {![info exists env($variable)] || $env($variable) eq ""} {
+		puts stderr "missing environment variable: $variable"
+		exit 1
+	}
+}
+
+set timeout 30
+log_file -noappend $env(QEMU_LOG)
+set command [list \
+	$env(MAKE_COMMAND) \
+	--silent \
+	--no-print-directory \
+	-C $env(TEST_TOPDIR) \
+	QEMU=$env(QEMU) \
+	SBI_FIRMWARE=$env(SBI_FIRMWARE) \
+	FS_IMG=$env(ROOT_IMAGE) \
+	FAT_IMG=$env(FAT_IMAGE) \
+	CPUS=3 \
+	MEMORY=96M \
+	ROOT_BUS=virtio-mmio-bus.0 \
+	FAT_BUS=virtio-mmio-bus.1 \
+	NET_BACKEND= \
+	NET_OPTIONS= \
+	QEMU_SNAPSHOT=1 \
+	QEMU_EXTRA_OPTS= \
+	QEMU_PREBUILT=1 \
+	qemu]
+
+spawn -noecho {*}$command
+expect {
+	-re {\[PANIC\]} { abort_test "kernel panic before shell startup" }
+	-re {\r?\n# $} {}
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited before shell startup" }
+}
+
+send -- "\001b"
+expect {
+	-re {DEBUG_STATE_BEGIN cpu=[0-9]+ tp=0x[0-9a-f]+} {}
+	timeout { abort_test "state dump start timeout" }
+	eof { abort_test "QEMU exited before state dump" }
+}
+expect {
+	-re {cpu=0 hart=0x[0-9a-f]+ current=0x[0-9a-f]+ tid=-?[0-9]+} {}
+	timeout { abort_test "CPU state timeout" }
+	eof { abort_test "QEMU exited during CPU state" }
+}
+expect {
+	-re {thread=[0-9]+ tid=[0-9]+ name=.* wait=0x[0-9a-f]+ timeout=[01]} {}
+	timeout { abort_test "thread state timeout" }
+	eof { abort_test "QEMU exited during thread state" }
+}
+expect {
+	-re {ext4 locked=[01] owner=0x[0-9a-f]+ owner_tid=-?[0-9]+} {}
+	timeout { abort_test "ext4 state timeout" }
+	eof { abort_test "QEMU exited during ext4 state" }
+}
+expect {
+	-re {virtio-blk[0-9]+ avail=[0-9]+ .* used=[0-9]+ .* size=[0-9]+} {}
+	timeout { abort_test "virtio-blk state timeout" }
+	eof { abort_test "QEMU exited during virtio-blk state" }
+}
+expect {
+	-re {virtio-blk[0-9]+ avail=[0-9]+ .* used=[0-9]+ .* size=[0-9]+} {}
+	timeout { abort_test "second virtio-blk state timeout" }
+	eof { abort_test "QEMU exited during virtio-blk state" }
+}
+expect {
+	-re {DEBUG_STATE_END} {}
+	timeout { abort_test "state dump end timeout" }
+	eof { abort_test "QEMU exited before state dump completed" }
+}
+
+send -- "echo DEBUG_STATE_RETURN_OK\r"
+expect {
+	-re {\r?\nDEBUG_STATE_RETURN_OK} {}
+	-re {\[PANIC\]} { abort_test "kernel panic after state dump" }
+	timeout { abort_test "shell did not resume after state dump" }
+	eof { abort_test "QEMU exited after state dump" }
+}
+
+send -- "\001x"
+expect {
+	eof {}
+	timeout { abort_test "QEMU exit timeout" }
+}
+
+puts "KERNEL_STATE_DUMP_OK"

--- a/tests/scripts/run-qemu.exp
+++ b/tests/scripts/run-qemu.exp
@@ -575,7 +575,7 @@ expect {
 	eof { abort_test "QEMU exited during raw TTY test" }
 }
 after 250
-send -- "R\rX!"
+send -- "R\r\035X!"
 expect {
 	-re {TTY_RAW_OK} {}
 	-re {TTY_RUNTIME_FAIL=[^\r\n]*} {

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -261,12 +261,14 @@ run_boot_smoke()
 {
 	local cpus=$1
 	local memory=$2
+	local pressure_iterations=${3:-1}
 	local log=$test_output/qemu-smp${cpus}-${memory}.log
 	local clean=$test_output/qemu-smp${cpus}-${memory}.clean.log
 
 	export QEMU_CPUS=$cpus
 	export QEMU_MEMORY=$memory
 	export QEMU_LOG=$log
+	export DYNAMIC_PRESSURE_ITERATIONS=$pressure_iterations
 	expect "$script_dir/run-boot.exp"
 	normalize_kernel_log "$log" "$clean"
 	if [ "$(awk '$0 == "OPENSBI_BOOT_OK" { count++ }
@@ -306,7 +308,7 @@ run_boot_smoke()
 
 run_boot_smoke 1 64M
 run_boot_smoke 2 192M
-run_boot_smoke 3 96M
+run_boot_smoke 3 96M 32
 run_boot_smoke 4 128M
 run_boot_smoke 8 256M
 run_boot_smoke 9 256M

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -319,6 +319,9 @@ run_boot_smoke 1 "$large_memory"
 check_boot_memory_latency \
 	"$test_output/qemu-smp1-$large_memory.clean.log.timestamped" 10000000
 
+export QEMU_LOG=$test_output/qemu-debug-state.log
+expect "$script_dir/run-debug-dump.exp"
+
 export QEMU_CPUS=2
 export QEMU_MEMORY=128M
 export QEMU_LOG=$test_output/qemu-network-offline.log

--- a/tests/tty_runtime.c
+++ b/tests/tty_runtime.c
@@ -134,7 +134,7 @@ static int test_nonblock(void)
 
 static int test_raw(void)
 {
-	static const char expected[] = { 'R', '\r', 'X', '!' };
+	static const char expected[] = { 'R', '\r', 0x1d, 'X', '!' };
 	struct termios original, mode;
 	char buffer[sizeof(expected)];
 	size_t total = 0;


### PR DESCRIPTION
A timer interrupt may migrate a thread after it has read the current CPU pointer but before it dereferences the current-thread field. Since trap return deliberately keeps the scheduler-selected `tp`, the interrupted code can otherwise continue with a stale CPU pointer and fault through a NULL `current` value.

Disable local interrupts while taking the paired CPU and thread snapshot. Add an SMP dynamic-exec stress test that reproduces the failure, plus a lockless state dump triggered by BREAK on the active serial console. BREAK events from other UARTs remain in their normal TTY input path.

Validated with 300 three-CPU cold boots, 2,400 fork/exec/wait child lifecycles, the complete local runtime suite, and focused QEMU coverage for the diagnostic path.