### PR TITLE
process: support Linux threads and signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ The kernel mounts devfs at `/dev`, tmpfs at `/tmp`, can mount a second FAT16
 or FAT32 disk at `/mnt/fat`, and can run IPv4 over a modern VirtIO network
 device through lwIP.
 
+Upstream musl pthreads run as Linux-style thread groups. The kernel provides
+process- and thread-directed signals, RV64 signal frames, alternate stacks,
+default actions, child notifications, and interruptible blocking calls.
+
 ## Supported target
 
 - Architecture: RISC-V 64-bit little-endian
 - ISA and ABI: RV64GC with LP64D
 - Machine: QEMU `virt`, one, two, four, and eight harts tested
 - Firmware: OpenSBI with SBI v0.2 or newer, TIME, HSM, and IPI for SMP
-- Userspace: dynamically linked and static musl ELF executables
+- Userspace: dynamically linked and static musl ELF executables with pthreads
 - Root filesystem: ext4 with 1 KiB filesystem blocks
 - Optional data filesystem: FAT16 or FAT32
 - Serial console: DT-discovered NS16550A at `/dev/ttyS0` (device 4:64)
@@ -407,10 +411,10 @@ the kernel. No separate rootfs repository or private compiler is required.
 ## Current limitations
 
 - Only a Linux RISC-V UAPI subset is implemented.
-- Pipelines, job control, and real signal delivery are not ready.
+- Pipelines, process groups, job control, and terminal-generated signals are
+  not ready. The underlying thread and signal core is available.
 - Dynamic musl executables and shared libraries use eager private mappings;
   demand paging, shared clean pages, copy-on-write, and ASLR are not ready.
-- Userspace threads are not ready.
 - Networking is IPv4-only and omits interface configuration, AF_UNIX,
   netlink, namespaces, firewalling, and the wider Linux socket option set.
 - VirtIO currently uses modern MMIO split rings without packed rings,

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -2,4 +2,4 @@ EXTRA_CFLAGS := -I ../../include -I ./include -I ../../kernel/include
 CFLAGS_file.o := 
 
 
-obj-y += vm_layout.o vm.o kernel_vec.o trap.o cpu.o sbi.o timer.o
+obj-y += vm_layout.o vm.o kernel_vec.o sigtramp.o trap.o cpu.o sbi.o timer.o

--- a/arch/riscv/cpu.c
+++ b/arch/riscv/cpu.c
@@ -8,6 +8,7 @@
 #include <riscv.h>
 #include <sbi.h>
 #include <scheduler.h>
+#include <sleeplock.h>
 #include <timer.h>
 #include <vm.h>
 
@@ -16,6 +17,8 @@
 extern void secondary_entry(void);
 
 static int logical_cpu_count;
+static struct sleeplock membarrier_lock;
+static uint64 membarrier_generation;
 
 /* Used directly by the trap entry before it can safely use a C stack. */
 uint64 *cpu_overflow_stack_tops;
@@ -67,6 +70,57 @@ void cpu_topology_init(uint64 boot_hart_id)
 int cpu_count(void)
 {
 	return logical_cpu_count;
+}
+
+void cpu_membarrier_init(void)
+{
+	sleeplock_init(&membarrier_lock, "CPU membarrier");
+	membarrier_generation = 0;
+}
+
+void cpu_membarrier_interrupt(void)
+{
+	cpu_t cpu = cur_cpu();
+	uint64 request;
+
+	request = __atomic_load_n(&cpu->membarrier_request,
+	                          __ATOMIC_ACQUIRE);
+	if (request == __atomic_load_n(&cpu->membarrier_done,
+	                              __ATOMIC_RELAXED))
+		return;
+	__sync_synchronize();
+	__atomic_store_n(&cpu->membarrier_done, request, __ATOMIC_RELEASE);
+}
+
+void cpu_membarrier(void)
+{
+	uint64 generation;
+	int current, logical;
+
+	sleeplock_acquire(&membarrier_lock);
+	generation = ++membarrier_generation;
+	if (!generation)
+		generation = ++membarrier_generation;
+	current = cpuid();
+	__sync_synchronize();
+	for (logical = 0; logical < logical_cpu_count; logical++) {
+		if (logical == current || !cpus[logical]->online)
+			continue;
+		__atomic_store_n(&cpus[logical]->membarrier_request,
+		                 generation, __ATOMIC_RELEASE);
+		if (sbi_send_ipi(cpu_hart_id(logical)))
+			PANIC("membarrier IPI failed");
+	}
+	__sync_synchronize();
+	for (logical = 0; logical < logical_cpu_count; logical++) {
+		if (logical == current || !cpus[logical]->online)
+			continue;
+		while (__atomic_load_n(&cpus[logical]->membarrier_done,
+		                       __ATOMIC_ACQUIRE) != generation)
+			;
+	}
+	__sync_synchronize();
+	sleeplock_release(&membarrier_lock);
 }
 
 uint64 cpu_hart_id(int logical_id)

--- a/arch/riscv/include/cpu.h
+++ b/arch/riscv/include/cpu.h
@@ -20,6 +20,9 @@ void cpu_secondary_validate(uint64 hart_id, uint64 logical_id,
 void cpu_secondary_boot_stack_release(void);
 void cpu_start_secondary_harts(void);
 void cpu_mark_online(void);
+void cpu_membarrier_init(void);
+void cpu_membarrier_interrupt(void);
+void cpu_membarrier(void);
 void cpu_wait_for_secondary_harts(void);
 
 #endif

--- a/arch/riscv/include/mem_layout.h
+++ b/arch/riscv/include/mem_layout.h
@@ -27,6 +27,8 @@
 #define USER_STACK_SIZE  (64 * PGSIZE)
 #define USER_STACK_BASE  (USER_STACK_TOP - USER_STACK_SIZE)
 #define USER_MMAP_TOP    (USER_STACK_BASE - PGSIZE)
+/* Executable userspace stub for the Linux RISC-V rt_sigreturn ABI. */
+#define USER_SIGRETURN   USER_STACK_TOP
 /* Deterministic hints; VMA placement falls back when either range is busy. */
 #define USER_PIE_BASE     0x10000000L
 #define USER_INTERP_BASE  0x30000000L

--- a/arch/riscv/include/mem_layout.h
+++ b/arch/riscv/include/mem_layout.h
@@ -20,8 +20,7 @@
         in both user and kernel space.
  */
 #define TRAMPOLINE      (MAXVA - PGSIZE)
-#define TRAPFRAME_INFO   (TRAMPOLINE - PGSIZE)
-#define TRAPFRAME(x)    (TRAPFRAME_INFO - ((PGSIZE) * (x + 1)))
+#define TRAPFRAME(x)    (TRAMPOLINE - ((PGSIZE) * ((x) + 1)))
 
 /* Keep the userspace stack separate from the ELF break and mmap area. */
 #define USER_STACK_TOP   0x40000000L

--- a/arch/riscv/sigtramp.S
+++ b/arch/riscv/sigtramp.S
@@ -1,0 +1,10 @@
+#define RISCV_LINUX_SYS_RT_SIGRETURN 139
+
+.section sigtrampsec
+.global sigtrampoline
+sigtrampoline:
+	li a7, RISCV_LINUX_SYS_RT_SIGRETURN
+	ecall
+
+.global sigtrampoline_end
+sigtrampoline_end:

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -195,8 +195,9 @@ void user_trap_ret(void)
         satp = MAKE_SATP(p->pagetable);
 
         trampoline_userret = TRAMPOLINE + (user_ret - trampoline);
-        /* Call user_ret */
-        ((void (*)(uint64))trampoline_userret)(satp);
+	/* Call user_ret with this hart's current user trapframe mapping. */
+	((void (*)(uint64, uint64))trampoline_userret)(
+		satp, TRAPFRAME(cur_thread()->id_p));
 }
 
 /* This function for first hart */

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -4,6 +4,8 @@
 #include <cpu.h>
 #include <irq.h>
 #include <scheduler.h>
+#include <signal.h>
+#include <linux_uapi.h>
 #include <printf.h>
 #include <plic.h>
 #include <printk.h>
@@ -109,8 +111,11 @@ void user_trap_entry(void)
 {
         int which_dev = 0;
 	int exit_status;
+	int from_syscall = 0;
         process_t p = cur_proc();
+	thread_t current = cur_thread();
         uint64 cause = scause_r();
+	uint64 trap_value = stval_r();
 
         if((sstatus_r() & SSTATUS_SPP)) {
                 PANIC("Not from user mode");
@@ -118,39 +123,54 @@ void user_trap_entry(void)
 
         stvec_w((uint64)kernel_vec);
 
-        cur_thread()->trapframe->epc = sepc_r();
+        current->trapframe->epc = sepc_r();
 
         if(cause == 8) {
-		if (killed(p) || process_group_exiting(p, &exit_status))
-			process_thread_exit(killed(p) ? -1 : exit_status, 0);
-		if (process_thread_exit_requested(cur_thread(), &exit_status))
+		if (process_group_exiting(p, &exit_status))
+			process_thread_exit(exit_status, 0);
+		if (process_thread_exit_requested(current, &exit_status))
 			process_thread_exit(exit_status, 0);
 
                 /* System call */
-                cur_thread()->trapframe->epc += 4;
+		current->syscall_a0 = current->trapframe->a0;
+		current->trapframe->epc += 4;
+		from_syscall = 1;
                 intr_on();
                 syscall();
         } else if (cause == SCAUSE_INSTRUCTION_PAGE_FAULT ||
 		   cause == SCAUSE_LOAD_PAGE_FAULT ||
 		   cause == SCAUSE_STORE_PAGE_FAULT) {
 		intr_on();
-		pr_warn("process: pid=%d (%s) page fault cause=%lu "
-			"address=%p epc=%p", p->pid, p->name, cause,
-			stval_r(), cur_thread()->trapframe->epc);
-		process_thread_exit(-1, 1);
-		return;
+		signal_force_fault(LINUX_SIGSEGV, LINUX_SEGV_MAPERR,
+		                   trap_value);
         } else {
                 if((which_dev = dev_intr(cause)) == 0) {
-                        printf("scause %p\n", cause);
-                        printf("sepc=%p stval=%p\n",
-                               cur_thread()->trapframe->epc, stval_r());
-                        PANIC("user_trap_entry");
+			if ((int64)cause < 0)
+				PANIC("unhandled user interrupt");
+			intr_on();
+			if (cause == 0 || cause == 4 || cause == 6)
+				signal_force_fault(LINUX_SIGBUS,
+				                   LINUX_BUS_ADRALN, trap_value);
+			else if (cause == 2)
+				signal_force_fault(LINUX_SIGILL,
+				                   LINUX_ILL_ILLOPC,
+				                   current->trapframe->epc);
+			else if (cause == 3)
+				signal_force_fault(LINUX_SIGTRAP,
+				                   LINUX_TRAP_BRKPT,
+				                   current->trapframe->epc);
+			else if (cause == 1 || cause == 5 || cause == 7)
+				signal_force_fault(LINUX_SIGSEGV,
+				                   LINUX_SEGV_ACCERR, trap_value);
+			else
+				signal_force_fault(LINUX_SIGSEGV,
+				                   LINUX_SEGV_MAPERR, trap_value);
                 }
         }
 
-	if (killed(p) || process_group_exiting(p, &exit_status))
-		process_thread_exit(killed(p) ? -1 : exit_status, 0);
-	if (process_thread_exit_requested(cur_thread(), &exit_status))
+	if (process_group_exiting(p, &exit_status))
+		process_thread_exit(exit_status, 0);
+	if (process_thread_exit_requested(current, &exit_status))
 		process_thread_exit(exit_status, 0);
 
 	if (which_dev == 2)
@@ -161,6 +181,7 @@ void user_trap_entry(void)
         if(scheduler_should_resched())
                 yield();
 
+	signal_user_return(from_syscall);
         user_trap_ret();
 }
 

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -91,8 +91,6 @@ void kernel_trap(void)
         sstatus_w(sstatus);
 }
 
-extern void exit(int cause);
-
 __attribute__((noreturn)) void kernel_stack_overflow(uint64 stack_pointer)
 {
 	printf_enter_panic();
@@ -108,6 +106,7 @@ __attribute__((noreturn)) void kernel_stack_overflow(uint64 stack_pointer)
 void user_trap_entry(void)
 {
         int which_dev = 0;
+	int exit_status;
         process_t p = cur_proc();
         uint64 cause = scause_r();
 
@@ -120,8 +119,10 @@ void user_trap_entry(void)
         cur_thread()->trapframe->epc = sepc_r();
 
         if(cause == 8) {
-                if(killed(p))
-                        exit(-1);
+		if (killed(p) || process_group_exiting(p, &exit_status))
+			process_thread_exit(killed(p) ? -1 : exit_status, 0);
+		if (process_thread_exit_requested(cur_thread(), &exit_status))
+			process_thread_exit(exit_status, 0);
 
                 /* System call */
                 cur_thread()->trapframe->epc += 4;
@@ -134,7 +135,7 @@ void user_trap_entry(void)
 		pr_warn("process: pid=%d (%s) page fault cause=%lu "
 			"address=%p epc=%p", p->pid, p->name, cause,
 			stval_r(), cur_thread()->trapframe->epc);
-		exit(-1);
+		process_thread_exit(-1, 1);
 		return;
         } else {
                 if((which_dev = dev_intr(cause)) == 0) {
@@ -145,8 +146,10 @@ void user_trap_entry(void)
                 }
         }
 
-        if(killed(p))
-                exit(-1);
+	if (killed(p) || process_group_exiting(p, &exit_status))
+		process_thread_exit(killed(p) ? -1 : exit_status, 0);
+	if (process_thread_exit_requested(cur_thread(), &exit_status))
+		process_thread_exit(exit_status, 0);
 
 	if (which_dev == 2)
 		scheduler_tick();

--- a/arch/riscv/trap.c
+++ b/arch/riscv/trap.c
@@ -1,6 +1,7 @@
 #include <trap.h>
 #include <spinlock.h>
 #include <debug.h>
+#include <cpu.h>
 #include <irq.h>
 #include <scheduler.h>
 #include <printf.h>
@@ -34,6 +35,7 @@ static int dev_intr(uint64 scause)
         if((scause & 0x8000000000000000L) &&
            (scause & 0xff) == 1) {
                 sip_clear_ssip();
+		cpu_membarrier_interrupt();
                 return 3;
         }
         /* This is a supervisor external interrupt via PLIC */

--- a/arch/riscv/vm.c
+++ b/arch/riscv/vm.c
@@ -457,6 +457,8 @@ static int vm_copy_walk(pagedir_t old, pagedir_t new, int level,
 		if (!(pte & PTE_V))
 			continue;
 		va = base | ((uint64)i << (PGSHIFT + 9 * level));
+		if (va == USER_SIGRETURN)
+			continue;
 		if (!(pte & (PTE_R | PTE_W | PTE_X))) {
 			if (level == 0 ||
 			    vm_copy_walk((pagedir_t)PTE2PA(pte), new,

--- a/arch/riscv/vm.c
+++ b/arch/riscv/vm.c
@@ -92,6 +92,29 @@ static uint64 user_va2pa(pagedir_t pgdir, uint64 va, int permissions)
 	       (va & (leaf_size - 1) & ~(PGSIZE - 1));
 }
 
+static uint64 user_copy_va2pa_pinned(pagedir_t pgdir, uint64 va,
+				     int permissions, void **pinned_page)
+{
+	void *page;
+	uint64 physical, validated;
+
+	*pinned_page = 0;
+	for (;;) {
+		physical = user_va2pa(pgdir, va, permissions);
+		if (!physical)
+			return 0;
+		page = (void *)PGROUNDDOWN(physical);
+		if (palloc_get(page) < 0)
+			continue;
+		validated = user_va2pa(pgdir, va, permissions);
+		if (validated == physical) {
+			*pinned_page = page;
+			return physical;
+		}
+		pfree(page);
+	}
+}
+
 uint64 va2pa(pagedir_t pgdir, uint64 va)
 {
 	return user_va2pa(pgdir, va, 0);
@@ -519,17 +542,20 @@ void vm_free_user(pagedir_t pgdir)
 
 int copyout(pagedir_t pgdir, uint64 dstva, char* src, uint64 len)
 {
+	void *pinned_page;
         uint64 n, va0, pa0;
 
         while(len > 0){
                 va0 = PGROUNDDOWN(dstva);
-                pa0 = user_va2pa(pgdir, va0, PTE_W);
+		pa0 = user_copy_va2pa_pinned(pgdir, va0, PTE_W,
+					     &pinned_page);
                 if(pa0 == 0)
                         return -1;
                 n = PGSIZE - (dstva - va0);
                 if(n > len)
                         n = len;
                 memmove((void *)(pa0 + (dstva - va0)), src, n);
+		pfree(pinned_page);
 
                 len -= n;
                 src += n;
@@ -540,17 +566,20 @@ int copyout(pagedir_t pgdir, uint64 dstva, char* src, uint64 len)
 
 int copyin(pagedir_t pgdir, char* dst, uint64 srcva, uint64 len)
 {
+	void *pinned_page;
          uint64 n, va0, pa0;
 
         while(len > 0){
                 va0 = PGROUNDDOWN(srcva);
-                pa0 = user_va2pa(pgdir, va0, PTE_R);
+		pa0 = user_copy_va2pa_pinned(pgdir, va0, PTE_R,
+					     &pinned_page);
                 if(pa0 == 0)
                         return -1;
                 n = PGSIZE - (srcva - va0);
                 if(n > len)
                         n = len;
                 memmove(dst, (void *)(pa0 + (srcva - va0)),n);
+		pfree(pinned_page);
 
                 len -= n;
                 dst += n;
@@ -561,12 +590,14 @@ int copyin(pagedir_t pgdir, char* dst, uint64 srcva, uint64 len)
 
 int copyinstr(pagedir_t pgdir, char *dst, uint64 srcva, uint64 max)
 {
+	void *pinned_page;
         uint64 n, va0, pa0;
         int got_null = 0;
 
         while(got_null == 0 && max > 0) {
                 va0 = PGROUNDDOWN(srcva);
-                pa0 = user_va2pa(pgdir, va0, PTE_R);
+		pa0 = user_copy_va2pa_pinned(pgdir, va0, PTE_R,
+					     &pinned_page);
                 if(pa0 == 0)
                         return -1;
                 n = PGSIZE - (srcva - va0);
@@ -587,6 +618,7 @@ int copyinstr(pagedir_t pgdir, char *dst, uint64 srcva, uint64 max)
                         p++;
                         dst++;
                 }
+		pfree(pinned_page);
 
                 srcva = va0 + PGSIZE;
         }

--- a/drivers/tty/tty.c
+++ b/drivers/tty/tty.c
@@ -80,7 +80,12 @@ static int64 tty_read(struct tty *tty, int user_destination,
 				spinlock_release(&tty->lock);
 				return total;
 			}
-			wait_queue_sleep(&tty->read_wait, &tty->lock);
+			if (wait_queue_sleep_interruptible(&tty->read_wait,
+			                                   &tty->lock) ==
+			    WAIT_QUEUE_INTERRUPTED) {
+				spinlock_release(&tty->lock);
+				return total ? total : VFS_ERR_INTR;
+			}
 		}
 		if (tty->read_position == tty->commit_position &&
 		    tty->eof_pending) {

--- a/include/kernel_config.h
+++ b/include/kernel_config.h
@@ -14,7 +14,7 @@
 #define NPROC                           64
 
 #define NTHREAD                         64
-#define PROC_MAXTHREAD                  3
+#define PROC_MAXTHREAD                  32
 
 #define MAXNAME                         16
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,7 @@ obj-y += debug.o string.o memrange.o buddy.o palloc.o spinlock.o rbtree.o \
 vma.o elf.o \
 ktime.o \
 timeconv.o \
-printk.o thread.o wait.o futex.o \
+printk.o thread.o wait.o futex.o membarrier.o \
 sleeplock.o switchto.o trampoline.o process.o mmap.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o workqueue.o main.o

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,7 @@ obj-y += debug.o string.o memrange.o buddy.o palloc.o spinlock.o rbtree.o \
 vma.o elf.o \
 ktime.o \
 timeconv.o \
-printk.o thread.o wait.o \
+printk.o thread.o wait.o futex.o \
 sleeplock.o switchto.o trampoline.o process.o mmap.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o workqueue.o main.o

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,7 @@ obj-y += debug.o string.o memrange.o buddy.o palloc.o spinlock.o rbtree.o \
 vma.o elf.o \
 ktime.o \
 timeconv.o \
-printk.o thread.o wait.o futex.o membarrier.o \
+printk.o thread.o wait.o futex.o membarrier.o signal.o \
 sleeplock.o switchto.o trampoline.o process.o mmap.o\
 plic.o console.o printf.o scheduler.o \
 exec.o sysfile.o syscall.o sysproc.o workqueue.o main.o

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -374,6 +374,8 @@ int exec_linux(char *path, char **argv, char **envp)
 	current->trapframe->epc = entry;
 	memset(current->trapframe->f, 0, sizeof(current->trapframe->f));
 	current->trapframe->fcsr = 0;
+	__atomic_store_n(&process->membarrier_private_expedited, 0,
+	                 __ATOMIC_RELEASE);
 
 	for (name = path_p = path; *path_p; path_p++) {
 		if (*path_p == '/')

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -376,6 +376,7 @@ int exec_linux(char *path, char **argv, char **envp)
 	current->trapframe->fcsr = 0;
 	__atomic_store_n(&process->membarrier_private_expedited, 0,
 	                 __ATOMIC_RELEASE);
+	signal_process_exec(process, current);
 
 	for (name = path_p = path; *path_p; path_p++) {
 		if (*path_p == '/')

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -298,11 +298,14 @@ int exec_linux(char *path, char **argv, char **envp)
 	char interpreter_path[MAXPATH];
 	pagedir_t oldpgdir, pgdir = 0;
 	process_t process = cur_proc();
+	thread_t current = cur_thread();
 	uint64 entry, oldsz, sp, sz = 0;
 	char *name, *path_p;
 	int argc, stack_permissions = PTE_W;
 	uint32 stack_protection = LINUX_PROT_READ | LINUX_PROT_WRITE;
 
+	if (process_exec_begin(process, current) < 0)
+		return -1;
 	vma_set_init(&new_vmas);
 	vma_set_init(&old_vmas);
 	if (elf_image_open(path, &executable) < 0)
@@ -311,7 +314,7 @@ int exec_linux(char *path, char **argv, char **envp)
 	    elf_image_interpreter(&executable, interpreter_path) < 0)
 		goto fail;
 
-	pgdir = process_pagedir(process);
+	pgdir = process_pagedir(process, current);
 	if (!pgdir ||
 	    elf_image_place(&executable, &new_vmas, USER_PIE_BASE) < 0 ||
 	    elf_image_map(&executable, pgdir, &new_vmas) < 0)
@@ -352,6 +355,8 @@ int exec_linux(char *path, char **argv, char **envp)
 				 argv, envp, &exec, &sp);
 	if (argc < 0)
 		goto fail;
+	if (process_exec_quiesce(process, current) < 0)
+		goto fail;
 
 	sleeplock_acquire(&process->mmap_lock);
 	oldpgdir = process->pagetable;
@@ -363,19 +368,19 @@ int exec_linux(char *path, char **argv, char **envp)
 	process->brk = sz;
 	process->brk_start = sz;
 	sleeplock_release(&process->mmap_lock);
-	cur_thread()->trapframe->a0 = argc;
-	cur_thread()->trapframe->a1 = sp + sizeof(uint64);
-	cur_thread()->trapframe->sp = sp;
-	cur_thread()->trapframe->epc = entry;
-	memset(cur_thread()->trapframe->f, 0,
-	       sizeof(cur_thread()->trapframe->f));
-	cur_thread()->trapframe->fcsr = 0;
+	current->trapframe->a0 = argc;
+	current->trapframe->a1 = sp + sizeof(uint64);
+	current->trapframe->sp = sp;
+	current->trapframe->epc = entry;
+	memset(current->trapframe->f, 0, sizeof(current->trapframe->f));
+	current->trapframe->fcsr = 0;
 
 	for (name = path_p = path; *path_p; path_p++) {
 		if (*path_p == '/')
 			name = path_p + 1;
 	}
 	safe_strncpy(process->name, name, MAXNAME);
+	process_exec_end(process);
 	process_freepagedir(oldpgdir, oldsz);
 	vma_set_destroy(&old_vmas);
 	return argc;
@@ -386,5 +391,6 @@ fail:
 	if (pgdir)
 		process_freepagedir(pgdir, sz);
 	vma_set_destroy(&new_vmas);
+	process_exec_end(process);
 	return -1;
 }

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -718,21 +718,32 @@ static int fd_alloc(file_t file, int minimum, uint8 flags)
 
 	if (minimum < 0)
 		minimum = 0;
+	spinlock_acquire(&process->files_lock);
 	for (fd = minimum; fd < NOFILE; fd++) {
 		if (!process->ofile[fd]) {
 			process->ofile[fd] = file;
 			process->fd_flags[fd] = flags;
+			spinlock_release(&process->files_lock);
 			return fd;
 		}
 	}
+	spinlock_release(&process->files_lock);
 	return -1;
 }
 
 static int fd_get(int fd, file_t *file)
 {
-	if (fd < 0 || fd >= NOFILE || !cur_proc()->ofile[fd])
+	process_t process = cur_proc();
+
+	if (fd < 0 || fd >= NOFILE)
 		return VFS_ERR_BADF;
-	*file = cur_proc()->ofile[fd];
+	spinlock_acquire(&process->files_lock);
+	if (!process->ofile[fd]) {
+		spinlock_release(&process->files_lock);
+		return VFS_ERR_BADF;
+	}
+	*file = file_dup(process->ofile[fd]);
+	spinlock_release(&process->files_lock);
 	return VFS_OK;
 }
 
@@ -919,14 +930,9 @@ int vfs_install_file(file_t file, uint8 flags, int *fd_out)
 
 int vfs_get_file_fd(int fd, file_t *result)
 {
-	file_t file;
-
 	if (!result)
 		return VFS_ERR_INVAL;
-	if (fd_get(fd, &file) != VFS_OK)
-		return VFS_ERR_BADF;
-	*result = file_dup(file);
-	return VFS_OK;
+	return fd_get(fd, result);
 }
 
 uint32 vfs_file_poll(struct vfs_file *file, uint32 events)
@@ -1038,12 +1044,20 @@ void vfs_poll_notify(void)
 
 int vfs_close(int fd)
 {
+	process_t process = cur_proc();
 	file_t file;
 
-	if (fd_get(fd, &file) != VFS_OK)
+	if (fd < 0 || fd >= NOFILE)
 		return VFS_ERR_BADF;
-	cur_proc()->ofile[fd] = 0;
-	cur_proc()->fd_flags[fd] = 0;
+	spinlock_acquire(&process->files_lock);
+	file = process->ofile[fd];
+	if (!file) {
+		spinlock_release(&process->files_lock);
+		return VFS_ERR_BADF;
+	}
+	process->ofile[fd] = 0;
+	process->fd_flags[fd] = 0;
+	spinlock_release(&process->files_lock);
 	file_close(file);
 	vfs_poll_notify();
 	return VFS_OK;
@@ -1051,15 +1065,31 @@ int vfs_close(int fd)
 
 int vfs_dup(int oldfd, int minimum, uint8 flags, int *fd_out)
 {
+	process_t process = cur_proc();
 	file_t file;
 	int fd;
 
-	if (fd_get(oldfd, &file) != VFS_OK)
+	if (oldfd < 0 || oldfd >= NOFILE)
 		return VFS_ERR_BADF;
-	fd = fd_alloc(file, minimum, flags);
-	if (fd < 0)
+	if (minimum < 0)
+		minimum = 0;
+	spinlock_acquire(&process->files_lock);
+	file = process->ofile[oldfd];
+	if (!file) {
+		spinlock_release(&process->files_lock);
+		return VFS_ERR_BADF;
+	}
+	for (fd = minimum; fd < NOFILE; fd++) {
+		if (!process->ofile[fd])
+			break;
+	}
+	if (fd == NOFILE) {
+		spinlock_release(&process->files_lock);
 		return VFS_ERR_MFILE;
-	file_dup(file);
+	}
+	process->ofile[fd] = file_dup(file);
+	process->fd_flags[fd] = flags;
+	spinlock_release(&process->files_lock);
 	*fd_out = fd;
 	return VFS_OK;
 }
@@ -1067,18 +1097,25 @@ int vfs_dup(int oldfd, int minimum, uint8 flags, int *fd_out)
 int vfs_dup_to(int oldfd, int newfd, uint8 flags)
 {
 	process_t process = cur_proc();
-	file_t file;
+	file_t file, replaced;
 
-	if (fd_get(oldfd, &file) != VFS_OK)
-		return VFS_ERR_BADF;
-	if (newfd < 0 || newfd >= NOFILE)
+	if (oldfd < 0 || oldfd >= NOFILE || newfd < 0 || newfd >= NOFILE)
 		return VFS_ERR_BADF;
 	if (oldfd == newfd)
 		return VFS_ERR_INVAL;
-	if (process->ofile[newfd])
-		vfs_close(newfd);
+	spinlock_acquire(&process->files_lock);
+	file = process->ofile[oldfd];
+	if (!file) {
+		spinlock_release(&process->files_lock);
+		return VFS_ERR_BADF;
+	}
+	replaced = process->ofile[newfd];
 	process->ofile[newfd] = file_dup(file);
 	process->fd_flags[newfd] = flags;
+	spinlock_release(&process->files_lock);
+	if (replaced)
+		file_close(replaced);
+	vfs_poll_notify();
 	return VFS_OK;
 }
 
@@ -1090,8 +1127,10 @@ int vfs_read(int fd, uint64 address, int length)
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
 	if (length < 0)
-		return VFS_ERR_INVAL;
-	result = file_read(file, 1, address, length, &file->position);
+		result = VFS_ERR_INVAL;
+	else
+		result = file_read(file, 1, address, length, &file->position);
+	vfs_file_put(file);
 	return result > 0x7fffffff ? VFS_ERR_INVAL : result;
 }
 
@@ -1124,17 +1163,20 @@ int vfs_write(int fd, uint64 address, int length)
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
-	if (length < 0)
-		return VFS_ERR_INVAL;
-	lock = vfs_regular_write_lock(file);
-	if (lock)
-		sleeplock_acquire(lock);
-	result = vfs_prepare_append(file);
-	if (result >= 0)
-		result = file_write(file, 1, address, length,
-				    &file->position);
-	if (lock)
-		sleeplock_release(lock);
+	if (length < 0) {
+		result = VFS_ERR_INVAL;
+	} else {
+		lock = vfs_regular_write_lock(file);
+		if (lock)
+			sleeplock_acquire(lock);
+		result = vfs_prepare_append(file);
+		if (result >= 0)
+			result = file_write(file, 1, address, length,
+					    &file->position);
+		if (lock)
+			sleeplock_release(lock);
+	}
+	vfs_file_put(file);
 	return result > 0x7fffffff ? VFS_ERR_INVAL : result;
 }
 
@@ -1149,11 +1191,15 @@ int64 vfs_writev(int fd, int user_source,
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
-	if (!(file->flags & VFS_OPEN_WRITE))
-		return VFS_ERR_BADF;
+	if (!(file->flags & VFS_OPEN_WRITE)) {
+		result = VFS_ERR_BADF;
+		goto out_file;
+	}
 	for (index = 0; index < count; index++) {
-		if (iovecs[index].length > 0x7fffffff)
-			return VFS_ERR_INVAL;
+		if (iovecs[index].length > 0x7fffffff) {
+			result = VFS_ERR_INVAL;
+			goto out_file;
+		}
 	}
 	lock = vfs_regular_write_lock(file);
 	if (lock)
@@ -1181,6 +1227,8 @@ int64 vfs_writev(int fd, int user_source,
 out:
 	if (lock)
 		sleeplock_release(lock);
+out_file:
+	vfs_file_put(file);
 	return result;
 }
 
@@ -1219,10 +1267,13 @@ out:
 int64 vfs_ioctl(int fd, uint64 request, uint64 argument)
 {
 	file_t file;
+	int64 result;
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
-	return file_ioctl(file, request, argument);
+	result = file_ioctl(file, request, argument);
+	vfs_file_put(file);
+	return result;
 }
 
 int vfs_seek(int fd, int64 offset, int whence, uint64 *result)
@@ -1234,8 +1285,10 @@ int vfs_seek(int fd, int64 offset, int whence, uint64 *result)
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
-	if (!file->path.dentry)
-		return VFS_ERR_SPIPE;
+	if (!file->path.dentry) {
+		status = VFS_ERR_SPIPE;
+		goto out;
+	}
 	if (whence == 0)
 		next = offset;
 	else if (whence == 1)
@@ -1243,30 +1296,41 @@ int vfs_seek(int fd, int64 offset, int whence, uint64 *result)
 	else if (whence == 2) {
 		status = vfs_inode_stat(file->path.dentry->inode, &stat);
 		if (status < 0)
-			return status;
+			goto out;
 		next = (int64)stat.size + offset;
 	} else {
-		return VFS_ERR_INVAL;
+		status = VFS_ERR_INVAL;
+		goto out;
 	}
-	if (next < 0)
-		return VFS_ERR_INVAL;
+	if (next < 0) {
+		status = VFS_ERR_INVAL;
+		goto out;
+	}
 	file->position = next;
 	*result = next;
-	return VFS_OK;
+	status = VFS_OK;
+out:
+	vfs_file_put(file);
+	return status;
 }
 
 int vfs_stat_fd(int fd, struct vfs_stat *stat)
 {
 	file_t file;
+	int result;
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
 	if (!file->path.dentry) {
 		if (!file->operations || !file->operations->getattr)
-			return VFS_ERR_INVAL;
-		return file->operations->getattr(file, stat);
+			result = VFS_ERR_INVAL;
+		else
+			result = file->operations->getattr(file, stat);
+	} else {
+		result = vfs_inode_stat(file->path.dentry->inode, stat);
 	}
-	return vfs_inode_stat(file->path.dentry->inode, stat);
+	vfs_file_put(file);
+	return result;
 }
 
 int vfs_stat_path(const char *name, int follow_symlink,
@@ -1286,16 +1350,20 @@ int vfs_stat_path(const char *name, int follow_symlink,
 int vfs_next_dirent(int fd, struct vfs_dirent *dirent)
 {
 	file_t file;
+	int result;
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
 	if (!file->path.dentry)
-		return VFS_ERR_NOTDIR;
-	if (file->path.dentry->inode->type != VFS_INODE_DIRECTORY)
-		return VFS_ERR_NOTDIR;
-	if (!file->operations || !file->operations->readdir)
-		return VFS_ERR_NOTSUPP;
-	return file->operations->readdir(file, dirent);
+		result = VFS_ERR_NOTDIR;
+	else if (file->path.dentry->inode->type != VFS_INODE_DIRECTORY)
+		result = VFS_ERR_NOTDIR;
+	else if (!file->operations || !file->operations->readdir)
+		result = VFS_ERR_NOTSUPP;
+	else
+		result = file->operations->readdir(file, dirent);
+	vfs_file_put(file);
+	return result;
 }
 
 int vfs_mkdir(const char *name, uint32 mode)
@@ -1511,12 +1579,16 @@ out_source:
 int vfs_fsync(int fd)
 {
 	file_t file;
+	int result;
 
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
 	if (!file->operations || !file->operations->fsync)
-		return VFS_ERR_INVAL;
-	return file->operations->fsync(file);
+		result = VFS_ERR_INVAL;
+	else
+		result = file->operations->fsync(file);
+	vfs_file_put(file);
+	return result;
 }
 
 int vfs_sync(void)
@@ -1623,23 +1695,33 @@ int vfs_access(const char *name)
 
 int vfs_get_fd_flags(int fd, uint8 *flags)
 {
-	file_t file;
+	process_t process = cur_proc();
 
-	if (fd_get(fd, &file) != VFS_OK)
+	if (fd < 0 || fd >= NOFILE)
 		return VFS_ERR_BADF;
-	(void)file;
-	*flags = cur_proc()->fd_flags[fd];
+	spinlock_acquire(&process->files_lock);
+	if (!process->ofile[fd]) {
+		spinlock_release(&process->files_lock);
+		return VFS_ERR_BADF;
+	}
+	*flags = process->fd_flags[fd];
+	spinlock_release(&process->files_lock);
 	return VFS_OK;
 }
 
 int vfs_set_fd_flags(int fd, uint8 flags)
 {
-	file_t file;
+	process_t process = cur_proc();
 
-	if (fd_get(fd, &file) != VFS_OK)
+	if (fd < 0 || fd >= NOFILE)
 		return VFS_ERR_BADF;
-	(void)file;
-	cur_proc()->fd_flags[fd] = flags;
+	spinlock_acquire(&process->files_lock);
+	if (!process->ofile[fd]) {
+		spinlock_release(&process->files_lock);
+		return VFS_ERR_BADF;
+	}
+	process->fd_flags[fd] = flags;
+	spinlock_release(&process->files_lock);
 	return VFS_OK;
 }
 
@@ -1650,6 +1732,7 @@ int vfs_get_file_flags(int fd, uint32 *flags)
 	if (fd_get(fd, &file) != VFS_OK)
 		return VFS_ERR_BADF;
 	*flags = file->flags;
+	vfs_file_put(file);
 	return VFS_OK;
 }
 
@@ -1665,20 +1748,34 @@ int vfs_set_file_flags(int fd, uint32 flags)
 	next = (file->flags & ~mutable) | (flags & mutable);
 	if (file->operations && file->operations->set_flags) {
 		status = file->operations->set_flags(file, next);
-		if (status < 0)
+		if (status < 0) {
+			vfs_file_put(file);
 			return status;
+		}
 	}
 	file->flags = next;
+	vfs_file_put(file);
 	return VFS_OK;
 }
 
 void vfs_close_on_exec(void)
 {
-	int fd;
+	process_t process = cur_proc();
+	file_t files[NOFILE];
+	int count = 0, fd;
 
+	spinlock_acquire(&process->files_lock);
 	for (fd = 0; fd < NOFILE; fd++) {
-		if (cur_proc()->ofile[fd] &&
-		    (cur_proc()->fd_flags[fd] & VFS_FD_CLOEXEC))
-			vfs_close(fd);
+		if (!process->ofile[fd] ||
+		    !(process->fd_flags[fd] & VFS_FD_CLOEXEC))
+			continue;
+		files[count++] = process->ofile[fd];
+		process->ofile[fd] = 0;
+		process->fd_flags[fd] = 0;
 	}
+	spinlock_release(&process->files_lock);
+	for (fd = 0; fd < count; fd++)
+		file_close(files[fd]);
+	if (count)
+		vfs_poll_notify();
 }

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -994,7 +994,10 @@ int vfs_poll(struct vfs_pollfd *fds, uint32 count, int timeout_ms)
 				break;
 			remaining = timeout_ms - elapsed;
 		}
-		vfs_poll_wait(generation, remaining);
+		if (vfs_poll_wait(generation, remaining) == VFS_ERR_INTR) {
+			ready = VFS_ERR_INTR;
+			break;
+		}
 	}
 	for (index = 0; index < count; index++) {
 		if (files[index])
@@ -1025,10 +1028,13 @@ int vfs_poll_wait(uint64 generation, int timeout_ms)
 		goto out;
 	}
 	if (timeout_ms < 0)
-		wait_queue_sleep(&poll_state.wait, &poll_state.lock);
+		result = wait_queue_sleep_interruptible(
+			&poll_state.wait, &poll_state.lock);
 	else
-		result = wait_queue_sleep_timeout(
+		result = wait_queue_sleep_interruptible_timeout(
 			&poll_state.wait, &poll_state.lock, timeout_ms);
+	if (result == WAIT_QUEUE_INTERRUPTED)
+		result = VFS_ERR_INTR;
 out:
 	spinlock_release(&poll_state.lock);
 	return result;

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -1,0 +1,521 @@
+#include <debug.h>
+#include <futex.h>
+#include <ktime.h>
+#include <linux_uapi.h>
+#include <process.h>
+#include <scheduler.h>
+#include <syscall.h>
+#include <vm.h>
+#include <wait.h>
+
+#define FUTEX_SLOT_COUNT 128
+#define FUTEX_ROBUST_LIMIT 2048
+#define FUTEX_TID_MASK 0x3fffffffU
+
+struct futex_key {
+	process_t process;
+	uint64 address;
+	uint8 shared;
+};
+
+struct futex_slot {
+	struct futex_key key;
+	struct wait_queue wait;
+	uint32 waiters;
+	uint8 active;
+};
+
+struct linux_robust_list_head {
+	uint64 next;
+	int64 futex_offset;
+	uint64 pending;
+};
+
+_Static_assert(sizeof(struct linux_robust_list_head) == 24,
+	       "Linux robust-list layout changed");
+
+static struct {
+	struct spinlock lock;
+	struct futex_slot slots[FUTEX_SLOT_COUNT];
+} futex_table;
+
+static int futex_key_equal(const struct futex_key *left,
+			   const struct futex_key *right)
+{
+	return left->process == right->process &&
+	       left->address == right->address &&
+	       left->shared == right->shared;
+}
+
+static int futex_key_get(process_t process, uint64 address, int private,
+			 struct futex_key *key)
+{
+	uint32 value;
+	uint64 physical;
+
+	if (!key || address & (sizeof(value) - 1))
+		return -LINUX_EINVAL;
+	if (copyin(process->pagetable, (char *)&value, address,
+	           sizeof(value)) < 0)
+		return -LINUX_EFAULT;
+	key->shared = !private;
+	if (private) {
+		key->process = process;
+		key->address = address;
+		return 0;
+	}
+	physical = vm_user_pa(process->pagetable, address);
+	if (!physical)
+		return -LINUX_EFAULT;
+	key->process = 0;
+	key->address = physical;
+	return 0;
+}
+
+static struct futex_slot *futex_slot_find_locked(
+	const struct futex_key *key)
+{
+	int index;
+
+	if (!spinlock_holding(&futex_table.lock))
+		PANIC("futex lookup unlocked");
+	for (index = 0; index < FUTEX_SLOT_COUNT; index++) {
+		struct futex_slot *slot = &futex_table.slots[index];
+
+		if (slot->active && futex_key_equal(&slot->key, key))
+			return slot;
+	}
+	return 0;
+}
+
+static struct futex_slot *futex_slot_get_locked(
+	const struct futex_key *key)
+{
+	struct futex_slot *slot;
+	int index;
+
+	slot = futex_slot_find_locked(key);
+	if (slot)
+		return slot;
+	for (index = 0; index < FUTEX_SLOT_COUNT; index++) {
+		slot = &futex_table.slots[index];
+		if (slot->active)
+			continue;
+		slot->key = *key;
+		slot->waiters = 0;
+		slot->active = 1;
+		return slot;
+	}
+	return 0;
+}
+
+static void futex_slot_put_locked(struct futex_slot *slot)
+{
+	if (!spinlock_holding(&futex_table.lock) || !slot ||
+	    !slot->active || !slot->waiters)
+		PANIC("invalid futex slot put");
+	slot->waiters--;
+	if (!slot->waiters) {
+		if (!wait_queue_empty(&slot->wait))
+			PANIC("empty futex reference count");
+		slot->active = 0;
+	}
+}
+
+static int futex_relative_timeout(process_t process, uint64 address,
+				  uint64 *milliseconds)
+{
+	struct linux_timespec timeout;
+	uint64 result;
+
+	if (!address)
+		return 0;
+	if (copyin(process->pagetable, (char *)&timeout, address,
+	           sizeof(timeout)) < 0)
+		return -LINUX_EFAULT;
+	if (timeout.seconds < 0 || timeout.nanoseconds < 0 ||
+	    timeout.nanoseconds >= (int64)NSEC_PER_SEC)
+		return -LINUX_EINVAL;
+	if (!timeout.seconds && !timeout.nanoseconds)
+		return -LINUX_ETIMEDOUT;
+	if ((uint64)timeout.seconds >
+	    (~(uint64)0 - 999999ULL) / 1000ULL)
+		result = ~(uint64)0;
+	else
+		result = (uint64)timeout.seconds * 1000ULL +
+			 ((uint64)timeout.nanoseconds + 999999ULL) /
+			 1000000ULL;
+	*milliseconds = result;
+	return 1;
+}
+
+static int futex_absolute_timeout(process_t process, uint64 address,
+				  uint64 *milliseconds)
+{
+	struct linux_timespec timeout;
+	uint64 absolute, now;
+
+	if (!address)
+		return 0;
+	if (copyin(process->pagetable, (char *)&timeout, address,
+	           sizeof(timeout)) < 0)
+		return -LINUX_EFAULT;
+	if (timeout.seconds < 0 || timeout.nanoseconds < 0 ||
+	    timeout.nanoseconds >= (int64)NSEC_PER_SEC)
+		return -LINUX_EINVAL;
+	if ((uint64)timeout.seconds >
+	    (~(uint64)0 - (uint64)timeout.nanoseconds) /
+	    NSEC_PER_SEC)
+		absolute = ~(uint64)0;
+	else
+		absolute = (uint64)timeout.seconds * NSEC_PER_SEC +
+			   (uint64)timeout.nanoseconds;
+	now = ktime_get_ns();
+	if (absolute <= now)
+		return -LINUX_ETIMEDOUT;
+	*milliseconds = (absolute - now + 999999ULL) / 1000000ULL;
+	return 1;
+}
+
+static int futex_wait(uint64 address, int private, uint32 expected,
+		      uint64 timeout_address, uint32 bitset,
+		      int absolute)
+{
+	struct futex_key key;
+	struct futex_slot *slot;
+	process_t process = cur_proc();
+	thread_t current = cur_thread();
+	uint64 milliseconds = 0;
+	uint32 value;
+	int result, timed;
+
+	if (!bitset)
+		return -LINUX_EINVAL;
+	result = futex_key_get(process, address, private, &key);
+	if (result < 0)
+		return result;
+	timed = absolute ?
+		futex_absolute_timeout(process, timeout_address,
+		                       &milliseconds) :
+		futex_relative_timeout(process, timeout_address,
+		                       &milliseconds);
+	if (timed < 0)
+		return timed;
+
+	spinlock_acquire(&futex_table.lock);
+	if (copyin(process->pagetable, (char *)&value, address,
+	           sizeof(value)) < 0) {
+		spinlock_release(&futex_table.lock);
+		return -LINUX_EFAULT;
+	}
+	if (value != expected) {
+		spinlock_release(&futex_table.lock);
+		return -LINUX_EAGAIN;
+	}
+	slot = futex_slot_get_locked(&key);
+	if (!slot) {
+		spinlock_release(&futex_table.lock);
+		return -LINUX_ENOMEM;
+	}
+	slot->waiters++;
+	current->wait_private = slot;
+	current->wait_bitset = bitset;
+	if (timed)
+		result = wait_queue_sleep_timeout(&slot->wait,
+			&futex_table.lock, milliseconds);
+	else {
+		wait_queue_sleep(&slot->wait, &futex_table.lock);
+		result = 0;
+	}
+	slot = current->wait_private;
+	if (!slot)
+		PANIC("futex waiter lost slot");
+	futex_slot_put_locked(slot);
+	current->wait_private = 0;
+	current->wait_bitset = ~(uint32)0;
+	spinlock_release(&futex_table.lock);
+	return result < 0 ? -LINUX_ETIMEDOUT : 0;
+}
+
+static int futex_wake_key_locked(const struct futex_key *key, int count,
+				 uint32 bitset)
+{
+	struct futex_slot *slot;
+
+	slot = futex_slot_find_locked(key);
+	if (!slot)
+		return 0;
+	return wait_queue_wake_mask(&slot->wait, count, bitset);
+}
+
+static int futex_wake(uint64 address, int private, int count,
+		      uint32 bitset)
+{
+	struct futex_key key;
+	process_t process = cur_proc();
+	int result;
+
+	if (count < 0 || !bitset)
+		return -LINUX_EINVAL;
+	result = futex_key_get(process, address, private, &key);
+	if (result < 0)
+		return result;
+	spinlock_acquire(&futex_table.lock);
+	result = futex_wake_key_locked(&key, count, bitset);
+	spinlock_release(&futex_table.lock);
+	return result;
+}
+
+static int futex_requeue(uint64 address, int private, int wake_count,
+			 int requeue_count, uint64 destination,
+			 int compare, uint32 expected)
+{
+	struct futex_key source_key, destination_key;
+	struct futex_slot *source, *target;
+	process_t process = cur_proc();
+	uint32 value;
+	int moved, result, woken;
+
+	if (wake_count < 0 || requeue_count < 0)
+		return -LINUX_EINVAL;
+	result = futex_key_get(process, address, private, &source_key);
+	if (result < 0)
+		return result;
+	result = futex_key_get(process, destination, private,
+	                       &destination_key);
+	if (result < 0)
+		return result;
+	if (futex_key_equal(&source_key, &destination_key))
+		return -LINUX_EINVAL;
+	spinlock_acquire(&futex_table.lock);
+	if (compare) {
+		if (copyin(process->pagetable, (char *)&value, address,
+		           sizeof(value)) < 0) {
+			spinlock_release(&futex_table.lock);
+			return -LINUX_EFAULT;
+		}
+		if (value != expected) {
+			spinlock_release(&futex_table.lock);
+			return -LINUX_EAGAIN;
+		}
+	}
+	source = futex_slot_find_locked(&source_key);
+	if (!source) {
+		spinlock_release(&futex_table.lock);
+		return 0;
+	}
+	woken = wait_queue_wake_mask(&source->wait, wake_count,
+	                              LINUX_FUTEX_BITSET_MATCH_ANY);
+	if (!requeue_count) {
+		spinlock_release(&futex_table.lock);
+		return woken;
+	}
+	target = futex_slot_get_locked(&destination_key);
+	if (!target) {
+		spinlock_release(&futex_table.lock);
+		return woken ? woken : -LINUX_ENOMEM;
+	}
+	moved = wait_queue_requeue(&source->wait, &target->wait,
+	                          requeue_count, target);
+	if (source->waiters < (uint32)moved)
+		PANIC("futex requeue source count");
+	source->waiters -= moved;
+	target->waiters += moved;
+	if (!source->waiters)
+		source->active = 0;
+	if (!moved && !target->waiters)
+		target->active = 0;
+	spinlock_release(&futex_table.lock);
+	return woken + moved;
+}
+
+uint64 sys_linux_futex(void)
+{
+	uint64 address, destination, timeout_address;
+	int command, count, operation, private, value3;
+
+	argaddr(0, &address);
+	argint(1, &operation);
+	argint(2, &count);
+	argaddr(3, &timeout_address);
+	argaddr(4, &destination);
+	argint(5, &value3);
+	command = operation & LINUX_FUTEX_CMD_MASK;
+	private = operation & LINUX_FUTEX_PRIVATE_FLAG;
+	if (operation & ~(LINUX_FUTEX_CMD_MASK |
+	                  LINUX_FUTEX_PRIVATE_FLAG |
+	                  LINUX_FUTEX_CLOCK_REALTIME))
+		return -LINUX_EINVAL;
+	if ((operation & LINUX_FUTEX_CLOCK_REALTIME) &&
+	    command != LINUX_FUTEX_WAIT_BITSET)
+		return -LINUX_EINVAL;
+	if (operation & LINUX_FUTEX_CLOCK_REALTIME)
+		return -LINUX_ENOSYS;
+	switch (command) {
+	case LINUX_FUTEX_WAIT:
+		return futex_wait(address, private, count, timeout_address,
+		                  LINUX_FUTEX_BITSET_MATCH_ANY, 0);
+	case LINUX_FUTEX_WAIT_BITSET:
+		return futex_wait(address, private, count, timeout_address,
+		                  (uint32)value3, 1);
+	case LINUX_FUTEX_WAKE:
+		return futex_wake(address, private, count,
+		                  LINUX_FUTEX_BITSET_MATCH_ANY);
+	case LINUX_FUTEX_WAKE_BITSET:
+		return futex_wake(address, private, count, (uint32)value3);
+	case LINUX_FUTEX_REQUEUE:
+		return futex_requeue(address, private, count,
+		                     (int)timeout_address, destination, 0, 0);
+	case LINUX_FUTEX_CMP_REQUEUE:
+		return futex_requeue(address, private, count,
+		                     (int)timeout_address, destination, 1,
+		                     (uint32)value3);
+	default:
+		return -LINUX_ENOSYS;
+	}
+}
+
+uint64 sys_linux_set_robust_list(void)
+{
+	thread_t current = cur_thread();
+	uint64 address, length;
+
+	argaddr(0, &address);
+	argaddr(1, &length);
+	if (length != sizeof(struct linux_robust_list_head))
+		return -LINUX_EINVAL;
+	current->robust_list = address;
+	current->robust_list_len = length;
+	return 0;
+}
+
+uint64 sys_linux_get_robust_list(void)
+{
+	process_t process = cur_proc();
+	uint64 head_address, length_address;
+	uint64 head, length;
+	int tid;
+
+	argint(0, &tid);
+	argaddr(1, &head_address);
+	argaddr(2, &length_address);
+	if (!tid)
+		tid = cur_thread()->tid;
+	if (thread_get_robust_list(tid, &head, &length) < 0)
+		return -LINUX_ESRCH;
+	if (copyout(process->pagetable, head_address, (char *)&head,
+	            sizeof(head)) < 0 ||
+	    copyout(process->pagetable, length_address, (char *)&length,
+	            sizeof(length)) < 0)
+		return -LINUX_EFAULT;
+	return 0;
+}
+
+static void futex_wake_address(process_t process, uint64 address)
+{
+	struct futex_key key;
+
+	spinlock_acquire(&futex_table.lock);
+	if (!futex_key_get(process, address, 1, &key))
+		(void)futex_wake_key_locked(&key, 1,
+		                            LINUX_FUTEX_BITSET_MATCH_ANY);
+	if (!futex_key_get(process, address, 0, &key))
+		(void)futex_wake_key_locked(&key, 1,
+		                            LINUX_FUTEX_BITSET_MATCH_ANY);
+	spinlock_release(&futex_table.lock);
+}
+
+static void futex_robust_mark(process_t process, uint64 node,
+			      int64 offset, int tid)
+{
+	volatile uint32 *word;
+	pte_t *pte;
+	uint64 address, physical;
+	uint64 delta;
+	uint32 old, replacement;
+
+	node &= ~1ULL;
+	if (!node)
+		return;
+	if (offset < 0) {
+		delta = 0 - (uint64)offset;
+		if (node < delta)
+			return;
+		address = node - delta;
+	} else {
+		if (node > ~(uint64)0 - (uint64)offset)
+			return;
+		address = node + (uint64)offset;
+	}
+	if (address & (sizeof(*word) - 1))
+		return;
+	pte = PTE(process->pagetable, address, 0);
+	if (!pte || !(*pte & PTE_V) || !(*pte & PTE_U) ||
+	    !(*pte & PTE_W))
+		return;
+	physical = vm_user_pa(process->pagetable, address);
+	if (!physical)
+		return;
+	word = (volatile uint32 *)physical;
+	old = __atomic_load_n(word, __ATOMIC_ACQUIRE);
+	while ((old & FUTEX_TID_MASK) == (uint32)tid) {
+		replacement = (old & LINUX_FUTEX_WAITERS) |
+			      LINUX_FUTEX_OWNER_DIED;
+		if (__atomic_compare_exchange_n(word, &old, replacement, 0,
+		                                __ATOMIC_RELEASE,
+		                                __ATOMIC_ACQUIRE)) {
+			futex_wake_address(process, address);
+			break;
+		}
+	}
+}
+
+void futex_thread_exit(thread_t thread)
+{
+	struct linux_robust_list_head head;
+	process_t process = thread->home;
+	uint64 current, next, pending = 0;
+	uint32 zero = 0;
+	int count;
+
+	if (thread->robust_list &&
+	    thread->robust_list_len == sizeof(head) &&
+	    copyin(process->pagetable, (char *)&head,
+	           thread->robust_list, sizeof(head)) == 0) {
+		pending = head.pending;
+		current = head.next;
+		for (count = 0; count < FUTEX_ROBUST_LIMIT &&
+		     (current & ~1ULL) != thread->robust_list; count++) {
+			if (!current || copyin(process->pagetable, (char *)&next,
+			                       current & ~1ULL,
+			                       sizeof(next)) < 0)
+				break;
+			futex_robust_mark(process, current, head.futex_offset,
+			                  thread->tid);
+			if ((current & ~1ULL) == (pending & ~1ULL))
+				pending = 0;
+			current = next;
+		}
+		if (pending)
+			futex_robust_mark(process, pending, head.futex_offset,
+			                  thread->tid);
+	}
+	if (thread->clear_child_tid &&
+	    copyout(process->pagetable, thread->clear_child_tid,
+	            (char *)&zero, sizeof(zero)) == 0)
+		futex_wake_address(process, thread->clear_child_tid);
+}
+
+void futex_init(void)
+{
+	int index;
+
+	spinlock_init(&futex_table.lock, "futex table");
+	for (index = 0; index < FUTEX_SLOT_COUNT; index++) {
+		struct futex_slot *slot = &futex_table.slots[index];
+
+		slot->active = 0;
+		slot->waiters = 0;
+		wait_queue_init(&slot->wait, "futex");
+	}
+}

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -4,6 +4,7 @@
 #include <linux_uapi.h>
 #include <process.h>
 #include <scheduler.h>
+#include <signal.h>
 #include <syscall.h>
 #include <vm.h>
 #include <wait.h>
@@ -38,6 +39,82 @@ static struct {
 	struct spinlock lock;
 	struct futex_slot slots[FUTEX_SLOT_COUNT];
 } futex_table;
+
+void futex_restart_cancel(thread_t thread)
+{
+	if (!thread)
+		return;
+	thread->futex_restart_active = 0;
+	thread->futex_restart_armed = 0;
+	thread->futex_restart_resume = 0;
+	thread->futex_restart_private = 0;
+	thread->futex_restart_epc = 0;
+	thread->futex_restart_address = 0;
+	thread->futex_restart_timeout_address = 0;
+	thread->futex_restart_deadline = 0;
+	thread->futex_restart_expected = 0;
+	thread->futex_restart_bitset = 0;
+}
+
+void futex_restart_signal(thread_t thread, int through_handler)
+{
+	if (!thread || !thread->futex_restart_active)
+		return;
+	thread->futex_restart_armed = !!through_handler;
+	thread->futex_restart_resume = !through_handler;
+}
+
+void futex_restart_sigreturn(thread_t thread)
+{
+	if (!thread || !thread->futex_restart_active ||
+	    !thread->futex_restart_armed)
+		return;
+	if (thread->trapframe->epc != thread->futex_restart_epc ||
+	    thread->trapframe->a7 != LINUX_SYS_futex ||
+	    thread->trapframe->a0 != thread->futex_restart_address) {
+		futex_restart_cancel(thread);
+		return;
+	}
+	thread->futex_restart_armed = 0;
+	thread->futex_restart_resume = 1;
+}
+
+static int futex_restart_take(thread_t thread, uint64 address, int private,
+			      uint32 expected, uint64 timeout_address,
+			      uint32 bitset, uint64 *deadline)
+{
+	uint64 epc = thread->trapframe->epc - 4;
+
+	if (thread->futex_restart_active && thread->futex_restart_resume &&
+	    thread->futex_restart_epc == epc &&
+	    thread->futex_restart_address == address &&
+	    thread->futex_restart_private == !!private &&
+	    thread->futex_restart_expected == expected &&
+	    thread->futex_restart_timeout_address == timeout_address &&
+	    thread->futex_restart_bitset == bitset) {
+		*deadline = thread->futex_restart_deadline;
+		thread->futex_restart_resume = 0;
+		return 1;
+	}
+	futex_restart_cancel(thread);
+	return 0;
+}
+
+static void futex_restart_set(thread_t thread, uint64 address, int private,
+			      uint32 expected, uint64 timeout_address,
+			      uint32 bitset, uint64 deadline)
+{
+	thread->futex_restart_active = 1;
+	thread->futex_restart_armed = 0;
+	thread->futex_restart_resume = 0;
+	thread->futex_restart_private = !!private;
+	thread->futex_restart_epc = thread->trapframe->epc - 4;
+	thread->futex_restart_address = address;
+	thread->futex_restart_timeout_address = timeout_address;
+	thread->futex_restart_deadline = deadline;
+	thread->futex_restart_expected = expected;
+	thread->futex_restart_bitset = bitset;
+}
 
 static int futex_key_equal(const struct futex_key *left,
 			   const struct futex_key *right)
@@ -185,16 +262,20 @@ static int futex_wait(uint64 address, int private, uint32 expected,
 	struct futex_slot *slot;
 	process_t process = cur_proc();
 	thread_t current = cur_thread();
-	uint64 milliseconds = 0;
+	uint64 deadline = 0, milliseconds = 0;
 	uint32 value;
-	int result, timed;
+	int result, restarted = 0, timed;
 
 	if (!bitset)
 		return -LINUX_EINVAL;
 	result = futex_key_get(process, address, private, &key);
 	if (result < 0)
 		return result;
-	timed = absolute ?
+	if (!absolute && timeout_address)
+		restarted = futex_restart_take(
+			current, address, private, expected, timeout_address,
+			bitset, &deadline);
+	timed = restarted ? 1 : absolute ?
 		futex_absolute_timeout(process, timeout_address,
 		                       &milliseconds) :
 		futex_relative_timeout(process, timeout_address,
@@ -210,6 +291,7 @@ static int futex_wait(uint64 address, int private, uint32 expected,
 	}
 	if (value != expected) {
 		spinlock_release(&futex_table.lock);
+		futex_restart_cancel(current);
 		return -LINUX_EAGAIN;
 	}
 	slot = futex_slot_get_locked(&key);
@@ -220,12 +302,24 @@ static int futex_wait(uint64 address, int private, uint32 expected,
 	slot->waiters++;
 	current->wait_private = slot;
 	current->wait_bitset = bitset;
-	if (timed)
-		result = wait_queue_sleep_timeout(&slot->wait,
-			&futex_table.lock, milliseconds);
-	else {
-		wait_queue_sleep(&slot->wait, &futex_table.lock);
-		result = 0;
+	if (timed && !absolute) {
+		if (!restarted) {
+			uint64 delta = ktime_ms_to_ticks(milliseconds);
+			uint64 now = ktime_get_ticks();
+
+			deadline = now > ~(uint64)0 - delta ?
+				~(uint64)0 : now + delta;
+			futex_restart_set(current, address, private, expected,
+			                  timeout_address, bitset, deadline);
+		}
+		result = wait_queue_sleep_interruptible_until(
+			&slot->wait, &futex_table.lock, deadline);
+	} else if (timed) {
+		result = wait_queue_sleep_interruptible_timeout(
+			&slot->wait, &futex_table.lock, milliseconds);
+	} else {
+		result = wait_queue_sleep_interruptible(
+			&slot->wait, &futex_table.lock);
 	}
 	slot = current->wait_private;
 	if (!slot)
@@ -234,7 +328,10 @@ static int futex_wait(uint64 address, int private, uint32 expected,
 	current->wait_private = 0;
 	current->wait_bitset = ~(uint32)0;
 	spinlock_release(&futex_table.lock);
-	return result < 0 ? -LINUX_ETIMEDOUT : 0;
+	if (result == WAIT_QUEUE_INTERRUPTED)
+		return -SIGNAL_RESTART_SYS;
+	futex_restart_cancel(current);
+	return result == WAIT_QUEUE_TIMEOUT ? -LINUX_ETIMEDOUT : 0;
 }
 
 static int futex_wake_key_locked(const struct futex_key *key, int count,

--- a/kernel/include/futex.h
+++ b/kernel/include/futex.h
@@ -1,0 +1,9 @@
+#ifndef __CAFFEINIX_KERNEL_FUTEX_H
+#define __CAFFEINIX_KERNEL_FUTEX_H
+
+#include <thread.h>
+
+void futex_init(void);
+void futex_thread_exit(thread_t thread);
+
+#endif

--- a/kernel/include/futex.h
+++ b/kernel/include/futex.h
@@ -5,5 +5,8 @@
 
 void futex_init(void);
 void futex_thread_exit(thread_t thread);
+void futex_restart_cancel(thread_t thread);
+void futex_restart_signal(thread_t thread, int through_handler);
+void futex_restart_sigreturn(thread_t thread);
 
 #endif

--- a/kernel/include/linux_uapi.h
+++ b/kernel/include/linux_uapi.h
@@ -36,6 +36,9 @@
 #define LINUX_SYS_exit               93
 #define LINUX_SYS_exit_group         94
 #define LINUX_SYS_set_tid_address    96
+#define LINUX_SYS_futex              98
+#define LINUX_SYS_set_robust_list    99
+#define LINUX_SYS_get_robust_list   100
 #define LINUX_SYS_clock_gettime     113
 #define LINUX_SYS_rt_sigaction      134
 #define LINUX_SYS_rt_sigprocmask    135
@@ -325,6 +328,19 @@ struct linux_linger {
 #define LINUX_CLONE_DETACHED     0x400000
 #define LINUX_CLONE_CHILD_SETTID 0x1000000
 #define LINUX_CLONE_SIGNAL_MASK     0xff
+
+#define LINUX_FUTEX_WAIT                 0
+#define LINUX_FUTEX_WAKE                 1
+#define LINUX_FUTEX_REQUEUE              3
+#define LINUX_FUTEX_CMP_REQUEUE          4
+#define LINUX_FUTEX_WAIT_BITSET          9
+#define LINUX_FUTEX_WAKE_BITSET         10
+#define LINUX_FUTEX_PRIVATE_FLAG       128
+#define LINUX_FUTEX_CLOCK_REALTIME     256
+#define LINUX_FUTEX_CMD_MASK           127
+#define LINUX_FUTEX_BITSET_MATCH_ANY 0xffffffffU
+#define LINUX_FUTEX_WAITERS          0x80000000U
+#define LINUX_FUTEX_OWNER_DIED       0x40000000U
 
 #define LINUX_WNOHANG                   1
 

--- a/kernel/include/linux_uapi.h
+++ b/kernel/include/linux_uapi.h
@@ -77,6 +77,7 @@
 #define LINUX_SYS_accept4           242
 #define LINUX_SYS_wait4             260
 #define LINUX_SYS_renameat2         276
+#define LINUX_SYS_membarrier        283
 
 #define LINUX_EPERM                   1
 #define LINUX_ENOENT                  2
@@ -341,6 +342,10 @@ struct linux_linger {
 #define LINUX_FUTEX_BITSET_MATCH_ANY 0xffffffffU
 #define LINUX_FUTEX_WAITERS          0x80000000U
 #define LINUX_FUTEX_OWNER_DIED       0x40000000U
+
+#define LINUX_MEMBARRIER_CMD_QUERY                         0
+#define LINUX_MEMBARRIER_CMD_PRIVATE_EXPEDITED             8
+#define LINUX_MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED   16
 
 #define LINUX_WNOHANG                   1
 

--- a/kernel/include/linux_uapi.h
+++ b/kernel/include/linux_uapi.h
@@ -313,7 +313,17 @@ struct linux_linger {
 #define LINUX_SIGSET_SIZE              8
 
 #define LINUX_CLONE_VM             0x100
+#define LINUX_CLONE_FS             0x200
+#define LINUX_CLONE_FILES          0x400
+#define LINUX_CLONE_SIGHAND        0x800
 #define LINUX_CLONE_VFORK         0x4000
+#define LINUX_CLONE_THREAD       0x10000
+#define LINUX_CLONE_SYSVSEM      0x40000
+#define LINUX_CLONE_SETTLS       0x80000
+#define LINUX_CLONE_PARENT_SETTID 0x100000
+#define LINUX_CLONE_CHILD_CLEARTID 0x200000
+#define LINUX_CLONE_DETACHED     0x400000
+#define LINUX_CLONE_CHILD_SETTID 0x1000000
 #define LINUX_CLONE_SIGNAL_MASK     0xff
 
 #define LINUX_WNOHANG                   1

--- a/kernel/include/linux_uapi.h
+++ b/kernel/include/linux_uapi.h
@@ -40,8 +40,16 @@
 #define LINUX_SYS_set_robust_list    99
 #define LINUX_SYS_get_robust_list   100
 #define LINUX_SYS_clock_gettime     113
+#define LINUX_SYS_kill              129
+#define LINUX_SYS_tkill             130
+#define LINUX_SYS_tgkill            131
+#define LINUX_SYS_sigaltstack       132
+#define LINUX_SYS_rt_sigsuspend     133
 #define LINUX_SYS_rt_sigaction      134
 #define LINUX_SYS_rt_sigprocmask    135
+#define LINUX_SYS_rt_sigpending     136
+#define LINUX_SYS_rt_sigtimedwait   137
+#define LINUX_SYS_rt_sigreturn      139
 #define LINUX_SYS_setpriority       140
 #define LINUX_SYS_getpriority       141
 #define LINUX_SYS_umask             166
@@ -311,10 +319,71 @@ struct linux_linger {
 #define LINUX_SIG_BLOCK                0
 #define LINUX_SIG_UNBLOCK              1
 #define LINUX_SIG_SETMASK              2
+#define LINUX_SIGHUP                    1
+#define LINUX_SIGINT                    2
+#define LINUX_SIGQUIT                   3
+#define LINUX_SIGILL                    4
+#define LINUX_SIGTRAP                   5
+#define LINUX_SIGABRT                   6
+#define LINUX_SIGBUS                    7
+#define LINUX_SIGFPE                    8
 #define LINUX_SIGKILL                  9
+#define LINUX_SIGUSR1                  10
+#define LINUX_SIGSEGV                  11
+#define LINUX_SIGUSR2                  12
+#define LINUX_SIGPIPE                  13
+#define LINUX_SIGALRM                  14
+#define LINUX_SIGTERM                  15
+#define LINUX_SIGSTKFLT                16
 #define LINUX_SIGCHLD                 17
+#define LINUX_SIGCONT                 18
 #define LINUX_SIGSTOP                 19
+#define LINUX_SIGTSTP                 20
+#define LINUX_SIGTTIN                 21
+#define LINUX_SIGTTOU                 22
+#define LINUX_SIGURG                  23
+#define LINUX_SIGXCPU                 24
+#define LINUX_SIGXFSZ                 25
+#define LINUX_SIGVTALRM               26
+#define LINUX_SIGPROF                 27
+#define LINUX_SIGWINCH                28
+#define LINUX_SIGIO                   29
+#define LINUX_SIGPWR                  30
+#define LINUX_SIGSYS                  31
+#define LINUX_SIGRTMIN                32
+#define LINUX_SIGRTMAX                64
 #define LINUX_SIGSET_SIZE              8
+
+#define LINUX_SIG_DFL                   0
+#define LINUX_SIG_IGN                   1
+
+#define LINUX_SA_NOCLDSTOP     0x00000001U
+#define LINUX_SA_NOCLDWAIT     0x00000002U
+#define LINUX_SA_SIGINFO       0x00000004U
+#define LINUX_SA_ONSTACK       0x08000000U
+#define LINUX_SA_RESTART       0x10000000U
+#define LINUX_SA_NODEFER       0x40000000U
+#define LINUX_SA_RESETHAND     0x80000000U
+
+#define LINUX_SS_ONSTACK                1
+#define LINUX_SS_DISABLE                2
+#define LINUX_SS_AUTODISARM    0x80000000U
+
+#define LINUX_SI_USER                    0
+#define LINUX_SI_KERNEL               128
+#define LINUX_SI_TKILL                 -6
+
+#define LINUX_ILL_ILLOPC                 1
+#define LINUX_TRAP_BRKPT                 1
+#define LINUX_BUS_ADRALN                 1
+#define LINUX_SEGV_MAPERR                1
+#define LINUX_SEGV_ACCERR                2
+
+#define LINUX_CLD_EXITED                 1
+#define LINUX_CLD_KILLED                 2
+#define LINUX_CLD_DUMPED                 3
+#define LINUX_CLD_STOPPED                5
+#define LINUX_CLD_CONTINUED              6
 
 #define LINUX_CLONE_VM             0x100
 #define LINUX_CLONE_FS             0x200
@@ -348,6 +417,8 @@ struct linux_linger {
 #define LINUX_MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED   16
 
 #define LINUX_WNOHANG                   1
+#define LINUX_WUNTRACED                 2
+#define LINUX_WCONTINUED                8
 
 #define LINUX_CLOCK_REALTIME             0
 #define LINUX_CLOCK_MONOTONIC            1
@@ -397,6 +468,113 @@ struct linux_sigaction {
 	uint64 mask;
 };
 
+struct linux_sigaltstack {
+	uint64 sp;
+	int32 flags;
+	uint32 padding;
+	uint64 size;
+};
+
+struct linux_user_regs {
+	uint64 pc;
+	uint64 ra;
+	uint64 sp;
+	uint64 gp;
+	uint64 tp;
+	uint64 t0;
+	uint64 t1;
+	uint64 t2;
+	uint64 s0;
+	uint64 s1;
+	uint64 a0;
+	uint64 a1;
+	uint64 a2;
+	uint64 a3;
+	uint64 a4;
+	uint64 a5;
+	uint64 a6;
+	uint64 a7;
+	uint64 s2;
+	uint64 s3;
+	uint64 s4;
+	uint64 s5;
+	uint64 s6;
+	uint64 s7;
+	uint64 s8;
+	uint64 s9;
+	uint64 s10;
+	uint64 s11;
+	uint64 t3;
+	uint64 t4;
+	uint64 t5;
+	uint64 t6;
+};
+
+struct linux_riscv_d_ext_state {
+	uint64 f[32];
+	uint32 fcsr;
+};
+
+struct linux_riscv_ctx_header {
+	uint32 magic;
+	uint32 size;
+};
+
+struct linux_riscv_extra_ext_header {
+	uint32 padding[129] __attribute__((aligned(16)));
+	uint32 reserved;
+	struct linux_riscv_ctx_header header;
+};
+
+union linux_riscv_fp_state {
+	struct linux_riscv_d_ext_state d;
+	struct linux_riscv_extra_ext_header ext;
+} __attribute__((aligned(16)));
+
+struct linux_sigcontext {
+	struct linux_user_regs regs;
+	union linux_riscv_fp_state fpregs;
+} __attribute__((aligned(16)));
+
+struct linux_ucontext {
+	uint64 flags;
+	uint64 link;
+	struct linux_sigaltstack stack;
+	uint64 signal_mask;
+	uint8 unused[120];
+	struct linux_sigcontext mcontext;
+} __attribute__((aligned(16)));
+
+struct linux_siginfo {
+	int32 signal;
+	int32 error;
+	int32 code;
+	int32 padding;
+	union {
+		struct {
+			int32 pid;
+			uint32 uid;
+		} kill;
+		struct {
+			int32 pid;
+			uint32 uid;
+			int32 status;
+			uint32 padding;
+			int64 user_time;
+			int64 system_time;
+		} child;
+		struct {
+			uint64 address;
+		} fault;
+		uint8 bytes[112];
+	} fields;
+};
+
+struct linux_rt_sigframe {
+	struct linux_siginfo info;
+	struct linux_ucontext context;
+};
+
 struct linux_termios {
 	uint32 iflag;
 	uint32 oflag;
@@ -431,6 +609,22 @@ _Static_assert(__builtin_offsetof(struct linux_stat, size) == 48,
 	       "Linux RISC-V stat offsets changed");
 _Static_assert(sizeof(struct linux_sigaction) == 24,
 	       "Linux RISC-V sigaction layout changed");
+_Static_assert(sizeof(struct linux_sigaltstack) == 24,
+	       "Linux RISC-V sigaltstack layout changed");
+_Static_assert(sizeof(struct linux_user_regs) == 256,
+	       "Linux RISC-V register layout changed");
+_Static_assert(sizeof(union linux_riscv_fp_state) == 528,
+	       "Linux RISC-V FP state layout changed");
+_Static_assert(sizeof(struct linux_sigcontext) == 784,
+	       "Linux RISC-V sigcontext layout changed");
+_Static_assert(__builtin_offsetof(struct linux_ucontext, mcontext) == 176,
+	       "Linux RISC-V ucontext offsets changed");
+_Static_assert(sizeof(struct linux_ucontext) == 960,
+	       "Linux RISC-V ucontext layout changed");
+_Static_assert(sizeof(struct linux_siginfo) == 128,
+	       "Linux RISC-V siginfo layout changed");
+_Static_assert(sizeof(struct linux_rt_sigframe) == 1088,
+	       "Linux RISC-V signal frame layout changed");
 _Static_assert(sizeof(struct linux_termios) == 36,
 	       "Linux RISC-V termios layout changed");
 _Static_assert(sizeof(struct linux_winsize) == 8,

--- a/kernel/include/palloc.h
+++ b/kernel/include/palloc.h
@@ -19,6 +19,7 @@ int palloc_managed_range_count(void);
 int palloc_managed_range_get(int index, uint64 *start, uint64 *end);
 uint64 palloc_heap_start(void);
 uint64 palloc_usable_bytes(void);
+int palloc_reference_selftest(void);
 
 void* malloc(uint64 size);
 void* calloc(size_t count, size_t size);

--- a/kernel/include/palloc.h
+++ b/kernel/include/palloc.h
@@ -13,6 +13,8 @@ void free_pages(void *p, unsigned int order);
 void pfree(void* p);
 void* palloc(void);
 void *palloc_zero(void);
+int palloc_get(void *p);
+uint32 palloc_refcount(void *p);
 int palloc_managed_range_count(void);
 int palloc_managed_range_get(int index, uint64 *start, uint64 *end);
 uint64 palloc_heap_start(void);

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -55,6 +55,7 @@ typedef struct process{
 	int group_exit_state;
 	int execing;
 	int live_threads;
+	uint8 membarrier_private_expedited;
 	struct process_signal_action signal_actions[64];
         struct process *parent;
         struct wait_queue child_wait;

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -46,15 +46,19 @@ typedef struct process{
 	struct vfs_path root;
 	struct vfs_path cwd;
 	uint32 umask;
+	struct spinlock files_lock;
         file_t ofile[NOFILE];
 	uint8 fd_flags[NOFILE];
         int exit_state;
         int killed;
-	uint64 clear_child_tid;
-	uint64 signal_mask;
+	int group_exiting;
+	int group_exit_state;
+	int execing;
+	int live_threads;
 	struct process_signal_action signal_actions[64];
         struct process *parent;
         struct wait_queue child_wait;
+	struct wait_queue thread_reap_wait;
         int tnums;
         thread_t thread[PROC_MAXTHREAD];
         
@@ -62,9 +66,17 @@ typedef struct process{
 }*process_t;
 
 void process_init(void);
-pagedir_t process_pagedir(process_t p);
+pagedir_t process_pagedir(process_t p, thread_t thread);
 void process_freepagedir(pagedir_t pgdir, uint64 sz);
 int process_fork(uint64 child_stack);
+int process_clone_thread(uint64 flags, uint64 child_stack,
+			 uint64 parent_tid, uint64 tls, uint64 child_tid);
+void process_thread_exit(int cause, int group);
+int process_group_exiting(process_t process, int *status);
+int process_exec_begin(process_t process, thread_t thread);
+int process_exec_quiesce(process_t process, thread_t thread);
+void process_exec_end(process_t process);
+int process_thread_exit_requested(thread_t thread, int *status);
 int process_wait(int target, uint64 status_address, int nohang);
 int process_set_nice(int pid, int nice);
 int process_get_nice(int pid, int *nice);

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -24,11 +24,6 @@ typedef enum process_state{
         PROCESS_ZOMBIE,
 }process_state_t;
 
-typedef struct trapframe_info {
-        uint64 addr;
-        uint64 nums;
-}*trapframe_info_t;
-
 struct process_signal_action {
 	uint64 handler;
 	uint64 flags;
@@ -60,7 +55,6 @@ typedef struct process{
 	struct process_signal_action signal_actions[64];
         struct process *parent;
         struct wait_queue child_wait;
-        trapframe_info_t tinfo;
         int tnums;
         thread_t thread[PROC_MAXTHREAD];
         

--- a/kernel/include/process.h
+++ b/kernel/include/process.h
@@ -18,11 +18,15 @@
 #include <sleeplock.h>
 #include <vma.h>
 #include <wait.h>
+#include <signal.h>
 
 typedef enum process_state{
         PROCESS_LIVE,
         PROCESS_ZOMBIE,
 }process_state_t;
+
+#define PROCESS_WAIT_FAULT -2
+#define PROCESS_WAIT_INTR  -3
 
 struct process_signal_action {
 	uint64 handler;
@@ -50,13 +54,20 @@ typedef struct process{
         file_t ofile[NOFILE];
 	uint8 fd_flags[NOFILE];
         int exit_state;
-        int killed;
 	int group_exiting;
 	int group_exit_state;
+	int group_exit_signal;
+	int group_exit_core;
 	int execing;
 	int live_threads;
+	int stopped;
+	int child_event;
+	int child_event_signal;
+	uint8 auto_reap;
 	uint8 membarrier_private_expedited;
+	struct signal_pending *signal_pending;
 	struct process_signal_action signal_actions[64];
+	struct wait_queue signal_wait;
         struct process *parent;
         struct wait_queue child_wait;
 	struct wait_queue thread_reap_wait;
@@ -73,16 +84,18 @@ int process_fork(uint64 child_stack);
 int process_clone_thread(uint64 flags, uint64 child_stack,
 			 uint64 parent_tid, uint64 tls, uint64 child_tid);
 void process_thread_exit(int cause, int group);
+void process_signal_exit(int signal, int core_dumped);
+void process_signal_stop(int signal);
+void process_auto_reap(process_t process);
 int process_group_exiting(process_t process, int *status);
 int process_exec_begin(process_t process, thread_t thread);
 int process_exec_quiesce(process_t process, thread_t thread);
 void process_exec_end(process_t process);
 int process_thread_exit_requested(thread_t thread, int *status);
-int process_wait(int target, uint64 status_address, int nohang);
+int process_wait(int target, uint64 status_address, int options);
 int process_set_nice(int pid, int nice);
 int process_get_nice(int pid, int *nice);
 
-int killed(process_t p);
 int either_copyout(int user_dst, uint64 dst, void* src, uint64 len);
 int either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 /* User init for first process */

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -37,6 +37,7 @@ void sched(void);
 void scheduler_exit(void);
 void scheduler_exit_locked(void);
 void scheduler_make_runnable(thread_t thread);
+void scheduler_kick(thread_t thread);
 void scheduler_block_current(void);
 void scheduler_inherit(thread_t child, thread_t parent);
 int scheduler_set_nice(thread_t thread, int nice);

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -22,6 +22,8 @@ typedef struct cpu {
 	volatile uint8 online;
 	uint8 idle;
 	volatile uint8 need_resched;
+	volatile uint64 membarrier_request;
+	volatile uint64 membarrier_done;
 }*cpu_t;
 
 extern cpu_t *cpus;

--- a/kernel/include/signal.h
+++ b/kernel/include/signal.h
@@ -1,0 +1,59 @@
+#ifndef __CAFFEINIX_KERNEL_SIGNAL_H
+#define __CAFFEINIX_KERNEL_SIGNAL_H
+
+#include <list.h>
+#include <typedefs.h>
+
+#define SIGNAL_COUNT 64
+#define SIGNAL_RESTART_SYS 512
+#define SIGNAL_QUEUE_FULL -2
+
+struct process;
+struct thread;
+
+struct signal_info {
+	int signal;
+	int error;
+	int code;
+	int sender_pid;
+	uint32 sender_uid;
+	int status;
+	uint64 address;
+};
+
+struct signal_pending {
+	uint64 bits;
+	struct signal_info information[SIGNAL_COUNT];
+	struct list realtime;
+	uint32 realtime_count;
+};
+
+void signal_thread_init(struct thread *thread);
+void signal_thread_destroy(struct thread *thread);
+void signal_process_init(struct process *process);
+void signal_process_destroy(struct process *process);
+void signal_thread_fork(struct thread *child, struct thread *parent);
+void signal_thread_clone(struct thread *child, struct thread *parent);
+void signal_process_fork(struct process *child, struct process *parent);
+void signal_process_exec(struct process *process, struct thread *thread);
+void signal_thread_detach_locked(struct process *process,
+				 struct thread *thread);
+void signal_thread_mask_changed_locked(struct process *process,
+				       struct thread *thread);
+
+int signal_queue_process_locked(struct process *process, int signal,
+				const struct signal_info *information);
+int signal_queue_thread_locked(struct process *process,
+			       struct thread *thread, int signal,
+			       const struct signal_info *information);
+int signal_send_process(int pid, int signal,
+			const struct signal_info *information);
+int signal_send_thread(int thread_group, int tid, int signal,
+		       const struct signal_info *information);
+
+int signal_pending_unblocked(struct thread *thread);
+uint64 signal_mask_sanitize(uint64 mask);
+void signal_force_fault(int signal, int code, uint64 address);
+void signal_user_return(int from_syscall);
+
+#endif

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -122,6 +122,11 @@ typedef struct thread {
         struct context context;
 
         process_t home;
+	uint64 clear_child_tid;
+	uint64 signal_mask;
+	uint8 process_reaper;
+	uint8 exit_requested;
+	int exit_status;
 	thread_func_t kernel_function;
 	void *kernel_argument;
 	uint8 kernel_thread;
@@ -143,6 +148,7 @@ void map_kernel_stack(pagedir_t pgdir);
 void thread_setup(void);
 thread_t thread_alloc(process_t p);
 void thread_free(thread_t t);
+void user_thread_reap(thread_t t);
 thread_t kernel_thread_create(const char *name, thread_func_t function,
 			      void *argument);
 void kernel_thread_reap(thread_t thread);

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -17,6 +17,7 @@
 #include <spinlock.h>
 #include <kernel_config.h>
 #include <riscv.h>
+#include <signal.h>
 
 typedef struct process *process_t;
 struct wait_queue;
@@ -126,6 +127,26 @@ typedef struct thread {
 	uint64 robust_list;
 	uint64 robust_list_len;
 	uint64 signal_mask;
+	struct signal_pending signal_pending;
+	uint64 signal_altstack_sp;
+	uint64 signal_altstack_size;
+	uint32 signal_altstack_flags;
+	uint64 signal_saved_mask;
+	uint64 syscall_a0;
+	uint8 syscall_restart;
+	uint8 futex_restart_active;
+	uint8 futex_restart_armed;
+	uint8 futex_restart_resume;
+	uint8 futex_restart_private;
+	uint64 futex_restart_epc;
+	uint64 futex_restart_address;
+	uint64 futex_restart_timeout_address;
+	uint64 futex_restart_deadline;
+	uint32 futex_restart_expected;
+	uint32 futex_restart_bitset;
+	uint64 signal_sequence;
+	uint64 process_signal_target;
+	uint8 signal_restore_mask;
 	uint8 process_reaper;
 	uint8 exit_requested;
 	int exit_status;
@@ -141,6 +162,7 @@ typedef struct thread {
 	uint64 wait_deadline;
 	int wait_result;
 	uint8 on_timeout_queue;
+	uint8 wait_interruptible;
 	void *wait_private;
 	uint32 wait_bitset;
 }*thread_t;

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -123,6 +123,8 @@ typedef struct thread {
 
         process_t home;
 	uint64 clear_child_tid;
+	uint64 robust_list;
+	uint64 robust_list_len;
 	uint64 signal_mask;
 	uint8 process_reaper;
 	uint8 exit_requested;
@@ -139,6 +141,8 @@ typedef struct thread {
 	uint64 wait_deadline;
 	int wait_result;
 	uint8 on_timeout_queue;
+	void *wait_private;
+	uint32 wait_bitset;
 }*thread_t;
 
 extern struct thread thread[NTHREAD];
@@ -149,6 +153,7 @@ void thread_setup(void);
 thread_t thread_alloc(process_t p);
 void thread_free(thread_t t);
 void user_thread_reap(thread_t t);
+int thread_get_robust_list(int tid, uint64 *head, uint64 *length);
 thread_t kernel_thread_create(const char *name, thread_func_t function,
 			      void *argument);
 void kernel_thread_reap(thread_t thread);

--- a/kernel/include/vfs.h
+++ b/kernel/include/vfs.h
@@ -82,6 +82,7 @@ enum vfs_result {
 	VFS_ERR_ALREADY = -46,
 	VFS_ERR_INPROGRESS = -47,
 	VFS_ERR_PIPE = -48,
+	VFS_ERR_INTR = -49,
 };
 
 #define VFS_RENAME_NOREPLACE (1U << 0)

--- a/kernel/include/wait.h
+++ b/kernel/include/wait.h
@@ -24,6 +24,9 @@ int wait_queue_sleep_timeout(wait_queue_t queue,
 			     spinlock_t condition_lock, uint64 timeout_ms);
 int wait_queue_wake_one(wait_queue_t queue);
 int wait_queue_wake_all(wait_queue_t queue);
+int wait_queue_wake_mask(wait_queue_t queue, int count, uint32 mask);
+int wait_queue_requeue(wait_queue_t source, wait_queue_t destination,
+		       int count, void *wait_private);
 int wait_queue_wake_thread(struct thread *thread);
 int wait_queue_terminate_thread(struct thread *thread);
 int wait_queue_empty(wait_queue_t queue);

--- a/kernel/include/wait.h
+++ b/kernel/include/wait.h
@@ -6,6 +6,8 @@
 
 struct thread;
 
+#define WAIT_QUEUE_TERMINATED  -3
+
 typedef struct wait_queue {
 	struct spinlock lock;
 	struct list waiters;
@@ -23,6 +25,7 @@ int wait_queue_sleep_timeout(wait_queue_t queue,
 int wait_queue_wake_one(wait_queue_t queue);
 int wait_queue_wake_all(wait_queue_t queue);
 int wait_queue_wake_thread(struct thread *thread);
+int wait_queue_terminate_thread(struct thread *thread);
 int wait_queue_empty(wait_queue_t queue);
 void wait_queue_timeout_init(void);
 void wait_queue_expire(uint64 now);

--- a/kernel/include/wait.h
+++ b/kernel/include/wait.h
@@ -6,6 +6,8 @@
 
 struct thread;
 
+#define WAIT_QUEUE_TIMEOUT     -1
+#define WAIT_QUEUE_INTERRUPTED -2
 #define WAIT_QUEUE_TERMINATED  -3
 
 typedef struct wait_queue {
@@ -22,12 +24,21 @@ void wait_queue_init(wait_queue_t queue, const char *name);
 void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock);
 int wait_queue_sleep_timeout(wait_queue_t queue,
 			     spinlock_t condition_lock, uint64 timeout_ms);
+int wait_queue_sleep_interruptible(wait_queue_t queue,
+				   spinlock_t condition_lock);
+int wait_queue_sleep_interruptible_timeout(wait_queue_t queue,
+					   spinlock_t condition_lock,
+					   uint64 timeout_ms);
+int wait_queue_sleep_interruptible_until(wait_queue_t queue,
+					 spinlock_t condition_lock,
+					 uint64 deadline);
 int wait_queue_wake_one(wait_queue_t queue);
 int wait_queue_wake_all(wait_queue_t queue);
 int wait_queue_wake_mask(wait_queue_t queue, int count, uint32 mask);
 int wait_queue_requeue(wait_queue_t source, wait_queue_t destination,
 		       int count, void *wait_private);
 int wait_queue_wake_thread(struct thread *thread);
+int wait_queue_interrupt_thread(struct thread *thread);
 int wait_queue_terminate_thread(struct thread *thread);
 int wait_queue_empty(wait_queue_t queue);
 void wait_queue_timeout_init(void);

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -20,6 +20,8 @@ SECTIONS
     /* _trampoline = .; */
     *(trampsec)
     . = ALIGN(0x1000);
+    *(sigtrampsec)
+    . = ALIGN(0x1000);
     PROVIDE(etext = .);
   } :text
   

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -147,6 +147,8 @@ void main(void)
 		pr_info("clocksource: riscv timer at %lu MHz",
 			timer_frequency() / 1000000);
 		palloc_init();
+		if (palloc_reference_selftest() < 0)
+			PANIC("physical page references");
 		cpu_topology_init(boot_hart_id);
 		sbi_init(cpu_count());
 		timer_init();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -58,6 +58,7 @@ static void main_boot(void)
 {
 	thread_setup();
 	scheduler_init();
+	cpu_membarrier_init();
 	wait_queue_timeout_init();
 	futex_init();
 	workqueue_init();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -45,6 +45,7 @@
 #include <virtio.h>
 #include <netdevice.h>
 #include <network_stack.h>
+#include <futex.h>
 
 volatile static uint8 start = 0;
 extern char end[];
@@ -58,6 +59,7 @@ static void main_boot(void)
 	thread_setup();
 	scheduler_init();
 	wait_queue_timeout_init();
+	futex_init();
 	workqueue_init();
 	trap_init_lock();
 	trap_init();

--- a/kernel/membarrier.c
+++ b/kernel/membarrier.c
@@ -1,0 +1,33 @@
+#include <cpu.h>
+#include <linux_uapi.h>
+#include <process.h>
+#include <scheduler.h>
+#include <syscall.h>
+
+uint64 sys_linux_membarrier(void)
+{
+	process_t process = cur_proc();
+	int command, flags;
+
+	argint(0, &command);
+	argint(1, &flags);
+	if (flags)
+		return -LINUX_EINVAL;
+	switch (command) {
+	case LINUX_MEMBARRIER_CMD_QUERY:
+		return LINUX_MEMBARRIER_CMD_PRIVATE_EXPEDITED |
+		       LINUX_MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED;
+	case LINUX_MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED:
+		__atomic_store_n(&process->membarrier_private_expedited, 1,
+		                 __ATOMIC_RELEASE);
+		return 0;
+	case LINUX_MEMBARRIER_CMD_PRIVATE_EXPEDITED:
+		if (!__atomic_load_n(&process->membarrier_private_expedited,
+		                     __ATOMIC_ACQUIRE))
+			return -LINUX_EPERM;
+		cpu_membarrier();
+		return 0;
+	default:
+		return -LINUX_EINVAL;
+	}
+}

--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -27,6 +27,13 @@
 	 ~(MALLOC_ALIGNMENT_BLOCKS - 1))
 #define PAGE_BLOCK                              512
 #define BITMAP_SIZE                             ((4096 - PAGE_BLOCK) / 8)
+#define PAGE_REF_ALIGNMENT                      sizeof(uint32)
+
+struct page_ref_region {
+	uint64 start;
+	uint64 end;
+	uint32 *refs;
+};
 
 
 typedef struct page {
@@ -60,6 +67,8 @@ static struct spinlock page_lock;
 static struct spinlock heap_lock;
 
 static struct memrange_set managed_ranges;
+static struct page_ref_region page_ref_regions[MEMRANGE_MAX];
+static int page_ref_region_count;
 static uint64 heap_start;
 static uint64 usable_bytes;
 
@@ -72,6 +81,29 @@ _Static_assert(PAGE_BLOCK % MALLOC_ALIGNMENT == 0,
 extern char end[];
 
 static void palloc_heap_alignment_selftest(void);
+
+static struct page_ref_region *page_ref_find(uint64 address)
+{
+	int index;
+
+	for (index = 0; index < page_ref_region_count; index++) {
+		struct page_ref_region *region = &page_ref_regions[index];
+
+		if (address >= region->start && address < region->end)
+			return region;
+	}
+	return 0;
+}
+
+static uint32 *page_ref_pointer(void *page)
+{
+	struct page_ref_region *region;
+	uint64 address = (uint64)page;
+
+	if (address % PGSIZE || !(region = page_ref_find(address)))
+		return 0;
+	return &region->refs[(address - region->start) / PGSIZE];
+}
 
 int palloc_managed_range_count(void)
 {
@@ -151,25 +183,40 @@ static void palloc_discover_memory(void)
 /* Init the physical memory */
 void palloc_init(void)
 {
-	uint64 finish, metadata_bytes, pages, start;
+	uint64 finish, metadata_bytes, pages, refs_offset, start;
 	int i;
 
 	spinlock_init(&page_lock, "physical pages");
 	spinlock_init(&heap_lock, "kernel heap");
 	palloc_discover_memory();
 	buddy_init(&page_allocator);
+	page_ref_region_count = 0;
 	usable_bytes = 0;
 	for (i = 0; i < managed_ranges.count; i++) {
 		if (memrange_get(&managed_ranges, i, &start, &finish) < 0)
 			PANIC("managed memory range");
 		pages = (finish - start) / PGSIZE;
-		metadata_bytes = PGROUNDUP(pages);
+		refs_offset = (pages + PAGE_REF_ALIGNMENT - 1) &
+			      ~(PAGE_REF_ALIGNMENT - 1);
+		if (pages > ((uint64)-1 - refs_offset) / sizeof(uint32))
+			PANIC("page metadata overflow");
+		metadata_bytes = PGROUNDUP(refs_offset +
+					     pages * sizeof(uint32));
 		if (metadata_bytes >= finish - start)
 			continue;
 		if (buddy_add_region(&page_allocator, start, finish,
 				     start + metadata_bytes, (uint8 *)start,
 				     pages) < 0)
 			PANIC("initialize page allocator");
+		if (page_ref_region_count >= MEMRANGE_MAX)
+			PANIC("page reference regions");
+		page_ref_regions[page_ref_region_count].start = start;
+		page_ref_regions[page_ref_region_count].end = finish;
+		page_ref_regions[page_ref_region_count].refs =
+			(uint32 *)(start + refs_offset);
+		memset(page_ref_regions[page_ref_region_count].refs, 0,
+		       pages * sizeof(uint32));
+		page_ref_region_count++;
 		usable_bytes += finish - start - metadata_bytes;
 	}
 	if (!usable_bytes)
@@ -181,7 +228,17 @@ void palloc_init(void)
 
 void free_pages(void *p, unsigned int order)
 {
+	uint32 *reference;
+
 	spinlock_acquire(&page_lock);
+	if (!order) {
+		reference = page_ref_pointer(p);
+		if (!reference || *reference != 1) {
+			spinlock_release(&page_lock);
+			PANIC("free referenced page");
+		}
+		*reference = 0;
+	}
 #ifdef CONFIG_PAGE_POISONING
 	if (!buddy_allocated(&page_allocator, (uint64)p, order)) {
 		spinlock_release(&page_lock);
@@ -199,11 +256,20 @@ void free_pages(void *p, unsigned int order)
 void *alloc_pages(unsigned int order, unsigned int flags)
 {
 	void *p;
+	uint32 *reference;
 
 	if (flags & ~PALLOC_ZERO)
 		return 0;
 	spinlock_acquire(&page_lock);
 	p = buddy_alloc(&page_allocator, order);
+	if (p && !order) {
+		reference = page_ref_pointer(p);
+		if (!reference || *reference) {
+			spinlock_release(&page_lock);
+			PANIC("allocate referenced page");
+		}
+		*reference = 1;
+	}
 	spinlock_release(&page_lock);
 	if (p && (flags & PALLOC_ZERO))
 		memset(p, 0, PGSIZE << order);
@@ -212,7 +278,56 @@ void *alloc_pages(unsigned int order, unsigned int flags)
 
 void pfree(void *p)
 {
-	free_pages(p, 0);
+	uint32 *reference;
+	int release = 0;
+
+	spinlock_acquire(&page_lock);
+	reference = page_ref_pointer(p);
+	if (!reference || !*reference ||
+	    !buddy_allocated(&page_allocator, (uint64)p, 0)) {
+		spinlock_release(&page_lock);
+		PANIC("put invalid page");
+	}
+	if (!--*reference)
+		release = 1;
+#ifdef CONFIG_PAGE_POISONING
+	if (release)
+		memset(p, 1, PGSIZE);
+#endif
+	if (release && buddy_free(&page_allocator, p, 0) < 0) {
+		spinlock_release(&page_lock);
+		PANIC("put physical page");
+	}
+	spinlock_release(&page_lock);
+}
+
+int palloc_get(void *p)
+{
+	uint32 *reference;
+	int result = -1;
+
+	spinlock_acquire(&page_lock);
+	reference = page_ref_pointer(p);
+	if (reference && *reference && *reference != ~(uint32)0 &&
+	    buddy_allocated(&page_allocator, (uint64)p, 0)) {
+		(*reference)++;
+		result = 0;
+	}
+	spinlock_release(&page_lock);
+	return result;
+}
+
+uint32 palloc_refcount(void *p)
+{
+	uint32 *reference;
+	uint32 result = 0;
+
+	spinlock_acquire(&page_lock);
+	reference = page_ref_pointer(p);
+	if (reference && buddy_allocated(&page_allocator, (uint64)p, 0))
+		result = *reference;
+	spinlock_release(&page_lock);
+	return result;
 }
 
 void *palloc(void)

--- a/kernel/palloc.c
+++ b/kernel/palloc.c
@@ -330,6 +330,31 @@ uint32 palloc_refcount(void *p)
 	return result;
 }
 
+int palloc_reference_selftest(void)
+{
+	uint64 free_before, free_shared, free_after;
+	void *page;
+
+	spinlock_acquire(&page_lock);
+	free_before = buddy_free_page_count(&page_allocator);
+	spinlock_release(&page_lock);
+	page = palloc_zero();
+	if (!page || palloc_refcount(page) != 1 || palloc_get(page) < 0 ||
+	    palloc_refcount(page) != 2)
+		return -1;
+	pfree(page);
+	spinlock_acquire(&page_lock);
+	free_shared = buddy_free_page_count(&page_allocator);
+	spinlock_release(&page_lock);
+	if (palloc_refcount(page) != 1 || free_shared + 1 != free_before)
+		return -1;
+	pfree(page);
+	spinlock_acquire(&page_lock);
+	free_after = buddy_free_page_count(&page_allocator);
+	spinlock_release(&page_lock);
+	return free_after == free_before ? 0 : -1;
+}
+
 void *palloc(void)
 {
 	void *page = alloc_pages(0, 0);

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -20,6 +20,7 @@
 #include <printk.h>
 #include <vfs.h>
 #include <linux_uapi.h>
+#include <futex.h>
 
 /* From trampoline.S */
 extern char trampoline[];
@@ -605,13 +606,10 @@ void process_thread_exit(int cause, int group)
 {
 	process_t p = cur_proc();
 	thread_t current = cur_thread();
-	uint32 zero = 0;
 	int last;
 	int i;
 
-	if (current->clear_child_tid)
-		(void)copyout(p->pagetable, current->clear_child_tid,
-		              (char *)&zero, sizeof(zero));
+	futex_thread_exit(current);
 
 	spinlock_acquire(&p->lock);
 	if (group && !p->group_exiting) {

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -19,23 +19,28 @@
 #include <block_device.h>
 #include <printk.h>
 #include <vfs.h>
+#include <linux_uapi.h>
 
 /* From trampoline.S */
 extern char trampoline[];
 extern int exec_linux(char *path, char **argv, char **envp);
+extern void user_trap_ret(void);
 
-static struct spinlock pid_lock, wait_lock;
+static struct spinlock wait_lock;
 // struct process proc[NPROC];
 struct list proc;
-static int next_pid = 1;
 static process_t first;
 
 static int setup_stdio(void)
 {
 	process_t p = cur_proc();
+	int occupied;
 	int fd;
 
-	if (p->ofile[0] || p->ofile[1] || p->ofile[2])
+	spinlock_acquire(&p->files_lock);
+	occupied = p->ofile[0] || p->ofile[1] || p->ofile[2];
+	spinlock_release(&p->files_lock);
+	if (occupied)
 		return -1;
 	if (vfs_open("/dev/console", VFS_OPEN_READ | VFS_OPEN_WRITE, 0,
 	             &fd) < 0 ||
@@ -102,13 +107,13 @@ static void reparent(process_t p)
         }
 }
 
-pagedir_t process_pagedir(process_t p)
+pagedir_t process_pagedir(process_t p, thread_t thread)
 {
         int ret;
         pagedir_t pgdir;
-        thread_t thread = p->thread[0];
 
-        if(!thread)
+	if (!p || !thread || thread->home != p || thread->id_p < 0 ||
+	    thread->id_p >= PROC_MAXTHREAD)
                 return 0;
         /* Malloc memory for page-talble */
         pgdir = pagedir_alloc();
@@ -121,7 +126,8 @@ pagedir_t process_pagedir(process_t p)
 		return 0;
         }
         /* Map address of under trampoline to trapframe */
-        ret = vm_map(pgdir, TRAPFRAME(0), (uint64)thread->trapframe,
+	ret = vm_map(pgdir, TRAPFRAME(thread->id_p),
+	             (uint64)thread->trapframe,
                      PGSIZE, PTE_W | PTE_R);
 	if(ret){
                 /* We don't need free the address that PTE points because it is a code seg */
@@ -199,19 +205,15 @@ static void proc_first_start(void)
 			PANIC("exec init");
 		}
 	}
-        extern void user_trap_ret(void);
         user_trap_ret();
 }
 
-/* All processes have a alone id, pid */
-static int pid_alloc(void)
+static void user_thread_start(void)
 {
-        int pid;
-        spinlock_acquire(&pid_lock);
-        pid = next_pid ++;
-        spinlock_release(&pid_lock);
-        return pid;
+	spinlock_release(&cur_thread()->lock);
+	user_trap_ret();
 }
+
 /* Alloc a process */
 static process_t process_alloc(void)
 {
@@ -225,8 +227,10 @@ static process_t process_alloc(void)
 	memset(p, 0, sizeof(*p));
 	p->umask = 0022;
 	p->state = PROCESS_LIVE;
-        wait_queue_init(&p->child_wait, "child wait");
+	wait_queue_init(&p->child_wait, "child wait");
+	wait_queue_init(&p->thread_reap_wait, "thread reap");
 	sleeplock_init(&p->mmap_lock, "process mmap");
+	spinlock_init(&p->files_lock, "process files");
 	vma_set_init(&p->vmas);
         
         spinlock_init(&p->lock, "process");
@@ -243,13 +247,13 @@ static process_t process_alloc(void)
                 goto r0;
 
         /* Alloc memory for page-table */
-        p->pagetable = process_pagedir(p);
+	p->pagetable = process_pagedir(p, t);
 	if(!p->pagetable) {
 		goto r1;
         }
         
-        /* Alloc pid */
-        p->pid = pid_alloc();
+	/* Linux thread-group leaders share their PID and TID. */
+	p->pid = t->tid;
         
         /* Set the context of return address */
         t->context.ra = (uint64)(proc_first_start);
@@ -274,9 +278,11 @@ static void process_free(process_t p)
         thread_t thread;
         int i;
 
-        spinlock_acquire(&p->lock);
+	spinlock_acquire(&p->lock);
         if(!wait_queue_empty(&p->child_wait))
                 PANIC("free process with child waiter");
+	if (!wait_queue_empty(&p->thread_reap_wait))
+		PANIC("free process with thread reaper");
 	vma_set_destroy(&p->vmas);
         if(p->pagetable) {
                 process_freepagedir(p->pagetable, p->sz);
@@ -302,7 +308,6 @@ static void process_free(process_t p)
 void process_init(void)
 {
 	/* Init the spinlock */
-	spinlock_init(&pid_lock, "pid_lock");
 	spinlock_init(&wait_lock, "wait_lock");
 	list_init(&proc);
 }
@@ -393,16 +398,18 @@ int process_fork(uint64 child_stack)
         pid = newp->pid;
         newt->trapframe->a0 = 0;
 
-        for(i = 0; i < NOFILE; i++) {
+	spinlock_acquire(&oldp->files_lock);
+	for(i = 0; i < NOFILE; i++) {
 		if(oldp->ofile[i])
 			newp->ofile[i] = file_dup(oldp->ofile[i]);
 		newp->fd_flags[i] = oldp->fd_flags[i];
-        }
+	}
+	spinlock_release(&oldp->files_lock);
 	vfs_path_copy(&newp->root, &oldp->root);
 	vfs_path_copy(&newp->cwd, &oldp->cwd);
         /* Copy the process name into newp */
 	safe_strncpy(newp->name, oldp->name, MAXNAME);
-	newp->signal_mask = oldp->signal_mask;
+	newt->signal_mask = oldt->signal_mask;
 	memmove(newp->signal_actions, oldp->signal_actions,
 	        sizeof(newp->signal_actions));
 
@@ -421,48 +428,236 @@ int process_fork(uint64 child_stack)
         return pid;
 }
 
-void exit(int cause)
+int process_clone_thread(uint64 flags, uint64 child_stack,
+			 uint64 parent_tid, uint64 tls, uint64 child_tid)
 {
-        process_t p;
-        file_t f;
-        int fd;
+	process_t p = cur_proc();
+	thread_t child, current = cur_thread();
+	int error = -LINUX_ENOMEM;
+	int tid;
 
-        p = cur_proc();
+	if (!child_stack)
+		return -LINUX_EINVAL;
+	spinlock_acquire(&p->lock);
+	if (p->execing || p->group_exiting || p->state != PROCESS_LIVE) {
+		spinlock_release(&p->lock);
+		return -LINUX_EAGAIN;
+	}
+	child = thread_alloc(p);
+	if (!child) {
+		spinlock_release(&p->lock);
+		return -LINUX_EAGAIN;
+	}
+	if (vm_map(p->pagetable, TRAPFRAME(child->id_p),
+	           (uint64)child->trapframe, PGSIZE, PTE_R | PTE_W) < 0)
+		goto fail;
+
+	*child->trapframe = *current->trapframe;
+	child->trapframe->a0 = 0;
+	child->trapframe->sp = child_stack;
+	if (flags & LINUX_CLONE_SETTLS)
+		child->trapframe->tp = tls;
+	child->signal_mask = current->signal_mask;
+	if (flags & LINUX_CLONE_CHILD_CLEARTID)
+		child->clear_child_tid = child_tid;
+	child->context.ra = (uint64)user_thread_start;
+	safe_strncpy(child->name, current->name, sizeof(child->name));
+	scheduler_inherit(child, current);
+	tid = child->tid;
+	if ((flags & LINUX_CLONE_PARENT_SETTID) &&
+	    copyout(p->pagetable, parent_tid, (char *)&tid,
+	            sizeof(tid)) < 0) {
+		error = -LINUX_EFAULT;
+		goto fail_mapped;
+	}
+	if ((flags & LINUX_CLONE_CHILD_SETTID) &&
+	    copyout(p->pagetable, child_tid, (char *)&tid,
+	            sizeof(tid)) < 0) {
+		error = -LINUX_EFAULT;
+		goto fail_mapped;
+	}
+	spinlock_release(&p->lock);
+	scheduler_make_runnable(child);
+	spinlock_release(&child->lock);
+	return tid;
+
+fail_mapped:
+	vm_unmap(p->pagetable, TRAPFRAME(child->id_p), 1, 0);
+fail:
+	thread_free(child);
+	spinlock_release(&child->lock);
+	spinlock_release(&p->lock);
+	return error;
+}
+
+int process_exec_begin(process_t p, thread_t current)
+{
+	int result = -1;
+
+	spinlock_acquire(&p->lock);
+	if (p->state == PROCESS_LIVE && !p->group_exiting && !p->execing &&
+	    current->home == p) {
+		p->execing = 1;
+		result = 0;
+	}
+	spinlock_release(&p->lock);
+	return result;
+}
+
+static void process_request_thread_exit_locked(thread_t thread, int status)
+{
+	if (!thread || !thread->home ||
+	    !spinlock_holding(&thread->home->lock) ||
+	    thread->state == THREAD_EXITED)
+		return;
+	thread->exit_status = status;
+	__atomic_store_n(&thread->exit_requested, 1, __ATOMIC_RELEASE);
+	wait_queue_terminate_thread(thread);
+	scheduler_kick(thread);
+}
+
+int process_thread_exit_requested(thread_t thread, int *status)
+{
+	if (!thread ||
+	    !__atomic_load_n(&thread->exit_requested, __ATOMIC_ACQUIRE))
+		return 0;
+	if (status)
+		*status = thread->exit_status;
+	return 1;
+}
+
+int process_exec_quiesce(process_t p, thread_t current)
+{
+	int index;
+
+	spinlock_acquire(&p->lock);
+	if (p->state != PROCESS_LIVE || p->group_exiting || !p->execing ||
+	    current->home != p) {
+		spinlock_release(&p->lock);
+		return -1;
+	}
+	for (index = 0; index < PROC_MAXTHREAD; index++) {
+		thread_t thread = p->thread[index];
+
+		if (thread && thread != current)
+			process_request_thread_exit_locked(thread, 0);
+	}
+	while (p->tnums != 1) {
+		if (p->group_exiting) {
+			spinlock_release(&p->lock);
+			return -1;
+		}
+		wait_queue_sleep(&p->thread_reap_wait, &p->lock);
+	}
+	if (p->thread[current->id_p] != current ||
+	    current->state != THREAD_RUNNING)
+		PANIC("invalid exec thread");
+	current->tid = p->pid;
+	spinlock_release(&p->lock);
+	return 0;
+}
+
+void process_exec_end(process_t p)
+{
+	spinlock_acquire(&p->lock);
+	if (!p->execing)
+		PANIC("finish inactive exec");
+	p->execing = 0;
+	spinlock_release(&p->lock);
+}
+
+int process_group_exiting(process_t p, int *status)
+{
+	int exiting;
+
+	spinlock_acquire(&p->lock);
+	exiting = p->group_exiting;
+	if (exiting && status)
+		*status = p->group_exit_state;
+	spinlock_release(&p->lock);
+	return exiting;
+}
+
+static void process_release_resources(process_t p)
+{
+	file_t files[NOFILE];
+	int count = 0, fd;
+
 	sleeplock_acquire(&p->mmap_lock);
 	vma_set_destroy(&p->vmas);
 	sleeplock_release(&p->mmap_lock);
-
-        for(fd = 0; fd < NOFILE; fd++) {
-                if((f = p->ofile[fd]) != 0) {
-                        file_close(f);
-                        p->ofile[fd] = 0;
-                }
-        }
-
+	spinlock_acquire(&p->files_lock);
+	for (fd = 0; fd < NOFILE; fd++) {
+		if (!p->ofile[fd])
+			continue;
+		files[count++] = p->ofile[fd];
+		p->ofile[fd] = 0;
+		p->fd_flags[fd] = 0;
+	}
+	spinlock_release(&p->files_lock);
+	for (fd = 0; fd < count; fd++)
+		file_close(files[fd]);
 	vfs_path_put(&p->cwd);
 	vfs_path_put(&p->root);
+}
 
-        spinlock_acquire(&wait_lock);
+void process_thread_exit(int cause, int group)
+{
+	process_t p = cur_proc();
+	thread_t current = cur_thread();
+	uint32 zero = 0;
+	int last;
+	int i;
 
-        reparent(p);
+	if (current->clear_child_tid)
+		(void)copyout(p->pagetable, current->clear_child_tid,
+		              (char *)&zero, sizeof(zero));
 
-	/*
-	 * Keep the final thread alive from publishing PROCESS_ZOMBIE until
-	 * the scheduler has switched away. A parent on another CPU may reap
-	 * the process as soon as wait_lock is released.
-	 */
-	spinlock_acquire(&cur_thread()->lock);
-        spinlock_acquire(&p->lock);
-	if (p->tnums != 1)
-		PANIC("multithreaded exit unsupported");
-        p->exit_state = cause;
-        p->state = PROCESS_ZOMBIE;
-        spinlock_release(&p->lock);
+	spinlock_acquire(&p->lock);
+	if (group && !p->group_exiting) {
+		p->group_exiting = 1;
+		p->group_exit_state = cause;
+	}
+	if (p->group_exiting)
+		cause = p->group_exit_state;
+	__atomic_store_n(&current->exit_requested, 0, __ATOMIC_RELEASE);
+	if (current->state != THREAD_RUNNING || p->live_threads <= 0)
+		PANIC("invalid user thread exit");
+	p->live_threads--;
+	last = p->live_threads == 0;
+	if (p->group_exiting) {
+		for (i = 0; i < PROC_MAXTHREAD; i++) {
+			thread_t thread = p->thread[i];
 
-        if(p->parent)
+			if (thread && thread != current)
+				process_request_thread_exit_locked(
+					thread, p->group_exit_state);
+		}
+	}
+	if (!last) {
+		spinlock_release(&p->lock);
+		spinlock_acquire(&current->lock);
+		scheduler_exit_locked();
+	}
+	while (p->tnums != 1)
+		wait_queue_sleep(&p->thread_reap_wait, &p->lock);
+	spinlock_release(&p->lock);
+
+	process_release_resources(p);
+	spinlock_acquire(&wait_lock);
+	reparent(p);
+	spinlock_acquire(&p->lock);
+	spinlock_acquire(&current->lock);
+	if (p->tnums != 1 || p->thread[current->id_p] != current ||
+	    p->state != PROCESS_LIVE)
+		PANIC("invalid final user thread");
+	p->exit_state = cause;
+	p->state = PROCESS_ZOMBIE;
+	current->process_reaper = 1;
+	spinlock_release(&p->lock);
+	if (p->parent)
 		wait_queue_wake_all(&p->parent->child_wait);
-
-        spinlock_release(&wait_lock);
+	spinlock_release(&wait_lock);
 	scheduler_exit_locked();
 }
 
@@ -523,51 +718,75 @@ int process_wait(int target, uint64 status_address, int nohang)
         }
 }
 
-static process_t process_find_locked(int pid)
+static thread_t process_find_thread_locked(int tid, process_t *owner)
 {
 	process_t process;
 	list_t entry;
+	int index;
 
 	if (!spinlock_holding(&wait_lock))
-		PANIC("process lookup unlocked");
+		PANIC("thread lookup unlocked");
 	for (entry = proc.next; entry != &proc; entry = entry->next) {
 		process = list_entry(entry, struct process, all_tag);
-		if (process->pid == pid && process->state == PROCESS_LIVE)
-			return process;
+		spinlock_acquire(&process->lock);
+		if (process->state != PROCESS_LIVE) {
+			spinlock_release(&process->lock);
+			continue;
+		}
+		for (index = 0; index < PROC_MAXTHREAD; index++) {
+			thread_t thread = process->thread[index];
+
+			if (thread && thread->state != THREAD_EXITED &&
+			    thread->tid == tid) {
+				*owner = process;
+				return thread;
+			}
+		}
+		spinlock_release(&process->lock);
 	}
 	return 0;
 }
 
-int process_set_nice(int pid, int nice)
+int process_set_nice(int tid, int nice)
 {
-	process_t process;
+	process_t process = 0;
 	thread_t thread;
-	int result = -1;
+	int result = -LINUX_ESRCH;
 
+	if (!tid)
+		return scheduler_set_nice(cur_thread(), nice) < 0 ?
+			-LINUX_EINVAL : 0;
 	spinlock_acquire(&wait_lock);
-	process = process_find_locked(pid);
-	thread = process ? process->thread[0] : 0;
+	thread = process_find_thread_locked(tid, &process);
 	if (thread)
-		result = scheduler_set_nice(thread, nice);
+		result = scheduler_set_nice(thread, nice) < 0 ?
+			-LINUX_EINVAL : 0;
+	if (process)
+		spinlock_release(&process->lock);
 	spinlock_release(&wait_lock);
 	return result;
 }
 
-int process_get_nice(int pid, int *nice)
+int process_get_nice(int tid, int *nice)
 {
-	process_t process;
+	process_t process = 0;
 	thread_t thread;
 	int result = -1;
 
 	if (!nice)
 		return -1;
+	if (!tid) {
+		*nice = scheduler_get_nice(cur_thread());
+		return 0;
+	}
 	spinlock_acquire(&wait_lock);
-	process = process_find_locked(pid);
-	thread = process ? process->thread[0] : 0;
+	thread = process_find_thread_locked(tid, &process);
 	if (thread) {
 		*nice = scheduler_get_nice(thread);
 		result = 0;
 	}
+	if (process)
+		spinlock_release(&process->lock);
 	spinlock_release(&wait_lock);
 	return result;
 }
@@ -591,7 +810,7 @@ int kill(int pid)
                 spinlock_acquire(&p->lock);
                 if(p->pid == pid) {
                         p->killed = 1;
-                        for(int i = 0; i < p->tnums; i++)
+				for(int i = 0; i < PROC_MAXTHREAD; i++)
                                 if(p->thread[i])
                                         wait_queue_wake_thread(p->thread[i]);
                         spinlock_release(&p->lock);

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -22,8 +22,13 @@
 #include <linux_uapi.h>
 #include <futex.h>
 
+#define PROCESS_CHILD_EVENT_NONE       0
+#define PROCESS_CHILD_EVENT_STOPPED    1
+#define PROCESS_CHILD_EVENT_CONTINUED  2
+
 /* From trampoline.S */
 extern char trampoline[];
+extern char sigtrampoline[], sigtrampoline_end[];
 extern int exec_linux(char *path, char **argv, char **envp);
 extern void user_trap_ret(void);
 
@@ -31,6 +36,31 @@ static struct spinlock wait_lock;
 // struct process proc[NPROC];
 struct list proc;
 static process_t first;
+
+static void process_notify_parent_locked(process_t child, int code,
+					 int status);
+
+static int process_parent_auto_reaps_locked(process_t child)
+{
+	struct process_signal_action *action;
+	process_t parent;
+	int result;
+
+	if (!spinlock_holding(&wait_lock))
+		PANIC("auto reap without wait lock");
+	parent = child->parent;
+	if (!parent)
+		return 0;
+	spinlock_acquire(&parent->lock);
+	action = &parent->signal_actions[LINUX_SIGCHLD - 1];
+	result = action->handler == LINUX_SIG_IGN ||
+	         (action->flags & LINUX_SA_NOCLDWAIT);
+	spinlock_release(&parent->lock);
+	return result;
+}
+
+_Static_assert(sizeof(struct signal_pending) <= PGSIZE,
+	       "process signal state must fit in one page");
 
 static int setup_stdio(void)
 {
@@ -126,12 +156,20 @@ pagedir_t process_pagedir(process_t p, thread_t thread)
 		pagedir_free(pgdir);
 		return 0;
         }
+	if (sigtrampoline_end - sigtrampoline > PGSIZE ||
+	    vm_map(pgdir, USER_SIGRETURN, (uint64)sigtrampoline, PGSIZE,
+	           PTE_U | PTE_R | PTE_X) < 0) {
+		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
+		pagedir_free(pgdir);
+		return 0;
+	}
         /* Map address of under trampoline to trapframe */
 	ret = vm_map(pgdir, TRAPFRAME(thread->id_p),
 	             (uint64)thread->trapframe,
                      PGSIZE, PTE_W | PTE_R);
 	if(ret){
                 /* We don't need free the address that PTE points because it is a code seg */
+		vm_unmap(pgdir, USER_SIGRETURN, 1, 0);
 		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
 		pagedir_free(pgdir);
 		return 0;
@@ -148,6 +186,8 @@ void process_freepagedir(pagedir_t pgdir, uint64 sz)
 		if (vm_mapped(pgdir, TRAPFRAME(i)))
 			vm_unmap(pgdir, TRAPFRAME(i), 1, 0);
 	}
+	if (vm_mapped(pgdir, USER_SIGRETURN))
+		vm_unmap(pgdir, USER_SIGRETURN, 1, 0);
 	if (vm_mapped(pgdir, TRAMPOLINE))
 		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
 	vm_free_user(pgdir);
@@ -222,14 +262,21 @@ static process_t process_alloc(void)
         thread_t t;
         int i;
         
-        p = malloc(sizeof(struct process));
-        if(!p)
-                return 0;
+	p = malloc(sizeof(struct process));
+	if(!p)
+		return 0;
 	memset(p, 0, sizeof(*p));
+	p->signal_pending = palloc_zero();
+	if (!p->signal_pending) {
+		free(p);
+		return 0;
+	}
+	signal_process_init(p);
 	p->umask = 0022;
 	p->state = PROCESS_LIVE;
 	wait_queue_init(&p->child_wait, "child wait");
 	wait_queue_init(&p->thread_reap_wait, "thread reap");
+	wait_queue_init(&p->signal_wait, "signal wait");
 	sleeplock_init(&p->mmap_lock, "process mmap");
 	spinlock_init(&p->files_lock, "process files");
 	vma_set_init(&p->vmas);
@@ -270,6 +317,8 @@ r1:
 	spinlock_release(&t->lock);
 r0:
 	spinlock_release(&p->lock);
+	signal_process_destroy(p);
+	pfree(p->signal_pending);
 	free(p);
 	return 0;
 }
@@ -284,7 +333,12 @@ static void process_free(process_t p)
                 PANIC("free process with child waiter");
 	if (!wait_queue_empty(&p->thread_reap_wait))
 		PANIC("free process with thread reaper");
+	if (!wait_queue_empty(&p->signal_wait))
+		PANIC("free process with signal waiter");
 	vma_set_destroy(&p->vmas);
+	signal_process_destroy(p);
+	pfree(p->signal_pending);
+	p->signal_pending = 0;
         if(p->pagetable) {
                 process_freepagedir(p->pagetable, p->sz);
         }
@@ -413,9 +467,10 @@ int process_fork(uint64 child_stack)
 	vfs_path_copy(&newp->cwd, &oldp->cwd);
         /* Copy the process name into newp */
 	safe_strncpy(newp->name, oldp->name, MAXNAME);
-	newt->signal_mask = oldt->signal_mask;
-	memmove(newp->signal_actions, oldp->signal_actions,
-	        sizeof(newp->signal_actions));
+	spinlock_acquire(&oldp->lock);
+	signal_thread_fork(newt, oldt);
+	signal_process_fork(newp, oldp);
+	spinlock_release(&oldp->lock);
 
         spinlock_release(&newp->lock);
         spinlock_release(&newt->lock);
@@ -461,7 +516,7 @@ int process_clone_thread(uint64 flags, uint64 child_stack,
 	child->trapframe->sp = child_stack;
 	if (flags & LINUX_CLONE_SETTLS)
 		child->trapframe->tp = tls;
-	child->signal_mask = current->signal_mask;
+	signal_thread_clone(child, current);
 	if (flags & LINUX_CLONE_CHILD_CLEARTID)
 		child->clear_child_tid = child_tid;
 	child->context.ra = (uint64)user_thread_start;
@@ -609,7 +664,7 @@ void process_thread_exit(int cause, int group)
 {
 	process_t p = cur_proc();
 	thread_t current = cur_thread();
-	int last;
+	int auto_reap, last;
 	int i;
 
 	futex_thread_exit(current);
@@ -618,6 +673,8 @@ void process_thread_exit(int cause, int group)
 	if (group && !p->group_exiting) {
 		p->group_exiting = 1;
 		p->group_exit_state = cause;
+		p->group_exit_signal = 0;
+		p->group_exit_core = 0;
 	}
 	if (p->group_exiting)
 		cause = p->group_exit_state;
@@ -625,8 +682,10 @@ void process_thread_exit(int cause, int group)
 	if (current->state != THREAD_RUNNING || p->live_threads <= 0)
 		PANIC("invalid user thread exit");
 	p->live_threads--;
+	signal_thread_detach_locked(p, current);
 	last = p->live_threads == 0;
 	if (p->group_exiting) {
+		wait_queue_wake_all(&p->signal_wait);
 		for (i = 0; i < PROC_MAXTHREAD; i++) {
 			thread_t thread = p->thread[i];
 
@@ -647,6 +706,7 @@ void process_thread_exit(int cause, int group)
 	process_release_resources(p);
 	spinlock_acquire(&wait_lock);
 	reparent(p);
+	auto_reap = process_parent_auto_reaps_locked(p);
 	spinlock_acquire(&p->lock);
 	spinlock_acquire(&current->lock);
 	if (p->tnums != 1 || p->thread[current->id_p] != current ||
@@ -654,15 +714,21 @@ void process_thread_exit(int cause, int group)
 		PANIC("invalid final user thread");
 	p->exit_state = cause;
 	p->state = PROCESS_ZOMBIE;
-	current->process_reaper = 1;
+	p->auto_reap = auto_reap;
+	current->process_reaper = auto_reap ? 2 : 1;
 	spinlock_release(&p->lock);
-	if (p->parent)
-		wait_queue_wake_all(&p->parent->child_wait);
+	if (p->group_exit_signal)
+		process_notify_parent_locked(
+			p, p->group_exit_core ? LINUX_CLD_DUMPED :
+			LINUX_CLD_KILLED, p->group_exit_signal);
+	else
+		process_notify_parent_locked(p, LINUX_CLD_EXITED,
+		                             p->exit_state & 0xff);
 	spinlock_release(&wait_lock);
 	scheduler_exit_locked();
 }
 
-int process_wait(int target, uint64 status_address, int nohang)
+int process_wait(int target, uint64 status_address, int options)
 {
         process_t p, pp;
 	int exit_status, kids, pid;
@@ -681,19 +747,28 @@ int process_wait(int target, uint64 status_address, int nohang)
 			if(pp->parent == p &&
 			   (target == -1 || target == pp->pid)) {
                                 spinlock_acquire(&pp->lock);
+				if (pp->auto_reap) {
+					spinlock_release(&pp->lock);
+					continue;
+				}
                                 kids = 1;
 				if(pp->state == PROCESS_ZOMBIE) {
                                         pid = pp->pid;
 
-					exit_status =
-						(pp->exit_state & 0xff) << 8;
+					if (pp->group_exit_signal)
+						exit_status =
+							(pp->group_exit_signal & 0x7f) |
+							(pp->group_exit_core ? 0x80 : 0);
+					else
+						exit_status =
+							(pp->exit_state & 0xff) << 8;
 					if(status_address &&
 					   either_copyout(1, status_address,
 					                  &exit_status,
 					                  sizeof(exit_status)) < 0) {
 						spinlock_release(&pp->lock);
 						spinlock_release(&wait_lock);
-						return -2;
+						return PROCESS_WAIT_FAULT;
 					}
 
 					spinlock_release(&pp->lock);
@@ -702,21 +777,232 @@ int process_wait(int target, uint64 status_address, int nohang)
 
                                         return pid;
                                 }
+				if ((pp->child_event ==
+				     PROCESS_CHILD_EVENT_STOPPED &&
+				     (options & LINUX_WUNTRACED)) ||
+				    (pp->child_event ==
+				     PROCESS_CHILD_EVENT_CONTINUED &&
+				     (options & LINUX_WCONTINUED))) {
+					pid = pp->pid;
+					if (pp->child_event ==
+					    PROCESS_CHILD_EVENT_STOPPED)
+						exit_status =
+							(pp->child_event_signal << 8) |
+							0x7f;
+					else
+						exit_status = 0xffff;
+					if (status_address &&
+					    either_copyout(1, status_address,
+					                   &exit_status,
+					                   sizeof(exit_status)) < 0) {
+						spinlock_release(&pp->lock);
+						spinlock_release(&wait_lock);
+						return PROCESS_WAIT_FAULT;
+					}
+					pp->child_event =
+						PROCESS_CHILD_EVENT_NONE;
+					spinlock_release(&pp->lock);
+					spinlock_release(&wait_lock);
+					return pid;
+				}
                                 spinlock_release(&pp->lock);
                         }
                 }
 
-		if(!kids || killed(p)) {
+		if(!kids) {
                         spinlock_release(&wait_lock);
                         return -1;
 		}
-		if (nohang) {
+		if (options & LINUX_WNOHANG) {
 			spinlock_release(&wait_lock);
 			return 0;
 		}
+		if (signal_pending_unblocked(cur_thread())) {
+			spinlock_release(&wait_lock);
+			return PROCESS_WAIT_INTR;
+		}
 
-                wait_queue_sleep(&p->child_wait, &wait_lock);
+		if (wait_queue_sleep_interruptible(&p->child_wait,
+		                                   &wait_lock) ==
+		    WAIT_QUEUE_INTERRUPTED)
+			continue;
         }
+}
+
+void process_auto_reap(process_t process)
+{
+	if (!process)
+		PANIC("auto reap null process");
+	spinlock_acquire(&wait_lock);
+	spinlock_acquire(&process->lock);
+	if (process->state != PROCESS_ZOMBIE || !process->auto_reap ||
+	    process->tnums != 1) {
+		spinlock_release(&process->lock);
+		spinlock_release(&wait_lock);
+		PANIC("invalid auto reap process");
+	}
+	spinlock_release(&process->lock);
+	process_free(process);
+	spinlock_release(&wait_lock);
+}
+
+static process_t process_find_locked(int pid)
+{
+	process_t process;
+	list_t entry;
+
+	if (!spinlock_holding(&wait_lock))
+		PANIC("process lookup unlocked");
+	for (entry = proc.next; entry != &proc; entry = entry->next) {
+		process = list_entry(entry, struct process, all_tag);
+		if (process->pid == pid && process->state == PROCESS_LIVE)
+			return process;
+	}
+	return 0;
+}
+
+static void process_notify_parent_locked(process_t child, int code,
+					 int status)
+{
+	process_t parent = child->parent;
+	struct signal_info information = {
+		.signal = LINUX_SIGCHLD,
+		.code = code,
+		.sender_pid = child->pid,
+		.sender_uid = 0,
+		.status = status,
+	};
+	int suppress;
+
+	if (!spinlock_holding(&wait_lock) || !parent)
+		return;
+	spinlock_acquire(&parent->lock);
+	suppress = (code == LINUX_CLD_STOPPED ||
+	            code == LINUX_CLD_CONTINUED) &&
+		(parent->signal_actions[LINUX_SIGCHLD - 1].flags &
+		 LINUX_SA_NOCLDSTOP);
+	if (!suppress)
+		(void)signal_queue_process_locked(parent, LINUX_SIGCHLD,
+		                                  &information);
+	spinlock_release(&parent->lock);
+	wait_queue_wake_all(&parent->child_wait);
+}
+
+static void process_continue_event_locked(process_t process, int resumed)
+{
+	if (!resumed)
+		return;
+	spinlock_acquire(&process->lock);
+	process->child_event = PROCESS_CHILD_EVENT_CONTINUED;
+	process->child_event_signal = LINUX_SIGCONT;
+	spinlock_release(&process->lock);
+	process_notify_parent_locked(process, LINUX_CLD_CONTINUED,
+	                             LINUX_SIGCONT);
+}
+
+int signal_send_process(int pid, int signal,
+			const struct signal_info *information)
+{
+	process_t process;
+	int result = -1, resumed = 0;
+
+	spinlock_acquire(&wait_lock);
+	process = process_find_locked(pid);
+	if (process) {
+		spinlock_acquire(&process->lock);
+		if (!signal)
+			result = 0;
+		else
+			result = resumed = signal_queue_process_locked(
+				process, signal, information);
+		spinlock_release(&process->lock);
+		if (result >= 0)
+			process_continue_event_locked(process, resumed);
+	}
+	spinlock_release(&wait_lock);
+	return result < 0 ? result : 0;
+}
+
+int signal_send_thread(int thread_group, int tid, int signal,
+		       const struct signal_info *information)
+{
+	process_t process;
+	thread_t target = 0;
+	list_t entry;
+	int index, result = -1, resumed = 0;
+
+	spinlock_acquire(&wait_lock);
+	for (entry = proc.next; entry != &proc; entry = entry->next) {
+		process = list_entry(entry, struct process, all_tag);
+		if (process->state != PROCESS_LIVE ||
+		    (thread_group && process->pid != thread_group))
+			continue;
+		spinlock_acquire(&process->lock);
+		for (index = 0; index < PROC_MAXTHREAD; index++) {
+			target = process->thread[index];
+			if (target && target->tid == tid &&
+			    target->state != THREAD_EXITED)
+				break;
+			target = 0;
+		}
+		if (!target) {
+			spinlock_release(&process->lock);
+			continue;
+		}
+		if (!signal)
+			result = 0;
+		else
+			result = resumed = signal_queue_thread_locked(
+				process, target, signal, information);
+		spinlock_release(&process->lock);
+		if (result >= 0)
+			process_continue_event_locked(process, resumed);
+		break;
+	}
+	spinlock_release(&wait_lock);
+	return result < 0 ? result : 0;
+}
+
+void process_signal_exit(int signal, int core_dumped)
+{
+	process_t process = cur_proc();
+
+	spinlock_acquire(&process->lock);
+	if (!process->group_exiting) {
+		process->group_exiting = 1;
+		process->group_exit_state = 0;
+		process->group_exit_signal = signal;
+		process->group_exit_core = !!core_dumped;
+	}
+	process->stopped = 0;
+	wait_queue_wake_all(&process->signal_wait);
+	spinlock_release(&process->lock);
+	process_thread_exit(0, 0);
+}
+
+void process_signal_stop(int signal)
+{
+	process_t process = cur_proc();
+	int notify = 0;
+
+	spinlock_acquire(&wait_lock);
+	spinlock_acquire(&process->lock);
+	if (!process->stopped && !process->group_exiting) {
+		process->stopped = 1;
+		process->child_event = PROCESS_CHILD_EVENT_STOPPED;
+		process->child_event_signal = signal;
+		notify = 1;
+	}
+	spinlock_release(&process->lock);
+	if (notify)
+		process_notify_parent_locked(process, LINUX_CLD_STOPPED,
+		                             signal);
+	spinlock_release(&wait_lock);
+
+	spinlock_acquire(&process->lock);
+	while (process->stopped && !process->group_exiting)
+		wait_queue_sleep(&process->signal_wait, &process->lock);
+	spinlock_release(&process->lock);
 }
 
 static thread_t process_find_thread_locked(int tid, process_t *owner)
@@ -798,37 +1084,3 @@ int process_get_nice(int tid, int *nice)
  * @return {*} 0: kill successfully     1:kill failed
  * @note This process will be killed actually by user_trap_entry in trap.c
  */
-int kill(int pid)
-{
-        process_t p;
-        list_t l;
-
-        spinlock_acquire(&wait_lock);
-        for(l = proc.next; l != &proc; l = l->next) {
-                p = list_entry(l, struct process, all_tag);
-                if(!p)
-                        continue;
-                spinlock_acquire(&p->lock);
-                if(p->pid == pid) {
-                        p->killed = 1;
-				for(int i = 0; i < PROC_MAXTHREAD; i++)
-                                if(p->thread[i])
-                                        wait_queue_wake_thread(p->thread[i]);
-                        spinlock_release(&p->lock);
-                        spinlock_release(&wait_lock);
-                        return 0;
-                }
-                spinlock_release(&p->lock);
-        }
-        spinlock_release(&wait_lock);
-        return -1;
-}
-
-int killed(process_t p)
-{
-        int killed;
-        spinlock_acquire(&p->lock);
-        killed = p->killed;
-        spinlock_release(&p->lock);
-        return killed;
-}

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -392,6 +392,9 @@ int process_fork(uint64 child_stack)
 	newp->brk = oldp->brk;
 	newp->brk_start = oldp->brk_start;
 	newp->umask = oldp->umask;
+	newp->membarrier_private_expedited =
+		__atomic_load_n(&oldp->membarrier_private_expedited,
+		                __ATOMIC_ACQUIRE);
 	*newt->trapframe = *oldt->trapframe;
 	if (child_stack)
 		newt->trapframe->sp = child_stack;

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -121,19 +121,11 @@ pagedir_t process_pagedir(process_t p)
 		return 0;
         }
         /* Map address of under trampoline to trapframe */
-        ret = vm_map(pgdir, TRAPFRAME_INFO, (uint64)p->tinfo, PGSIZE, PTE_W | PTE_R);
-	if(ret){
-                /* We don't need free the address that PTE points because it is a code seg */
-		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
-		pagedir_free(pgdir);
-		return 0;
-	}
         ret = vm_map(pgdir, TRAPFRAME(0), (uint64)thread->trapframe,
                      PGSIZE, PTE_W | PTE_R);
 	if(ret){
                 /* We don't need free the address that PTE points because it is a code seg */
 		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
-		vm_unmap(pgdir, TRAPFRAME_INFO, 1, 0);
 		pagedir_free(pgdir);
 		return 0;
 	}
@@ -149,8 +141,6 @@ void process_freepagedir(pagedir_t pgdir, uint64 sz)
 		if (vm_mapped(pgdir, TRAPFRAME(i)))
 			vm_unmap(pgdir, TRAPFRAME(i), 1, 0);
 	}
-	if (vm_mapped(pgdir, TRAPFRAME_INFO))
-		vm_unmap(pgdir, TRAPFRAME_INFO, 1, 0);
 	if (vm_mapped(pgdir, TRAMPOLINE))
 		vm_unmap(pgdir, TRAMPOLINE, 1, 0);
 	vm_free_user(pgdir);
@@ -252,17 +242,10 @@ static process_t process_alloc(void)
         if(!t)
                 goto r0;
 
-	p->tinfo = (trapframe_info_t)palloc_zero();
-        if(!p->tinfo) {
-                goto r1;
-        }
-
-        p->tinfo->nums = 1;
-
         /* Alloc memory for page-table */
         p->pagetable = process_pagedir(p);
-        if(!p->pagetable) {
-                goto r2;
+	if(!p->pagetable) {
+		goto r1;
         }
         
         /* Alloc pid */
@@ -277,8 +260,6 @@ static process_t process_alloc(void)
         spinlock_release(&wait_lock);
 
         return p;
-r2:
-	pfree(p->tinfo);
 r1:
 	thread_free(t);
 	spinlock_release(&t->lock);
@@ -308,8 +289,6 @@ static void process_free(process_t p)
                 thread_free(thread);
                 spinlock_release(&thread->lock);
         }
-	if (p->tinfo)
-		pfree(p->tinfo);
         list_remove(&p->all_tag);
         spinlock_release(&p->lock);
         free(p);

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -455,8 +455,6 @@ void scheduler(void)
 		__atomic_store_n(&cpu->need_resched, 0, __ATOMIC_RELEASE);
 		cpu->current = next;
 		spinlock_release(&runqueue.lock);
-		if (next->home)
-			next->home->tinfo->addr = TRAPFRAME(next->id_p);
 		switchto(&cpu->context, &next->context);
 		spinlock_acquire(&runqueue.lock);
 		if (cpu->current != next || cpu->selected)

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -2,6 +2,7 @@
 #include <debug.h>
 #include <ktime.h>
 #include <mem_layout.h>
+#include <process.h>
 #include <rbtree.h>
 #include <riscv.h>
 #include <sbi.h>
@@ -483,7 +484,13 @@ void scheduler(void)
 		if (next->state == THREAD_EXITED) {
 			if (next->kernel_thread)
 				kernel_thread_reap(next);
-			else if (!next->process_reaper)
+			else if (next->process_reaper == 2) {
+				process_t process = next->home;
+
+				spinlock_release(&next->lock);
+				process_auto_reap(process);
+				continue;
+			} else if (!next->process_reaper)
 				user_thread_reap(next);
 		}
 		spinlock_release(&next->lock);

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -263,6 +263,25 @@ static void wake_cpu(int target)
 		PANIC("SBI send IPI failed");
 }
 
+void scheduler_kick(thread_t thread)
+{
+	int logical, target = -1;
+
+	if (!thread)
+		return;
+	spinlock_acquire(&runqueue.lock);
+	for (logical = 0; logical < cpu_count(); logical++) {
+		if (cpus[logical]->current != thread)
+			continue;
+		__atomic_store_n(&cpus[logical]->need_resched, 1,
+		                 __ATOMIC_RELEASE);
+		target = logical;
+		break;
+	}
+	spinlock_release(&runqueue.lock);
+	wake_cpu(target);
+}
+
 static void scheduler_enqueue(thread_t thread, int wake_idle)
 {
 	thread_state_t previous;
@@ -461,8 +480,12 @@ void scheduler(void)
 			PANIC("invalid current thread");
 		cpu->current = 0;
 		spinlock_release(&runqueue.lock);
-		if (next->state == THREAD_EXITED && next->kernel_thread)
-			kernel_thread_reap(next);
+		if (next->state == THREAD_EXITED) {
+			if (next->kernel_thread)
+				kernel_thread_reap(next);
+			else if (!next->process_reaper)
+				user_thread_reap(next);
+		}
 		spinlock_release(&next->lock);
 	}
 }

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -1,0 +1,1180 @@
+#include <debug.h>
+#include <futex.h>
+#include <ktime.h>
+#include <linux_uapi.h>
+#include <mem_layout.h>
+#include <mystring.h>
+#include <palloc.h>
+#include <process.h>
+#include <scheduler.h>
+#include <signal.h>
+#include <syscall.h>
+#include <vm.h>
+#include <wait.h>
+
+#define SIGNAL_ALTSTACK_MIN 2048
+#define SIGNAL_REALTIME_LIMIT 128
+#define SIGNAL_UNMASKABLE \
+	(SIGNAL_BIT(LINUX_SIGKILL) | SIGNAL_BIT(LINUX_SIGSTOP))
+
+#define SIGNAL_BIT(signal) (1ULL << ((signal) - 1))
+
+struct signal_queue_entry {
+	struct list list;
+	struct signal_info information;
+};
+
+uint64 signal_mask_sanitize(uint64 mask)
+{
+	return mask & ~SIGNAL_UNMASKABLE;
+}
+
+static int signal_valid(int signal)
+{
+	return signal >= 1 && signal <= SIGNAL_COUNT;
+}
+
+static int signal_default_ignored(int signal)
+{
+	return signal == LINUX_SIGCHLD || signal == LINUX_SIGURG ||
+	       signal == LINUX_SIGWINCH;
+}
+
+static int signal_default_stops(int signal)
+{
+	return signal == LINUX_SIGSTOP || signal == LINUX_SIGTSTP ||
+	       signal == LINUX_SIGTTIN || signal == LINUX_SIGTTOU;
+}
+
+static int signal_default_cores(int signal)
+{
+	return signal == LINUX_SIGQUIT || signal == LINUX_SIGILL ||
+	       signal == LINUX_SIGTRAP || signal == LINUX_SIGABRT ||
+	       signal == LINUX_SIGBUS || signal == LINUX_SIGFPE ||
+	       signal == LINUX_SIGSEGV || signal == LINUX_SIGXCPU ||
+	       signal == LINUX_SIGXFSZ || signal == LINUX_SIGSYS;
+}
+
+static void signal_pending_init(struct signal_pending *pending)
+{
+	memset(pending, 0, sizeof(*pending));
+	list_init(&pending->realtime);
+}
+
+static void signal_pending_destroy(struct signal_pending *pending)
+{
+	while (pending->realtime.next != &pending->realtime) {
+		struct signal_queue_entry *entry = list_entry(
+			pending->realtime.next, struct signal_queue_entry, list);
+
+		list_remove(&entry->list);
+		free(entry);
+	}
+	signal_pending_init(pending);
+}
+
+static void signal_thread_reset(thread_t thread)
+{
+	thread->signal_mask = 0;
+	thread->signal_altstack_sp = 0;
+	thread->signal_altstack_size = 0;
+	thread->signal_altstack_flags = LINUX_SS_DISABLE;
+	thread->signal_saved_mask = 0;
+	thread->signal_restore_mask = 0;
+	thread->syscall_a0 = 0;
+	thread->syscall_restart = 0;
+	futex_restart_cancel(thread);
+	thread->signal_sequence = 0;
+	thread->process_signal_target = 0;
+}
+
+void signal_thread_init(thread_t thread)
+{
+	signal_pending_init(&thread->signal_pending);
+	signal_thread_reset(thread);
+}
+
+void signal_thread_destroy(thread_t thread)
+{
+	signal_pending_destroy(&thread->signal_pending);
+	signal_thread_reset(thread);
+}
+
+void signal_process_init(process_t process)
+{
+	signal_pending_init(process->signal_pending);
+}
+
+void signal_process_destroy(process_t process)
+{
+	signal_pending_destroy(process->signal_pending);
+}
+
+void signal_thread_fork(thread_t child, thread_t parent)
+{
+	if (!child || !parent || !child->home || !parent->home ||
+	    !spinlock_holding(&child->home->lock) ||
+	    !spinlock_holding(&parent->home->lock))
+		PANIC("fork signal state unlocked");
+	signal_thread_init(child);
+	child->signal_mask = parent->signal_mask;
+	child->signal_altstack_sp = parent->signal_altstack_sp;
+	child->signal_altstack_size = parent->signal_altstack_size;
+	child->signal_altstack_flags = parent->signal_altstack_flags;
+}
+
+void signal_thread_clone(thread_t child, thread_t parent)
+{
+	if (!child || !parent || child->home != parent->home ||
+	    !spinlock_holding(&child->home->lock))
+		PANIC("clone signal state unlocked");
+	signal_thread_init(child);
+	child->signal_mask = parent->signal_mask;
+}
+
+void signal_process_fork(process_t child, process_t parent)
+{
+	if (!child || !parent || !spinlock_holding(&child->lock) ||
+	    !spinlock_holding(&parent->lock))
+		PANIC("process signal state unlocked");
+	memmove(child->signal_actions, parent->signal_actions,
+	        sizeof(child->signal_actions));
+}
+
+void signal_process_exec(process_t process, thread_t thread)
+{
+	int signal;
+
+	spinlock_acquire(&process->lock);
+	for (signal = 1; signal <= SIGNAL_COUNT; signal++) {
+		if (process->signal_actions[signal - 1].handler !=
+		    LINUX_SIG_IGN)
+			memset(&process->signal_actions[signal - 1], 0,
+			       sizeof(process->signal_actions[signal - 1]));
+	}
+	thread->signal_altstack_sp = 0;
+	thread->signal_altstack_size = 0;
+	thread->signal_altstack_flags = LINUX_SS_DISABLE;
+	thread->signal_restore_mask = 0;
+	signal_thread_mask_changed_locked(process, thread);
+	spinlock_release(&process->lock);
+}
+
+static void signal_pending_clear(struct signal_pending *pending, int signal)
+{
+	uint64 bit = SIGNAL_BIT(signal);
+	list_t current, next;
+
+	pending->bits &= ~bit;
+	memset(&pending->information[signal - 1], 0,
+	       sizeof(pending->information[signal - 1]));
+	for (current = pending->realtime.next;
+	     current != &pending->realtime; current = next) {
+		struct signal_queue_entry *entry = list_entry(
+			current, struct signal_queue_entry, list);
+
+		next = current->next;
+		if (entry->information.signal != signal)
+			continue;
+		list_remove(current);
+		pending->realtime_count--;
+		free(entry);
+	}
+}
+
+static void signal_clear_locked(process_t process, int signal)
+{
+	int index;
+
+	signal_pending_clear(process->signal_pending, signal);
+	for (index = 0; index < PROC_MAXTHREAD; index++) {
+		thread_t thread = process->thread[index];
+
+		if (thread) {
+			signal_pending_clear(&thread->signal_pending, signal);
+			thread->process_signal_target &= ~SIGNAL_BIT(signal);
+		}
+	}
+}
+
+static int signal_thread_targetable_locked(thread_t thread, int signal,
+					   thread_t exclude)
+{
+	return thread && thread != exclude &&
+	       thread->state != THREAD_UNUSED &&
+	       thread->state != THREAD_ALLOCATED &&
+	       thread->state != THREAD_EXITED &&
+	       ((SIGNAL_BIT(signal) & SIGNAL_UNMASKABLE) ||
+	       !(thread->signal_mask & SIGNAL_BIT(signal)));
+}
+
+static int signal_process_generation_ignored_locked(process_t process,
+					    int signal)
+{
+	uint64 handler = process->signal_actions[signal - 1].handler;
+	int index;
+
+	if (handler == LINUX_SIG_IGN)
+		return 1;
+	if (handler != LINUX_SIG_DFL || !signal_default_ignored(signal))
+		return 0;
+	for (index = 0; index < PROC_MAXTHREAD; index++) {
+		if (signal_thread_targetable_locked(process->thread[index],
+		                                    signal, 0))
+			return 1;
+	}
+	return 0;
+}
+
+static int signal_thread_generation_ignored_locked(process_t process,
+					   thread_t thread, int signal)
+{
+	uint64 handler = process->signal_actions[signal - 1].handler;
+
+	if (handler == LINUX_SIG_IGN)
+		return 1;
+	return handler == LINUX_SIG_DFL && signal_default_ignored(signal) &&
+	       !(thread->signal_mask & SIGNAL_BIT(signal));
+}
+
+static void signal_target_clear_locked(process_t process, int signal)
+{
+	uint64 bit = SIGNAL_BIT(signal);
+	int index;
+
+	for (index = 0; index < PROC_MAXTHREAD; index++) {
+		thread_t thread = process->thread[index];
+
+		if (thread)
+			thread->process_signal_target &= ~bit;
+	}
+}
+
+static void signal_target_wake_locked(thread_t thread)
+{
+	__atomic_add_fetch(&thread->signal_sequence, 1, __ATOMIC_RELEASE);
+	wait_queue_interrupt_thread(thread);
+	scheduler_kick(thread);
+}
+
+static void signal_process_retarget_locked(process_t process, int signal,
+					   thread_t exclude)
+{
+	uint64 bit = SIGNAL_BIT(signal);
+	thread_t target = 0;
+	int index;
+
+	if (!(process->signal_pending->bits & bit)) {
+		signal_target_clear_locked(process, signal);
+		return;
+	}
+	for (index = 0; index < PROC_MAXTHREAD; index++) {
+		thread_t thread = process->thread[index];
+
+		if (thread && (thread->process_signal_target & bit) &&
+		    signal_thread_targetable_locked(thread, signal, exclude))
+			return;
+	}
+	signal_target_clear_locked(process, signal);
+	for (index = 0; index < PROC_MAXTHREAD; index++) {
+		thread_t thread = process->thread[index];
+
+		if (signal_thread_targetable_locked(thread, signal, exclude)) {
+			target = thread;
+			break;
+		}
+	}
+	if (!target)
+		return;
+	target->process_signal_target |= bit;
+	signal_target_wake_locked(target);
+}
+
+void signal_thread_mask_changed_locked(process_t process, thread_t thread)
+{
+	uint64 pending;
+	int signal;
+
+	if (!process || !thread || thread->home != process ||
+	    !spinlock_holding(&process->lock))
+		PANIC("signal mask change unlocked");
+	pending = process->signal_pending->bits;
+	for (signal = 1; pending; signal++, pending >>= 1) {
+		if (pending & 1)
+			signal_process_retarget_locked(process, signal, 0);
+	}
+}
+
+void signal_thread_detach_locked(process_t process, thread_t thread)
+{
+	uint64 targeted;
+	int signal;
+
+	if (!process || !thread || thread->home != process ||
+	    !spinlock_holding(&process->lock))
+		PANIC("signal detach unlocked");
+	targeted = thread->process_signal_target;
+	thread->process_signal_target = 0;
+	for (signal = 1; targeted; signal++, targeted >>= 1) {
+		if (targeted & 1)
+			signal_process_retarget_locked(process, signal, thread);
+	}
+}
+
+static int signal_prepare_group_locked(process_t process, int signal)
+{
+	int resumed = 0;
+
+	if (signal == LINUX_SIGCONT) {
+		signal_clear_locked(process, LINUX_SIGSTOP);
+		signal_clear_locked(process, LINUX_SIGTSTP);
+		signal_clear_locked(process, LINUX_SIGTTIN);
+		signal_clear_locked(process, LINUX_SIGTTOU);
+		if (process->stopped) {
+			process->stopped = 0;
+			resumed = 1;
+		}
+		wait_queue_wake_all(&process->signal_wait);
+	} else if (signal_default_stops(signal)) {
+		signal_clear_locked(process, LINUX_SIGCONT);
+	} else if (signal == LINUX_SIGKILL) {
+		process->stopped = 0;
+		wait_queue_wake_all(&process->signal_wait);
+	}
+	return resumed;
+}
+
+static void signal_wake_locked(process_t process, thread_t target,
+			       int signal)
+{
+	wait_queue_wake_all(&process->signal_wait);
+	if (!target) {
+		signal_process_retarget_locked(process, signal, 0);
+		return;
+	}
+	if (!(SIGNAL_BIT(signal) & SIGNAL_UNMASKABLE) &&
+	    (target->signal_mask & SIGNAL_BIT(signal)))
+		return;
+	signal_target_wake_locked(target);
+}
+
+static int signal_store_pending(struct signal_pending *pending, int signal,
+				const struct signal_info *information)
+{
+	struct signal_info generated = {
+		.signal = signal,
+	};
+	struct signal_queue_entry *entry = 0;
+	uint64 bit = SIGNAL_BIT(signal);
+
+	if (signal >= LINUX_SIGRTMIN) {
+		if (pending->realtime_count >= SIGNAL_REALTIME_LIMIT)
+			return SIGNAL_QUEUE_FULL;
+		entry = malloc(sizeof(*entry));
+		if (!entry)
+			return SIGNAL_QUEUE_FULL;
+		entry->information = information ? *information : generated;
+		entry->information.signal = signal;
+		list_init(&entry->list);
+		list_insert_before(&pending->realtime, &entry->list);
+		pending->realtime_count++;
+		pending->bits |= bit;
+		return 0;
+	}
+
+	/* Standard signals coalesce and retain the first queued siginfo. */
+	if (pending->bits & bit)
+		return 0;
+	pending->bits |= bit;
+	pending->information[signal - 1] = information ?
+		*information : generated;
+	pending->information[signal - 1].signal = signal;
+	return 0;
+}
+
+int signal_queue_process_locked(process_t process, int signal,
+				const struct signal_info *information)
+{
+	int result, resumed;
+
+	if (!process || !spinlock_holding(&process->lock) ||
+	    !signal_valid(signal) || process->state != PROCESS_LIVE)
+		return -1;
+	resumed = signal_prepare_group_locked(process, signal);
+	if (!signal_process_generation_ignored_locked(process, signal)) {
+		result = signal_store_pending(process->signal_pending, signal,
+		                              information);
+		if (result < 0)
+			return result;
+		signal_wake_locked(process, 0, signal);
+	}
+	return resumed;
+}
+
+int signal_queue_thread_locked(process_t process, thread_t thread,
+			       int signal,
+			       const struct signal_info *information)
+{
+	int result, resumed;
+
+	if (!process || !thread || !spinlock_holding(&process->lock) ||
+	    thread->home != process || thread->state == THREAD_UNUSED ||
+	    thread->state == THREAD_EXITED || !signal_valid(signal) ||
+	    process->state != PROCESS_LIVE)
+		return -1;
+	resumed = signal_prepare_group_locked(process, signal);
+	if (!signal_thread_generation_ignored_locked(process, thread, signal)) {
+		result = signal_store_pending(&thread->signal_pending, signal,
+		                              information);
+		if (result < 0)
+			return result;
+		signal_wake_locked(process, thread, signal);
+	}
+	return resumed;
+}
+
+int signal_pending_unblocked(thread_t thread)
+{
+	process_t process;
+	uint64 pending;
+
+	if (!thread || !(process = thread->home))
+		return 0;
+	spinlock_acquire(&process->lock);
+	pending = (thread->signal_pending.bits |
+	           (process->signal_pending->bits &
+	            thread->process_signal_target)) & ~thread->signal_mask;
+	spinlock_release(&process->lock);
+	return !!pending;
+}
+
+static int signal_take_set_locked(process_t process, thread_t thread,
+				  uint64 set,
+				  int honor_process_target,
+				  struct signal_info *information)
+{
+	struct signal_pending *pending;
+	struct signal_queue_entry *entry = 0;
+	list_t current;
+	uint64 available;
+	int signal;
+
+	available = process->signal_pending->bits;
+	if (honor_process_target)
+		available &= thread->process_signal_target;
+	available = (thread->signal_pending.bits | available) & set;
+	if (!available)
+		return 0;
+	for (signal = 1; !(available & SIGNAL_BIT(signal)); signal++)
+		;
+	pending = thread->signal_pending.bits & SIGNAL_BIT(signal) ?
+		&thread->signal_pending : process->signal_pending;
+	if (signal >= LINUX_SIGRTMIN) {
+		for (current = pending->realtime.next;
+		     current != &pending->realtime; current = current->next) {
+			entry = list_entry(current, struct signal_queue_entry, list);
+			if (entry->information.signal == signal)
+				break;
+			entry = 0;
+		}
+		if (!entry) {
+			PANIC("missing realtime signal");
+			return 0;
+		}
+		*information = entry->information;
+		list_remove(current);
+		pending->realtime_count--;
+		free(entry);
+		for (current = pending->realtime.next;
+		     current != &pending->realtime; current = current->next) {
+			entry = list_entry(current, struct signal_queue_entry, list);
+			if (entry->information.signal == signal)
+				return signal;
+		}
+		pending->bits &= ~SIGNAL_BIT(signal);
+		if (pending == process->signal_pending)
+			signal_target_clear_locked(process, signal);
+		return signal;
+	}
+	pending->bits &= ~SIGNAL_BIT(signal);
+	if (pending == process->signal_pending)
+		signal_target_clear_locked(process, signal);
+	*information = pending->information[signal - 1];
+	memset(&pending->information[signal - 1], 0,
+	       sizeof(pending->information[signal - 1]));
+	return signal;
+}
+
+static int signal_take_unblocked_locked(
+	process_t process, thread_t thread, struct signal_info *information,
+	struct process_signal_action *action)
+{
+	int signal;
+
+	signal = signal_take_set_locked(process, thread,
+		~thread->signal_mask, 1, information);
+	if (!signal)
+		return 0;
+	*action = process->signal_actions[signal - 1];
+	return signal;
+}
+
+void signal_force_fault(int signal, int code, uint64 address)
+{
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	struct signal_info information = {
+		.signal = signal,
+		.code = code,
+		.address = address,
+	};
+
+	spinlock_acquire(&process->lock);
+	thread->signal_mask &= ~SIGNAL_BIT(signal);
+	if (process->signal_actions[signal - 1].handler == LINUX_SIG_IGN)
+		memset(&process->signal_actions[signal - 1], 0,
+		       sizeof(process->signal_actions[signal - 1]));
+	(void)signal_queue_thread_locked(process, thread, signal,
+	                                 &information);
+	spinlock_release(&process->lock);
+}
+
+static void signal_regs_save(struct linux_user_regs *registers,
+			     trapframe_t trapframe)
+{
+	registers->pc = trapframe->epc;
+	registers->ra = trapframe->ra;
+	registers->sp = trapframe->sp;
+	registers->gp = trapframe->gp;
+	registers->tp = trapframe->tp;
+	registers->t0 = trapframe->t0;
+	registers->t1 = trapframe->t1;
+	registers->t2 = trapframe->t2;
+	registers->s0 = trapframe->s0;
+	registers->s1 = trapframe->s1;
+	registers->a0 = trapframe->a0;
+	registers->a1 = trapframe->a1;
+	registers->a2 = trapframe->a2;
+	registers->a3 = trapframe->a3;
+	registers->a4 = trapframe->a4;
+	registers->a5 = trapframe->a5;
+	registers->a6 = trapframe->a6;
+	registers->a7 = trapframe->a7;
+	registers->s2 = trapframe->s2;
+	registers->s3 = trapframe->s3;
+	registers->s4 = trapframe->s4;
+	registers->s5 = trapframe->s5;
+	registers->s6 = trapframe->s6;
+	registers->s7 = trapframe->s7;
+	registers->s8 = trapframe->s8;
+	registers->s9 = trapframe->s9;
+	registers->s10 = trapframe->s10;
+	registers->s11 = trapframe->s11;
+	registers->t3 = trapframe->t3;
+	registers->t4 = trapframe->t4;
+	registers->t5 = trapframe->t5;
+	registers->t6 = trapframe->t6;
+}
+
+static void signal_regs_restore(trapframe_t trapframe,
+				const struct linux_user_regs *registers)
+{
+	trapframe->epc = registers->pc;
+	trapframe->ra = registers->ra;
+	trapframe->sp = registers->sp;
+	trapframe->gp = registers->gp;
+	trapframe->tp = registers->tp;
+	trapframe->t0 = registers->t0;
+	trapframe->t1 = registers->t1;
+	trapframe->t2 = registers->t2;
+	trapframe->s0 = registers->s0;
+	trapframe->s1 = registers->s1;
+	trapframe->a0 = registers->a0;
+	trapframe->a1 = registers->a1;
+	trapframe->a2 = registers->a2;
+	trapframe->a3 = registers->a3;
+	trapframe->a4 = registers->a4;
+	trapframe->a5 = registers->a5;
+	trapframe->a6 = registers->a6;
+	trapframe->a7 = registers->a7;
+	trapframe->s2 = registers->s2;
+	trapframe->s3 = registers->s3;
+	trapframe->s4 = registers->s4;
+	trapframe->s5 = registers->s5;
+	trapframe->s6 = registers->s6;
+	trapframe->s7 = registers->s7;
+	trapframe->s8 = registers->s8;
+	trapframe->s9 = registers->s9;
+	trapframe->s10 = registers->s10;
+	trapframe->s11 = registers->s11;
+	trapframe->t3 = registers->t3;
+	trapframe->t4 = registers->t4;
+	trapframe->t5 = registers->t5;
+	trapframe->t6 = registers->t6;
+}
+
+static int signal_on_altstack(thread_t thread, uint64 stack_pointer)
+{
+	uint64 end;
+
+	if (thread->signal_altstack_flags & LINUX_SS_DISABLE)
+		return 0;
+	end = thread->signal_altstack_sp + thread->signal_altstack_size;
+	return end >= thread->signal_altstack_sp &&
+	       stack_pointer >= thread->signal_altstack_sp &&
+	       stack_pointer < end;
+}
+
+static void signal_altstack_save(thread_t thread, uint64 stack_pointer,
+				 struct linux_sigaltstack *stack)
+{
+	stack->sp = thread->signal_altstack_sp;
+	stack->size = thread->signal_altstack_size;
+	stack->padding = 0;
+	stack->flags = thread->signal_altstack_flags;
+	if (signal_on_altstack(thread, stack_pointer))
+		stack->flags |= LINUX_SS_ONSTACK;
+}
+
+static int signal_altstack_restore(thread_t thread,
+				   const struct linux_sigaltstack *stack)
+{
+	uint32 flags = stack->flags & ~LINUX_SS_ONSTACK;
+
+	if (flags == LINUX_SS_DISABLE) {
+		thread->signal_altstack_sp = 0;
+		thread->signal_altstack_size = 0;
+		thread->signal_altstack_flags = LINUX_SS_DISABLE;
+		return 0;
+	}
+	if (flags & ~LINUX_SS_AUTODISARM ||
+	    stack->size < SIGNAL_ALTSTACK_MIN ||
+	    stack->sp >= MAXVA || stack->size > MAXVA - stack->sp)
+		return -1;
+	thread->signal_altstack_sp = stack->sp;
+	thread->signal_altstack_size = stack->size;
+	thread->signal_altstack_flags = flags;
+	return 0;
+}
+
+static void signal_info_export(struct linux_siginfo *destination,
+			       const struct signal_info *source)
+{
+	memset(destination, 0, sizeof(*destination));
+	destination->signal = source->signal;
+	destination->error = source->error;
+	destination->code = source->code;
+	if (source->code == LINUX_SI_USER ||
+	    source->code == LINUX_SI_TKILL) {
+		destination->fields.kill.pid = source->sender_pid;
+		destination->fields.kill.uid = source->sender_uid;
+	} else if (source->signal == LINUX_SIGCHLD) {
+		destination->fields.child.pid = source->sender_pid;
+		destination->fields.child.uid = source->sender_uid;
+		destination->fields.child.status = source->status;
+	} else {
+		destination->fields.fault.address = source->address;
+	}
+}
+
+static int signal_frame_setup(thread_t thread,
+			      const struct signal_info *information,
+			      const struct process_signal_action *action,
+			      uint64 old_mask)
+{
+	struct linux_rt_sigframe frame;
+	trapframe_t trapframe = thread->trapframe;
+	process_t process = thread->home;
+	uint64 frame_address, stack_pointer = trapframe->sp;
+	int use_altstack = 0;
+
+	memset(&frame, 0, sizeof(frame));
+	if ((action->flags & LINUX_SA_ONSTACK) &&
+	    !(thread->signal_altstack_flags & LINUX_SS_DISABLE) &&
+	    !signal_on_altstack(thread, stack_pointer)) {
+		stack_pointer = thread->signal_altstack_sp +
+		                thread->signal_altstack_size;
+		use_altstack = 1;
+	}
+	if (stack_pointer < sizeof(frame))
+		return -1;
+	frame_address = (stack_pointer - sizeof(frame)) & ~15ULL;
+	if (frame_address >= MAXVA)
+		return -1;
+	signal_info_export(&frame.info, information);
+	signal_altstack_save(thread, trapframe->sp, &frame.context.stack);
+	frame.context.signal_mask = old_mask;
+	signal_regs_save(&frame.context.mcontext.regs, trapframe);
+	memmove(frame.context.mcontext.fpregs.d.f, trapframe->f,
+	        sizeof(trapframe->f));
+	frame.context.mcontext.fpregs.d.fcsr = trapframe->fcsr;
+	frame.context.mcontext.fpregs.ext.reserved = 0;
+	frame.context.mcontext.fpregs.ext.header.magic = 0;
+	frame.context.mcontext.fpregs.ext.header.size = 0;
+	if (copyout(process->pagetable, frame_address, (char *)&frame,
+	            sizeof(frame)) < 0)
+		return -1;
+	if (use_altstack &&
+	    (thread->signal_altstack_flags & LINUX_SS_AUTODISARM)) {
+		thread->signal_altstack_sp = 0;
+		thread->signal_altstack_size = 0;
+		thread->signal_altstack_flags = LINUX_SS_DISABLE;
+	}
+	trapframe->epc = action->handler;
+	trapframe->ra = USER_SIGRETURN;
+	trapframe->sp = frame_address;
+	trapframe->a0 = information->signal;
+	trapframe->a1 = frame_address +
+		__builtin_offsetof(struct linux_rt_sigframe, info);
+	trapframe->a2 = frame_address +
+		__builtin_offsetof(struct linux_rt_sigframe, context);
+	return 0;
+}
+
+static void signal_restart_syscall(thread_t thread, int restart,
+				   int through_handler)
+{
+	trapframe_t trapframe = thread->trapframe;
+
+	if (!thread->syscall_restart)
+		return;
+	thread->syscall_restart = 0;
+	if (!restart) {
+		trapframe->a0 = -LINUX_EINTR;
+		futex_restart_cancel(thread);
+		return;
+	}
+	trapframe->a0 = thread->syscall_a0;
+	trapframe->epc -= 4;
+	futex_restart_signal(thread, through_handler);
+}
+
+void signal_user_return(int from_syscall)
+{
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	struct process_signal_action action;
+	struct signal_info information;
+	uint64 frame_mask, new_mask;
+	int signal;
+
+	for (;;) {
+		spinlock_acquire(&process->lock);
+		if (process->stopped &&
+		    !(thread->signal_pending.bits & SIGNAL_BIT(LINUX_SIGKILL)) &&
+		    !(process->signal_pending->bits &
+		      SIGNAL_BIT(LINUX_SIGKILL))) {
+			wait_queue_sleep(&process->signal_wait, &process->lock);
+			spinlock_release(&process->lock);
+			continue;
+		}
+		signal = signal_take_unblocked_locked(process, thread,
+		                                      &information, &action);
+		if (!signal) {
+			if (thread->signal_restore_mask) {
+				thread->signal_mask = thread->signal_saved_mask;
+				thread->signal_restore_mask = 0;
+				signal_thread_mask_changed_locked(process, thread);
+			}
+			spinlock_release(&process->lock);
+			if (from_syscall)
+				signal_restart_syscall(thread, 1, 0);
+			return;
+		}
+		if (action.handler == LINUX_SIG_IGN ||
+		    (action.handler == LINUX_SIG_DFL &&
+		     signal_default_ignored(signal))) {
+			spinlock_release(&process->lock);
+			continue;
+		}
+		if (action.handler == LINUX_SIG_DFL) {
+			spinlock_release(&process->lock);
+			if (signal == LINUX_SIGCONT)
+				continue;
+			if (signal_default_stops(signal)) {
+				process_signal_stop(signal);
+				continue;
+			}
+			process_signal_exit(signal,
+			                    signal_default_cores(signal));
+		}
+		frame_mask = thread->signal_restore_mask ?
+			thread->signal_saved_mask : thread->signal_mask;
+		thread->signal_restore_mask = 0;
+		new_mask = thread->signal_mask | action.mask;
+		if (!(action.flags & LINUX_SA_NODEFER))
+			new_mask |= SIGNAL_BIT(signal);
+		thread->signal_mask = signal_mask_sanitize(new_mask);
+		signal_thread_mask_changed_locked(process, thread);
+		if (action.flags & LINUX_SA_RESETHAND)
+			memset(&process->signal_actions[signal - 1], 0,
+			       sizeof(process->signal_actions[signal - 1]));
+		spinlock_release(&process->lock);
+		if (from_syscall)
+			signal_restart_syscall(
+				thread, !!(action.flags & LINUX_SA_RESTART), 1);
+		if (signal_frame_setup(thread, &information, &action,
+		                       frame_mask) < 0)
+			process_signal_exit(LINUX_SIGSEGV, 1);
+		return;
+	}
+}
+
+uint64 sys_linux_rt_sigreturn(void)
+{
+	struct linux_rt_sigframe frame;
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	trapframe_t trapframe = thread->trapframe;
+	uint64 address = trapframe->sp;
+
+	if (address & 15 || address >= MAXVA ||
+	    sizeof(frame) > MAXVA - address ||
+	    copyin(process->pagetable, (char *)&frame, address,
+	           sizeof(frame)) < 0 ||
+	    frame.context.mcontext.fpregs.ext.reserved ||
+	    frame.context.mcontext.fpregs.ext.header.magic ||
+	    frame.context.mcontext.fpregs.ext.header.size ||
+	    frame.context.mcontext.regs.pc >= MAXVA ||
+	    frame.context.mcontext.regs.sp >= MAXVA ||
+	    signal_altstack_restore(thread, &frame.context.stack) < 0) {
+		signal_force_fault(LINUX_SIGSEGV, LINUX_SEGV_MAPERR, address);
+		return 0;
+	}
+	signal_regs_restore(trapframe, &frame.context.mcontext.regs);
+	memmove(trapframe->f, frame.context.mcontext.fpregs.d.f,
+	        sizeof(trapframe->f));
+	trapframe->fcsr = frame.context.mcontext.fpregs.d.fcsr;
+	spinlock_acquire(&process->lock);
+	thread->signal_mask = signal_mask_sanitize(
+		frame.context.signal_mask);
+	thread->signal_restore_mask = 0;
+	signal_thread_mask_changed_locked(process, thread);
+	spinlock_release(&process->lock);
+	futex_restart_sigreturn(thread);
+	return trapframe->a0;
+}
+
+uint64 sys_linux_rt_sigaction(void)
+{
+	const uint64 supported_flags =
+		LINUX_SA_NOCLDSTOP | LINUX_SA_NOCLDWAIT |
+		LINUX_SA_SIGINFO |
+		LINUX_SA_ONSTACK | LINUX_SA_RESTART |
+		LINUX_SA_NODEFER | LINUX_SA_RESETHAND;
+	struct linux_sigaction requested, old;
+	process_t process = cur_proc();
+	uint64 action_address, old_action_address, sigset_size;
+	int signal;
+
+	argint(0, &signal);
+	argaddr(1, &action_address);
+	argaddr(2, &old_action_address);
+	argaddr(3, &sigset_size);
+	if (!signal_valid(signal) || sigset_size != LINUX_SIGSET_SIZE)
+		return -LINUX_EINVAL;
+	if (action_address &&
+	    copyin(process->pagetable, (char *)&requested, action_address,
+	           sizeof(requested)) < 0)
+		return -LINUX_EFAULT;
+	/* musl widens its signed int sa_flags member to this UAPI word. */
+	if (action_address)
+		requested.flags = (uint32)requested.flags;
+	if (action_address &&
+	    (signal == LINUX_SIGKILL || signal == LINUX_SIGSTOP ||
+	     requested.flags & ~supported_flags))
+		return -LINUX_EINVAL;
+	spinlock_acquire(&process->lock);
+	memmove(&old, &process->signal_actions[signal - 1], sizeof(old));
+	if (action_address) {
+		requested.mask = signal_mask_sanitize(requested.mask);
+		memmove(&process->signal_actions[signal - 1], &requested,
+		        sizeof(requested));
+		if (requested.handler == LINUX_SIG_IGN ||
+		    (requested.handler == LINUX_SIG_DFL &&
+		     signal_default_ignored(signal)))
+			signal_clear_locked(process, signal);
+	}
+	spinlock_release(&process->lock);
+	if (old_action_address &&
+	    copyout(process->pagetable, old_action_address, (char *)&old,
+	            sizeof(old)) < 0)
+		return -LINUX_EFAULT;
+	return 0;
+}
+
+uint64 sys_linux_rt_sigprocmask(void)
+{
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	uint64 mask, mask_address, old_mask_address, old_mask, sigset_size;
+	int how;
+
+	argint(0, &how);
+	argaddr(1, &mask_address);
+	argaddr(2, &old_mask_address);
+	argaddr(3, &sigset_size);
+	if (sigset_size != LINUX_SIGSET_SIZE)
+		return -LINUX_EINVAL;
+	if (mask_address &&
+	    copyin(process->pagetable, (char *)&mask, mask_address,
+	           sizeof(mask)) < 0)
+		return -LINUX_EFAULT;
+	spinlock_acquire(&process->lock);
+	old_mask = thread->signal_mask;
+	if (mask_address) {
+		mask = signal_mask_sanitize(mask);
+		if (how == LINUX_SIG_BLOCK)
+			thread->signal_mask |= mask;
+		else if (how == LINUX_SIG_UNBLOCK)
+			thread->signal_mask &= ~mask;
+		else if (how == LINUX_SIG_SETMASK)
+			thread->signal_mask = mask;
+		else {
+			spinlock_release(&process->lock);
+			return -LINUX_EINVAL;
+		}
+		signal_thread_mask_changed_locked(process, thread);
+	}
+	spinlock_release(&process->lock);
+	if (old_mask_address &&
+	    copyout(process->pagetable, old_mask_address, (char *)&old_mask,
+	            sizeof(old_mask)) < 0)
+		return -LINUX_EFAULT;
+	return 0;
+}
+
+uint64 sys_linux_rt_sigpending(void)
+{
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	uint64 address, pending, sigset_size;
+
+	argaddr(0, &address);
+	argaddr(1, &sigset_size);
+	if (sigset_size != LINUX_SIGSET_SIZE)
+		return -LINUX_EINVAL;
+	spinlock_acquire(&process->lock);
+	pending = (process->signal_pending->bits |
+	           thread->signal_pending.bits) & thread->signal_mask;
+	spinlock_release(&process->lock);
+	if (copyout(process->pagetable, address, (char *)&pending,
+	            sizeof(pending)) < 0)
+		return -LINUX_EFAULT;
+	return 0;
+}
+
+static int signal_send_syscall(int thread_group, int tid, int signal,
+			       int thread_directed)
+{
+	struct signal_info information = {
+		.signal = signal,
+		.code = thread_directed ? LINUX_SI_TKILL : LINUX_SI_USER,
+		.sender_pid = cur_proc()->pid,
+		.sender_uid = 0,
+	};
+	int result;
+
+	if (signal < 0 || signal > SIGNAL_COUNT)
+		return -LINUX_EINVAL;
+	if (thread_directed)
+		result = signal_send_thread(thread_group, tid, signal,
+		                            &information);
+	else
+		result = signal_send_process(tid, signal, &information);
+	if (result == SIGNAL_QUEUE_FULL)
+		return -LINUX_EAGAIN;
+	return result < 0 ? -LINUX_ESRCH : 0;
+}
+
+uint64 sys_linux_kill(void)
+{
+	int pid, signal;
+
+	argint(0, &pid);
+	argint(1, &signal);
+	if (pid <= 0)
+		return -LINUX_EINVAL;
+	return signal_send_syscall(0, pid, signal, 0);
+}
+
+uint64 sys_linux_tkill(void)
+{
+	int tid, signal;
+
+	argint(0, &tid);
+	argint(1, &signal);
+	if (tid <= 0)
+		return -LINUX_EINVAL;
+	return signal_send_syscall(0, tid, signal, 1);
+}
+
+uint64 sys_linux_tgkill(void)
+{
+	int thread_group, tid, signal;
+
+	argint(0, &thread_group);
+	argint(1, &tid);
+	argint(2, &signal);
+	if (thread_group <= 0 || tid <= 0)
+		return -LINUX_EINVAL;
+	return signal_send_syscall(thread_group, tid, signal, 1);
+}
+
+uint64 sys_linux_sigaltstack(void)
+{
+	struct linux_sigaltstack requested, old;
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	uint64 address, old_address;
+
+	argaddr(0, &address);
+	argaddr(1, &old_address);
+	if (address &&
+	    copyin(process->pagetable, (char *)&requested, address,
+	           sizeof(requested)) < 0)
+		return -LINUX_EFAULT;
+	spinlock_acquire(&process->lock);
+	signal_altstack_save(thread, thread->trapframe->sp, &old);
+	if (address) {
+		if (signal_on_altstack(thread, thread->trapframe->sp)) {
+			spinlock_release(&process->lock);
+			return -LINUX_EPERM;
+		}
+		if (requested.flags == LINUX_SS_DISABLE) {
+			thread->signal_altstack_sp = 0;
+			thread->signal_altstack_size = 0;
+			thread->signal_altstack_flags = LINUX_SS_DISABLE;
+		} else if (requested.flags & ~LINUX_SS_AUTODISARM) {
+			spinlock_release(&process->lock);
+			return -LINUX_EINVAL;
+		} else if (requested.size < SIGNAL_ALTSTACK_MIN) {
+			spinlock_release(&process->lock);
+			return -LINUX_ENOMEM;
+		} else if (requested.sp >= MAXVA ||
+		           requested.size > MAXVA - requested.sp) {
+			spinlock_release(&process->lock);
+			return -LINUX_EINVAL;
+		} else {
+			thread->signal_altstack_sp = requested.sp;
+			thread->signal_altstack_size = requested.size;
+			thread->signal_altstack_flags = requested.flags;
+		}
+	}
+	spinlock_release(&process->lock);
+	if (old_address &&
+	    copyout(process->pagetable, old_address, (char *)&old,
+	            sizeof(old)) < 0)
+		return -LINUX_EFAULT;
+	return 0;
+}
+
+uint64 sys_linux_rt_sigsuspend(void)
+{
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	uint64 address, mask, sigset_size;
+
+	argaddr(0, &address);
+	argaddr(1, &sigset_size);
+	if (sigset_size != LINUX_SIGSET_SIZE ||
+	    copyin(process->pagetable, (char *)&mask, address,
+	           sizeof(mask)) < 0)
+		return sigset_size != LINUX_SIGSET_SIZE ?
+			-LINUX_EINVAL : -LINUX_EFAULT;
+	spinlock_acquire(&process->lock);
+	thread->signal_saved_mask = thread->signal_mask;
+	thread->signal_restore_mask = 1;
+	thread->signal_mask = signal_mask_sanitize(mask);
+	signal_thread_mask_changed_locked(process, thread);
+	while (!((thread->signal_pending.bits |
+	          (process->signal_pending->bits &
+	           thread->process_signal_target)) &
+	         ~thread->signal_mask) &&
+	       !process->group_exiting)
+		wait_queue_sleep(&process->signal_wait, &process->lock);
+	spinlock_release(&process->lock);
+	return -LINUX_EINTR;
+}
+
+static int signal_timeout_ms(const struct linux_timespec *time,
+			     uint64 *milliseconds)
+{
+	if (time->seconds < 0 || time->nanoseconds < 0 ||
+	    time->nanoseconds >= 1000000000)
+		return -1;
+	if ((uint64)time->seconds > (~(uint64)0 - 999999999) / 1000) {
+		*milliseconds = ~(uint64)0;
+		return 0;
+	}
+	*milliseconds = time->seconds * 1000ULL +
+		(time->nanoseconds + 999999) / 1000000;
+	return 0;
+}
+
+uint64 sys_linux_rt_sigtimedwait(void)
+{
+	struct linux_timespec timeout;
+	struct linux_siginfo exported;
+	struct signal_info information;
+	process_t process = cur_proc();
+	thread_t thread = cur_thread();
+	uint64 set_address, info_address, timeout_address, sigset_size;
+	uint64 set, timeout_ms = 0, start = 0, remaining;
+	int result, signal;
+
+	argaddr(0, &set_address);
+	argaddr(1, &info_address);
+	argaddr(2, &timeout_address);
+	argaddr(3, &sigset_size);
+	if (sigset_size != LINUX_SIGSET_SIZE)
+		return -LINUX_EINVAL;
+	if (copyin(process->pagetable, (char *)&set, set_address,
+	           sizeof(set)) < 0)
+		return -LINUX_EFAULT;
+	set = signal_mask_sanitize(set);
+	if (timeout_address) {
+		if (copyin(process->pagetable, (char *)&timeout,
+		           timeout_address, sizeof(timeout)) < 0)
+			return -LINUX_EFAULT;
+		if (signal_timeout_ms(&timeout, &timeout_ms) < 0)
+			return -LINUX_EINVAL;
+		start = ktime_get_ms();
+	}
+	spinlock_acquire(&process->lock);
+	for (;;) {
+		signal = signal_take_set_locked(process, thread, set, 0,
+		                                &information);
+		if (signal)
+			break;
+		if ((process->signal_pending->bits |
+		     thread->signal_pending.bits) & ~thread->signal_mask) {
+			spinlock_release(&process->lock);
+			return -LINUX_EINTR;
+		}
+		if (timeout_address) {
+			uint64 elapsed = ktime_get_ms() - start;
+
+			if (elapsed >= timeout_ms) {
+				spinlock_release(&process->lock);
+				return -LINUX_EAGAIN;
+			}
+			remaining = timeout_ms - elapsed;
+			result = wait_queue_sleep_timeout(
+				&process->signal_wait, &process->lock, remaining);
+			if (result == WAIT_QUEUE_TIMEOUT)
+				continue;
+		} else {
+			wait_queue_sleep(&process->signal_wait,
+			                 &process->lock);
+		}
+	}
+	spinlock_release(&process->lock);
+	if (info_address) {
+		signal_info_export(&exported, &information);
+		if (copyout(process->pagetable, info_address,
+		            (char *)&exported, sizeof(exported)) < 0)
+			return -LINUX_EFAULT;
+	}
+	return signal;
+}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -61,6 +61,9 @@ extern uint64 sys_linux_dup3(void);
 extern uint64 sys_linux_execve(void);
 extern uint64 sys_linux_exit(void);
 extern uint64 sys_linux_exit_group(void);
+extern uint64 sys_linux_futex(void);
+extern uint64 sys_linux_set_robust_list(void);
+extern uint64 sys_linux_get_robust_list(void);
 extern uint64 sys_linux_faccessat(void);
 extern uint64 sys_linux_fcntl(void);
 extern uint64 sys_linux_fstat(void);
@@ -156,6 +159,9 @@ static syscall_t linux_syscalls[LINUX_SYS_renameat2 + 1] = {
 	[LINUX_SYS_utimensat] = sys_linux_utimensat,
 	[LINUX_SYS_exit] = sys_linux_exit,
 	[LINUX_SYS_exit_group] = sys_linux_exit_group,
+	[LINUX_SYS_futex] = sys_linux_futex,
+	[LINUX_SYS_set_robust_list] = sys_linux_set_robust_list,
+	[LINUX_SYS_get_robust_list] = sys_linux_get_robust_list,
 	[LINUX_SYS_set_tid_address] = sys_linux_set_tid_address,
 	[LINUX_SYS_clock_gettime] = sys_linux_clock_gettime,
 	[LINUX_SYS_rt_sigaction] = sys_linux_rt_sigaction,

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -84,6 +84,7 @@ extern uint64 sys_linux_lseek(void);
 extern uint64 sys_linux_mkdirat(void);
 extern uint64 sys_linux_mmap(void);
 extern uint64 sys_linux_mprotect(void);
+extern uint64 sys_linux_membarrier(void);
 extern uint64 sys_linux_munmap(void);
 extern uint64 sys_linux_newfstatat(void);
 extern uint64 sys_linux_openat(void);
@@ -128,7 +129,7 @@ extern uint64 sys_linux_ftruncate(void);
 
 typedef uint64 (*syscall_t)(void);
 
-static syscall_t linux_syscalls[LINUX_SYS_renameat2 + 1] = {
+static syscall_t linux_syscalls[LINUX_SYS_membarrier + 1] = {
 	[LINUX_SYS_getcwd] = sys_linux_getcwd,
 	[LINUX_SYS_dup] = sys_linux_dup,
 	[LINUX_SYS_dup3] = sys_linux_dup3,
@@ -201,6 +202,7 @@ static syscall_t linux_syscalls[LINUX_SYS_renameat2 + 1] = {
 	[LINUX_SYS_accept4] = sys_linux_accept4,
 	[LINUX_SYS_wait4] = sys_linux_wait4,
 	[LINUX_SYS_renameat2] = sys_linux_renameat2,
+	[LINUX_SYS_membarrier] = sys_linux_membarrier,
 };
 
 void syscall(void)

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -3,6 +3,7 @@
 #include <mystring.h>
 #include <printk.h>
 #include <scheduler.h>
+#include <signal.h>
 #include <syscall.h>
 #include <vm.h>
 
@@ -96,8 +97,16 @@ extern uint64 sys_linux_renameat2(void);
 extern uint64 sys_linux_set_tid_address(void);
 extern uint64 sys_linux_clone(void);
 extern uint64 sys_linux_clock_gettime(void);
+extern uint64 sys_linux_kill(void);
+extern uint64 sys_linux_tkill(void);
+extern uint64 sys_linux_tgkill(void);
+extern uint64 sys_linux_sigaltstack(void);
+extern uint64 sys_linux_rt_sigsuspend(void);
 extern uint64 sys_linux_rt_sigaction(void);
 extern uint64 sys_linux_rt_sigprocmask(void);
+extern uint64 sys_linux_rt_sigpending(void);
+extern uint64 sys_linux_rt_sigtimedwait(void);
+extern uint64 sys_linux_rt_sigreturn(void);
 extern uint64 sys_linux_setpriority(void);
 extern uint64 sys_linux_getpriority(void);
 extern uint64 sys_linux_symlinkat(void);
@@ -165,8 +174,16 @@ static syscall_t linux_syscalls[LINUX_SYS_membarrier + 1] = {
 	[LINUX_SYS_get_robust_list] = sys_linux_get_robust_list,
 	[LINUX_SYS_set_tid_address] = sys_linux_set_tid_address,
 	[LINUX_SYS_clock_gettime] = sys_linux_clock_gettime,
+	[LINUX_SYS_kill] = sys_linux_kill,
+	[LINUX_SYS_tkill] = sys_linux_tkill,
+	[LINUX_SYS_tgkill] = sys_linux_tgkill,
+	[LINUX_SYS_sigaltstack] = sys_linux_sigaltstack,
+	[LINUX_SYS_rt_sigsuspend] = sys_linux_rt_sigsuspend,
 	[LINUX_SYS_rt_sigaction] = sys_linux_rt_sigaction,
 	[LINUX_SYS_rt_sigprocmask] = sys_linux_rt_sigprocmask,
+	[LINUX_SYS_rt_sigpending] = sys_linux_rt_sigpending,
+	[LINUX_SYS_rt_sigtimedwait] = sys_linux_rt_sigtimedwait,
+	[LINUX_SYS_rt_sigreturn] = sys_linux_rt_sigreturn,
 	[LINUX_SYS_setpriority] = sys_linux_setpriority,
 	[LINUX_SYS_getpriority] = sys_linux_getpriority,
 	[LINUX_SYS_umask] = sys_linux_umask,
@@ -207,13 +224,19 @@ static syscall_t linux_syscalls[LINUX_SYS_membarrier + 1] = {
 
 void syscall(void)
 {
+	uint64 result;
 	uint64 nr;
 	process_t p = cur_proc();
 	thread_t current = cur_thread();
 
 	nr = current->trapframe->a7;
+	current->syscall_restart = 0;
 	if (nr < NELEM(linux_syscalls) && linux_syscalls[nr]) {
-		current->trapframe->a0 = linux_syscalls[nr]();
+		result = linux_syscalls[nr]();
+		if (nr != LINUX_SYS_rt_sigreturn &&
+		    (int64)result == -SIGNAL_RESTART_SYS)
+			current->syscall_restart = 1;
+		current->trapframe->a0 = result;
 		return;
 	}
 

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -4,6 +4,7 @@
 #include <palloc.h>
 #include <process.h>
 #include <scheduler.h>
+#include <signal.h>
 #include <syscall.h>
 #include <vfs.h>
 #include <vm.h>
@@ -142,6 +143,8 @@ static uint64 linux_error(int result)
 		return -LINUX_EINPROGRESS;
 	case VFS_ERR_PIPE:
 		return -LINUX_EPIPE;
+	case VFS_ERR_INTR:
+		return -LINUX_EINTR;
 	default:
 		return -LINUX_EIO;
 	}
@@ -278,6 +281,8 @@ uint64 sys_linux_read(void)
 	argaddr(1, &address);
 	argint(2, &length);
 	result = vfs_read(fd, address, length);
+	if (result == VFS_ERR_INTR)
+		return -SIGNAL_RESTART_SYS;
 	return result < 0 ? linux_error(result) : result;
 }
 

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -7,8 +7,6 @@
 #include <syscall.h>
 #include <vm.h>
 
-extern void exit(int cause);
-
 uint64 sys_linux_clock_gettime(void)
 {
 	struct linux_timespec time;
@@ -34,22 +32,25 @@ uint64 sys_linux_exit_group(void)
 	int status;
 
 	argint(0, &status);
-	exit(status);
+	process_thread_exit(status, 1);
 	return 0;
 }
 
 uint64 sys_linux_exit(void)
 {
-	return sys_linux_exit_group();
+	int status;
+
+	argint(0, &status);
+	process_thread_exit(status, 0);
+	return 0;
 }
 
 uint64 sys_linux_set_tid_address(void)
 {
-	process_t p = cur_proc();
 	uint64 address;
 
 	argaddr(0, &address);
-	p->clear_child_tid = address;
+	cur_thread()->clear_child_tid = address;
 	return cur_thread()->tid;
 }
 
@@ -110,7 +111,6 @@ uint64 sys_linux_gettid(void)
 
 uint64 sys_linux_setpriority(void)
 {
-	process_t process = cur_proc();
 	int which, who, nice;
 
 	argint(0, &which);
@@ -118,26 +118,21 @@ uint64 sys_linux_setpriority(void)
 	argint(2, &nice);
 	if (which != LINUX_PRIO_PROCESS)
 		return -LINUX_EINVAL;
-	if (!who)
-		who = process->pid;
 	if (nice < -20)
 		nice = -20;
 	if (nice > 19)
 		nice = 19;
-	return process_set_nice(who, nice) ? -LINUX_ESRCH : 0;
+	return process_set_nice(who, nice);
 }
 
 uint64 sys_linux_getpriority(void)
 {
-	process_t process = cur_proc();
 	int nice, which, who;
 
 	argint(0, &which);
 	argint(1, &who);
 	if (which != LINUX_PRIO_PROCESS)
 		return -LINUX_EINVAL;
-	if (!who)
-		who = process->pid;
 	if (process_get_nice(who, &nice))
 		return -LINUX_ESRCH;
 	/* Linux returns 20 - nice so a negative nice value is not an error. */
@@ -192,6 +187,7 @@ uint64 sys_linux_rt_sigaction(void)
 uint64 sys_linux_rt_sigprocmask(void)
 {
 	process_t process = cur_proc();
+	thread_t current = cur_thread();
 	uint64 mask, mask_address, old_mask_address, sigset_size;
 	int how;
 
@@ -203,7 +199,7 @@ uint64 sys_linux_rt_sigprocmask(void)
 		return -LINUX_EINVAL;
 	if (old_mask_address &&
 	    copyout(process->pagetable, old_mask_address,
-	            (char *)&process->signal_mask, sizeof(uint64)) < 0)
+	            (char *)&current->signal_mask, sizeof(uint64)) < 0)
 		return -LINUX_EFAULT;
 	if (!mask_address)
 		return 0;
@@ -213,11 +209,11 @@ uint64 sys_linux_rt_sigprocmask(void)
 	mask &= ~(1ULL << (LINUX_SIGKILL - 1));
 	mask &= ~(1ULL << (LINUX_SIGSTOP - 1));
 	if (how == LINUX_SIG_BLOCK)
-		process->signal_mask |= mask;
+		current->signal_mask |= mask;
 	else if (how == LINUX_SIG_UNBLOCK)
-		process->signal_mask &= ~mask;
+		current->signal_mask &= ~mask;
 	else if (how == LINUX_SIG_SETMASK)
-		process->signal_mask = mask;
+		current->signal_mask = mask;
 	else
 		return -LINUX_EINVAL;
 	return 0;
@@ -225,11 +221,29 @@ uint64 sys_linux_rt_sigprocmask(void)
 
 uint64 sys_linux_clone(void)
 {
-	uint64 child_stack, flags;
+	const uint64 thread_required =
+		LINUX_CLONE_VM | LINUX_CLONE_FS | LINUX_CLONE_FILES |
+		LINUX_CLONE_SIGHAND | LINUX_CLONE_THREAD;
+	const uint64 thread_allowed =
+		thread_required | LINUX_CLONE_SYSVSEM | LINUX_CLONE_SETTLS |
+		LINUX_CLONE_PARENT_SETTID | LINUX_CLONE_CHILD_CLEARTID |
+		LINUX_CLONE_CHILD_SETTID | LINUX_CLONE_DETACHED;
+	uint64 child_stack, child_tid, flags, parent_tid, tls;
 	int pid;
 
 	argaddr(0, &flags);
 	argaddr(1, &child_stack);
+	argaddr(2, &parent_tid);
+	argaddr(3, &tls);
+	argaddr(4, &child_tid);
+	if (flags & LINUX_CLONE_THREAD) {
+		if ((flags & thread_required) != thread_required ||
+		    flags & ~thread_allowed ||
+		    (flags & LINUX_CLONE_SIGNAL_MASK))
+			return -LINUX_EINVAL;
+		return process_clone_thread(flags, child_stack, parent_tid,
+		                            tls, child_tid);
+	}
 	if ((flags & LINUX_CLONE_SIGNAL_MASK) != LINUX_SIGCHLD ||
 	    flags & ~(LINUX_CLONE_SIGNAL_MASK | LINUX_CLONE_VM |
 	              LINUX_CLONE_VFORK))

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -150,75 +150,6 @@ uint64 sys_linux_umask(void)
 	return old_mask;
 }
 
-uint64 sys_linux_rt_sigaction(void)
-{
-	struct linux_sigaction action;
-	process_t process = cur_proc();
-	uint64 action_address, old_action_address, sigset_size;
-	int signal;
-
-	_Static_assert(sizeof(action) ==
-	               sizeof(struct process_signal_action),
-	               "signal action layout mismatch");
-	argint(0, &signal);
-	argaddr(1, &action_address);
-	argaddr(2, &old_action_address);
-	argaddr(3, &sigset_size);
-	if (signal < 1 || signal > 64 ||
-	    sigset_size != LINUX_SIGSET_SIZE)
-		return -LINUX_EINVAL;
-	if (old_action_address &&
-	    copyout(process->pagetable, old_action_address,
-	            (char *)&process->signal_actions[signal - 1],
-	            sizeof(action)) < 0)
-		return -LINUX_EFAULT;
-	if (!action_address)
-		return 0;
-	if (signal == LINUX_SIGKILL || signal == LINUX_SIGSTOP)
-		return -LINUX_EINVAL;
-	if (copyin(process->pagetable, (char *)&action, action_address,
-	           sizeof(action)) < 0)
-		return -LINUX_EFAULT;
-	memmove(&process->signal_actions[signal - 1], &action,
-	        sizeof(action));
-	return 0;
-}
-
-uint64 sys_linux_rt_sigprocmask(void)
-{
-	process_t process = cur_proc();
-	thread_t current = cur_thread();
-	uint64 mask, mask_address, old_mask_address, sigset_size;
-	int how;
-
-	argint(0, &how);
-	argaddr(1, &mask_address);
-	argaddr(2, &old_mask_address);
-	argaddr(3, &sigset_size);
-	if (sigset_size != LINUX_SIGSET_SIZE)
-		return -LINUX_EINVAL;
-	if (old_mask_address &&
-	    copyout(process->pagetable, old_mask_address,
-	            (char *)&current->signal_mask, sizeof(uint64)) < 0)
-		return -LINUX_EFAULT;
-	if (!mask_address)
-		return 0;
-	if (copyin(process->pagetable, (char *)&mask, mask_address,
-	           sizeof(mask)) < 0)
-		return -LINUX_EFAULT;
-	mask &= ~(1ULL << (LINUX_SIGKILL - 1));
-	mask &= ~(1ULL << (LINUX_SIGSTOP - 1));
-	if (how == LINUX_SIG_BLOCK)
-		current->signal_mask |= mask;
-	else if (how == LINUX_SIG_UNBLOCK)
-		current->signal_mask &= ~mask;
-	else if (how == LINUX_SIG_SETMASK)
-		current->signal_mask = mask;
-	else
-		return -LINUX_EINVAL;
-	return 0;
-}
-
 uint64 sys_linux_clone(void)
 {
 	const uint64 thread_required =
@@ -260,12 +191,15 @@ uint64 sys_linux_wait4(void)
 	argint(0, &target);
 	argaddr(1, &status_address);
 	argint(2, &options);
-	if ((target < -1) || target == 0 || options & ~LINUX_WNOHANG)
+	if ((target < -1) || target == 0 ||
+	    options & ~(LINUX_WNOHANG | LINUX_WUNTRACED |
+	                LINUX_WCONTINUED))
 		return -LINUX_EINVAL;
-	result = process_wait(target, status_address,
-	                      options & LINUX_WNOHANG);
-	if (result == -2)
+	result = process_wait(target, status_address, options);
+	if (result == PROCESS_WAIT_FAULT)
 		return -LINUX_EFAULT;
+	if (result == PROCESS_WAIT_INTR)
+		return -SIGNAL_RESTART_SYS;
 	if (result < 0)
 		return -LINUX_ECHILD;
 	return result;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -20,6 +20,7 @@
 struct thread thread[NTHREAD];
 
 static int next_tid = 1;
+static int next_kernel_tid = -1;
 static struct spinlock tid_lock;
 
 static void thread_sched_init(thread_t thread)
@@ -54,6 +55,16 @@ static int tid_alloc(void)
         tid = next_tid++;
         spinlock_release(&tid_lock);
         return tid;
+}
+
+static int kernel_tid_alloc(void)
+{
+	int tid;
+
+	spinlock_acquire(&tid_lock);
+	tid = next_kernel_tid--;
+	spinlock_release(&tid_lock);
+	return tid;
 }
 
 /* Be called by vm_create */
@@ -95,6 +106,18 @@ void thread_setup(void)
 thread_t thread_alloc(process_t p)
 {
         thread_t t;
+	int slot;
+
+	if (!p || !spinlock_holding(&p->lock))
+		PANIC("thread_alloc process lock");
+	if (p->tnums == PROC_MAXTHREAD)
+		return 0;
+	for (slot = 0; slot < PROC_MAXTHREAD; slot++) {
+		if (!p->thread[slot])
+			break;
+	}
+	if (slot == PROC_MAXTHREAD)
+		PANIC("thread slot count");
 
         for(t = thread; t <= &thread[NTHREAD - 1]; t++) {
                 int ret = spinlock_trylock(&t->lock);
@@ -109,13 +132,18 @@ thread_t thread_alloc(process_t p)
         }
         return 0;
 found:
-        if(p->tnums == PROC_MAXTHREAD)
-                goto r1;
-        t->id_p = p->tnums ++;
+	t->id_p = slot;
         p->thread[t->id_p] = t;
+	p->tnums++;
+	p->live_threads++;
 
         t->state = THREAD_ALLOCATED;
 	t->lwip_errno = 0;
+	t->clear_child_tid = 0;
+	t->signal_mask = 0;
+	t->process_reaper = 0;
+	t->exit_requested = 0;
+	t->exit_status = 0;
 	thread_sched_init(t);
         t->waiting_on = 0;
         t->on_waitqueue = 0;
@@ -140,9 +168,9 @@ found:
 
         return t;
 r2:
-        p->tnums --;
+	p->live_threads--;
+	p->tnums--;
         p->thread[t->id_p] = 0;
-r1:
         t->state = THREAD_UNUSED;
         t->home = 0;
         spinlock_release(&t->lock);
@@ -167,7 +195,7 @@ thread_t kernel_thread_create(const char *name, thread_func_t function,
 
 found:
 	t->state = THREAD_ALLOCATED;
-	t->tid = tid_alloc();
+	t->tid = kernel_tid_alloc();
 	t->id_p = -1;
 	t->home = 0;
 	t->trapframe = 0;
@@ -175,6 +203,11 @@ found:
 	t->kernel_argument = argument;
 	t->kernel_thread = 1;
 	t->lwip_errno = 0;
+	t->clear_child_tid = 0;
+	t->signal_mask = 0;
+	t->process_reaper = 0;
+	t->exit_requested = 0;
+	t->exit_status = 0;
 	thread_sched_init(t);
 	t->waiting_on = 0;
 	t->on_waitqueue = 0;
@@ -202,6 +235,11 @@ void kernel_thread_reap(thread_t t)
 	t->kernel_function = 0;
 	t->kernel_argument = 0;
 	t->lwip_errno = 0;
+	t->clear_child_tid = 0;
+	t->signal_mask = 0;
+	t->process_reaper = 0;
+	t->exit_requested = 0;
+	t->exit_status = 0;
 	thread_sched_init(t);
 	list_init(&t->wait_node);
 	list_init(&t->timeout_node);
@@ -213,7 +251,10 @@ void thread_free(thread_t t)
         process_t p;
         int i;
 
-        p = t->home;
+	p = t->home;
+	if (!p || !spinlock_holding(&p->lock) ||
+	    !spinlock_holding(&t->lock))
+		PANIC("thread_free locks");
 
 	if (t->sched.on_runqueue)
                 PANIC("thread_free runnable");
@@ -228,14 +269,54 @@ void thread_free(thread_t t)
                         break;
                 }
         }
-        p->tnums --;
+	p->tnums--;
+	if (t->state != THREAD_EXITED) {
+		if (!p->live_threads)
+			PANIC("thread_free live count");
+		p->live_threads--;
+	}
 
         t->state = THREAD_UNUSED;
         if(t->trapframe)
                 pfree(t->trapframe);
-        t->trapframe = 0;
-        t->home = 0;
+	t->trapframe = 0;
+	t->home = 0;
+	t->tid = 0;
+	t->id_p = -1;
+	t->clear_child_tid = 0;
+	t->signal_mask = 0;
+	t->process_reaper = 0;
+	t->exit_requested = 0;
+	t->exit_status = 0;
 	thread_sched_init(t);
         list_init(&t->wait_node);
 	list_init(&t->timeout_node);
+}
+
+void user_thread_reap(thread_t t)
+{
+	process_t p;
+	int slot;
+
+	if (!t || !spinlock_holding(&t->lock) || t->kernel_thread ||
+	    t->state != THREAD_EXITED || t->process_reaper)
+		PANIC("reap user thread");
+	p = t->home;
+	if (!p)
+		PANIC("reap detached thread");
+	/* Keep the global process -> thread lock order. */
+	spinlock_release(&t->lock);
+	spinlock_acquire(&p->lock);
+	spinlock_acquire(&t->lock);
+	if (t->home != p || t->state != THREAD_EXITED ||
+	    t->process_reaper)
+		PANIC("changed user reaper");
+	slot = t->id_p;
+	if (slot < 0 || slot >= PROC_MAXTHREAD || p->thread[slot] != t)
+		PANIC("reap user slot");
+	if (vm_mapped(p->pagetable, TRAPFRAME(slot)))
+		vm_unmap(p->pagetable, TRAPFRAME(slot), 1, 0);
+	thread_free(t);
+	wait_queue_wake_all(&p->thread_reap_wait);
+	spinlock_release(&p->lock);
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -96,6 +96,8 @@ void thread_setup(void)
 		thread_sched_init(t);
                 t->waiting_on = 0;
                 t->on_waitqueue = 0;
+		t->wait_private = 0;
+		t->wait_bitset = ~(uint32)0;
                 list_init(&t->wait_node);
 		t->on_timeout_queue = 0;
 		list_init(&t->timeout_node);
@@ -140,6 +142,8 @@ found:
         t->state = THREAD_ALLOCATED;
 	t->lwip_errno = 0;
 	t->clear_child_tid = 0;
+	t->robust_list = 0;
+	t->robust_list_len = 0;
 	t->signal_mask = 0;
 	t->process_reaper = 0;
 	t->exit_requested = 0;
@@ -147,6 +151,8 @@ found:
 	thread_sched_init(t);
         t->waiting_on = 0;
         t->on_waitqueue = 0;
+	t->wait_private = 0;
+	t->wait_bitset = ~(uint32)0;
         list_init(&t->wait_node);
 	t->on_timeout_queue = 0;
 	list_init(&t->timeout_node);
@@ -204,6 +210,8 @@ found:
 	t->kernel_thread = 1;
 	t->lwip_errno = 0;
 	t->clear_child_tid = 0;
+	t->robust_list = 0;
+	t->robust_list_len = 0;
 	t->signal_mask = 0;
 	t->process_reaper = 0;
 	t->exit_requested = 0;
@@ -211,6 +219,8 @@ found:
 	thread_sched_init(t);
 	t->waiting_on = 0;
 	t->on_waitqueue = 0;
+	t->wait_private = 0;
+	t->wait_bitset = ~(uint32)0;
 	list_init(&t->wait_node);
 	t->on_timeout_queue = 0;
 	list_init(&t->timeout_node);
@@ -236,10 +246,14 @@ void kernel_thread_reap(thread_t t)
 	t->kernel_argument = 0;
 	t->lwip_errno = 0;
 	t->clear_child_tid = 0;
+	t->robust_list = 0;
+	t->robust_list_len = 0;
 	t->signal_mask = 0;
 	t->process_reaper = 0;
 	t->exit_requested = 0;
 	t->exit_status = 0;
+	t->wait_private = 0;
+	t->wait_bitset = ~(uint32)0;
 	thread_sched_init(t);
 	list_init(&t->wait_node);
 	list_init(&t->timeout_node);
@@ -249,7 +263,8 @@ void kernel_thread_reap(thread_t t)
 void thread_free(thread_t t)
 {
         process_t p;
-        int i;
+	int found = 0;
+	int i;
 
 	p = t->home;
 	if (!p || !spinlock_holding(&p->lock) ||
@@ -266,9 +281,12 @@ void thread_free(thread_t t)
         for(i = 0; i < PROC_MAXTHREAD; i++) {
                 if(p->thread[i] == t) {
                         p->thread[i] = 0;
+			found = 1;
                         break;
                 }
         }
+	if (!found)
+		PANIC("thread_free slot");
 	p->tnums--;
 	if (t->state != THREAD_EXITED) {
 		if (!p->live_threads)
@@ -284,13 +302,37 @@ void thread_free(thread_t t)
 	t->tid = 0;
 	t->id_p = -1;
 	t->clear_child_tid = 0;
+	t->robust_list = 0;
+	t->robust_list_len = 0;
 	t->signal_mask = 0;
 	t->process_reaper = 0;
 	t->exit_requested = 0;
 	t->exit_status = 0;
+	t->wait_private = 0;
+	t->wait_bitset = ~(uint32)0;
 	thread_sched_init(t);
         list_init(&t->wait_node);
 	list_init(&t->timeout_node);
+}
+
+int thread_get_robust_list(int tid, uint64 *head, uint64 *length)
+{
+	thread_t target;
+
+	if (tid <= 0 || !head || !length)
+		return -1;
+	for (target = thread; target < &thread[NTHREAD]; target++) {
+		spinlock_acquire(&target->lock);
+		if (target->state != THREAD_UNUSED && !target->kernel_thread &&
+		    target->tid == tid) {
+			*head = target->robust_list;
+			*length = target->robust_list_len;
+			spinlock_release(&target->lock);
+			return 0;
+		}
+		spinlock_release(&target->lock);
+	}
+	return -1;
 }
 
 void user_thread_reap(thread_t t)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -94,12 +94,14 @@ void thread_setup(void)
                 t->kstack = KSTACK((int)(t - thread));;
                 t->state = THREAD_UNUSED;
 		thread_sched_init(t);
+	signal_thread_init(t);
                 t->waiting_on = 0;
                 t->on_waitqueue = 0;
 		t->wait_private = 0;
 		t->wait_bitset = ~(uint32)0;
                 list_init(&t->wait_node);
 		t->on_timeout_queue = 0;
+		t->wait_interruptible = 0;
 		list_init(&t->timeout_node);
                 strncpy(t->name, "thread", 7);
         }
@@ -144,7 +146,7 @@ found:
 	t->clear_child_tid = 0;
 	t->robust_list = 0;
 	t->robust_list_len = 0;
-	t->signal_mask = 0;
+	signal_thread_init(t);
 	t->process_reaper = 0;
 	t->exit_requested = 0;
 	t->exit_status = 0;
@@ -155,6 +157,7 @@ found:
 	t->wait_bitset = ~(uint32)0;
         list_init(&t->wait_node);
 	t->on_timeout_queue = 0;
+	t->wait_interruptible = 0;
 	list_init(&t->timeout_node);
 	t->kernel_function = 0;
 	t->kernel_argument = 0;
@@ -212,7 +215,7 @@ found:
 	t->clear_child_tid = 0;
 	t->robust_list = 0;
 	t->robust_list_len = 0;
-	t->signal_mask = 0;
+		signal_thread_init(t);
 	t->process_reaper = 0;
 	t->exit_requested = 0;
 	t->exit_status = 0;
@@ -223,6 +226,7 @@ found:
 	t->wait_bitset = ~(uint32)0;
 	list_init(&t->wait_node);
 	t->on_timeout_queue = 0;
+	t->wait_interruptible = 0;
 	list_init(&t->timeout_node);
 	memset(&t->context, 0, sizeof(t->context));
 	t->context.ra = (uint64)kernel_thread_entry;
@@ -248,12 +252,13 @@ void kernel_thread_reap(thread_t t)
 	t->clear_child_tid = 0;
 	t->robust_list = 0;
 	t->robust_list_len = 0;
-	t->signal_mask = 0;
+	signal_thread_destroy(t);
 	t->process_reaper = 0;
 	t->exit_requested = 0;
 	t->exit_status = 0;
 	t->wait_private = 0;
 	t->wait_bitset = ~(uint32)0;
+	t->wait_interruptible = 0;
 	thread_sched_init(t);
 	list_init(&t->wait_node);
 	list_init(&t->timeout_node);
@@ -278,7 +283,8 @@ void thread_free(thread_t t)
         if(p->tnums == 0)
                 PANIC("thread_free");
 
-        for(i = 0; i < PROC_MAXTHREAD; i++) {
+	signal_thread_detach_locked(p, t);
+	for(i = 0; i < PROC_MAXTHREAD; i++) {
                 if(p->thread[i] == t) {
                         p->thread[i] = 0;
 			found = 1;
@@ -304,12 +310,13 @@ void thread_free(thread_t t)
 	t->clear_child_tid = 0;
 	t->robust_list = 0;
 	t->robust_list_len = 0;
-	t->signal_mask = 0;
+	signal_thread_destroy(t);
 	t->process_reaper = 0;
 	t->exit_requested = 0;
 	t->exit_status = 0;
 	t->wait_private = 0;
 	t->wait_bitset = ~(uint32)0;
+	t->wait_interruptible = 0;
 	thread_sched_init(t);
         list_init(&t->wait_node);
 	list_init(&t->timeout_node);

--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -7,10 +7,7 @@ trampoline:
 .align 4
 .global user_vec
 user_vec:
-        csrw sscratch, a0
-
-        li a0, TRAPFRAME_INFO
-        ld a0, 0(a0)
+	csrrw a0, sscratch, a0
 
         sd ra, 40(a0)
         sd sp, 48(a0)
@@ -100,8 +97,8 @@ user_ret:
         csrw satp, a0
         sfence.vma zero, zero
 
-        li a0, TRAPFRAME_INFO
-        ld a0, 0(a0)
+	csrw sscratch, a1
+	mv a0, a1
 
 	ld t0, 544(a0)
 	fscsr t0
@@ -138,7 +135,7 @@ user_ret:
 	fld f30, 528(a0)
 	fld f31, 536(a0)
 
-        # restore all but a0 from TRAPFRAME_INFO
+	# Restore all but a0 from the current thread's trapframe.
         ld ra, 40(a0)
         ld sp, 48(a0)
         ld gp, 56(a0)

--- a/kernel/wait.c
+++ b/kernel/wait.c
@@ -1,5 +1,6 @@
 #include <debug.h>
 #include <ktime.h>
+#include <process.h>
 #include <scheduler.h>
 #include <thread.h>
 #include <wait.h>
@@ -43,10 +44,15 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 				     uint64 deadline)
 {
 	thread_t current = cur_thread();
-	int result;
+	int exit_status, result;
 
 	if (!current || !spinlock_holding(condition_lock))
 		PANIC("wait without condition lock");
+	if (process_thread_exit_requested(current, &exit_status)) {
+		spinlock_release(condition_lock);
+		process_thread_exit(exit_status, 0);
+		PANIC("terminated wait returned");
+	}
 	spinlock_acquire(&timeout_queue.lock);
 	spinlock_acquire(&queue->lock);
 	spinlock_acquire(&current->lock);
@@ -60,6 +66,22 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 	list_insert_before(&queue->waiters, &current->wait_node);
 	if (deadline)
 		timeout_insert_locked(current);
+	if (process_thread_exit_requested(current, &exit_status)) {
+		list_remove(&current->wait_node);
+		current->on_waitqueue = 0;
+		current->waiting_on = 0;
+		if (current->on_timeout_queue) {
+			list_remove(&current->timeout_node);
+			current->on_timeout_queue = 0;
+		}
+		current->wait_result = WAIT_QUEUE_TERMINATED;
+		spinlock_release(&current->lock);
+		spinlock_release(&queue->lock);
+		spinlock_release(&timeout_queue.lock);
+		spinlock_release(condition_lock);
+		process_thread_exit(exit_status, 0);
+		PANIC("terminated wait returned");
+	}
 	scheduler_block_current();
 	spinlock_release(condition_lock);
 	spinlock_release(&queue->lock);
@@ -73,6 +95,13 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 	result = current->wait_result;
 	spinlock_release(&current->lock);
 	spinlock_acquire(condition_lock);
+	if (result == WAIT_QUEUE_TERMINATED) {
+		if (!process_thread_exit_requested(current, &exit_status))
+			PANIC("terminated wait without request");
+		spinlock_release(condition_lock);
+		process_thread_exit(exit_status, 0);
+		PANIC("terminated wait returned");
+	}
 	return result;
 }
 
@@ -182,6 +211,29 @@ int wait_queue_wake_thread(thread_t thread)
 	thread->wait_result = 0;
 	scheduler_make_runnable(thread);
 	spinlock_release(&thread->lock);
+	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
+	return 1;
+}
+
+int wait_queue_terminate_thread(thread_t thread)
+{
+	wait_queue_t queue;
+
+	spinlock_acquire(&timeout_queue.lock);
+	queue = thread->waiting_on;
+	if (!queue) {
+		spinlock_release(&timeout_queue.lock);
+		return 0;
+	}
+	spinlock_acquire(&queue->lock);
+	if (thread->state != THREAD_SLEEPING || !thread->on_waitqueue ||
+	    thread->waiting_on != queue) {
+		spinlock_release(&queue->lock);
+		spinlock_release(&timeout_queue.lock);
+		return 0;
+	}
+	wait_queue_wake_locked(queue, thread, WAIT_QUEUE_TERMINATED);
 	spinlock_release(&queue->lock);
 	spinlock_release(&timeout_queue.lock);
 	return 1;

--- a/kernel/wait.c
+++ b/kernel/wait.c
@@ -41,9 +41,10 @@ static void timeout_insert_locked(thread_t thread)
 
 static int wait_queue_sleep_deadline(wait_queue_t queue,
 				     spinlock_t condition_lock,
-				     uint64 deadline)
+				     uint64 deadline, int interruptible)
 {
 	thread_t current = cur_thread();
+	uint64 signal_sequence = 0;
 	int exit_status, result;
 
 	if (!current || !spinlock_holding(condition_lock))
@@ -52,6 +53,12 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 		spinlock_release(condition_lock);
 		process_thread_exit(exit_status, 0);
 		PANIC("terminated wait returned");
+	}
+	if (interruptible) {
+		signal_sequence = __atomic_load_n(&current->signal_sequence,
+		                                  __ATOMIC_ACQUIRE);
+		if (signal_pending_unblocked(current))
+			return WAIT_QUEUE_INTERRUPTED;
 	}
 	spinlock_acquire(&timeout_queue.lock);
 	spinlock_acquire(&queue->lock);
@@ -63,6 +70,7 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 	current->on_waitqueue = 1;
 	current->wait_deadline = deadline;
 	current->wait_result = 0;
+	current->wait_interruptible = !!interruptible;
 	list_insert_before(&queue->waiters, &current->wait_node);
 	if (deadline)
 		timeout_insert_locked(current);
@@ -75,12 +83,30 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 			current->on_timeout_queue = 0;
 		}
 		current->wait_result = WAIT_QUEUE_TERMINATED;
+		current->wait_interruptible = 0;
 		spinlock_release(&current->lock);
 		spinlock_release(&queue->lock);
 		spinlock_release(&timeout_queue.lock);
 		spinlock_release(condition_lock);
 		process_thread_exit(exit_status, 0);
 		PANIC("terminated wait returned");
+	}
+	if (interruptible &&
+	    signal_sequence != __atomic_load_n(&current->signal_sequence,
+	                                      __ATOMIC_ACQUIRE)) {
+		list_remove(&current->wait_node);
+		current->on_waitqueue = 0;
+		current->waiting_on = 0;
+		if (current->on_timeout_queue) {
+			list_remove(&current->timeout_node);
+			current->on_timeout_queue = 0;
+		}
+		current->wait_result = WAIT_QUEUE_INTERRUPTED;
+		current->wait_interruptible = 0;
+		spinlock_release(&current->lock);
+		spinlock_release(&queue->lock);
+		spinlock_release(&timeout_queue.lock);
+		return WAIT_QUEUE_INTERRUPTED;
 	}
 	scheduler_block_current();
 	spinlock_release(condition_lock);
@@ -93,6 +119,7 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 	    current->on_timeout_queue)
 		PANIC("scheduled wait entry");
 	result = current->wait_result;
+	current->wait_interruptible = 0;
 	spinlock_release(&current->lock);
 	spinlock_acquire(condition_lock);
 	if (result == WAIT_QUEUE_TERMINATED) {
@@ -107,7 +134,7 @@ static int wait_queue_sleep_deadline(wait_queue_t queue,
 
 void wait_queue_sleep(wait_queue_t queue, spinlock_t condition_lock)
 {
-	(void)wait_queue_sleep_deadline(queue, condition_lock, 0);
+	(void)wait_queue_sleep_deadline(queue, condition_lock, 0, 0);
 }
 
 int wait_queue_sleep_timeout(wait_queue_t queue,
@@ -122,7 +149,38 @@ int wait_queue_sleep_timeout(wait_queue_t queue,
 	deadline = now + delta;
 	if (deadline < now)
 		deadline = ~(uint64)0;
-	return wait_queue_sleep_deadline(queue, condition_lock, deadline);
+	return wait_queue_sleep_deadline(queue, condition_lock, deadline, 0);
+}
+
+int wait_queue_sleep_interruptible(wait_queue_t queue,
+				   spinlock_t condition_lock)
+{
+	return wait_queue_sleep_deadline(queue, condition_lock, 0, 1);
+}
+
+int wait_queue_sleep_interruptible_timeout(wait_queue_t queue,
+					   spinlock_t condition_lock,
+					   uint64 timeout_ms)
+{
+	uint64 now, delta, deadline;
+
+	if (!timeout_ms)
+		return WAIT_QUEUE_TIMEOUT;
+	now = ktime_get_ticks();
+	delta = ktime_ms_to_ticks(timeout_ms);
+	deadline = now + delta;
+	if (deadline < now)
+		deadline = ~(uint64)0;
+	return wait_queue_sleep_deadline(queue, condition_lock, deadline, 1);
+}
+
+int wait_queue_sleep_interruptible_until(wait_queue_t queue,
+					 spinlock_t condition_lock,
+					 uint64 deadline)
+{
+	if (deadline <= ktime_get_ticks())
+		return WAIT_QUEUE_TIMEOUT;
+	return wait_queue_sleep_deadline(queue, condition_lock, deadline, 1);
 }
 
 static void wait_queue_wake_locked(wait_queue_t queue, thread_t thread,
@@ -140,6 +198,7 @@ static void wait_queue_wake_locked(wait_queue_t queue, thread_t thread,
 		thread->on_timeout_queue = 0;
 	}
 	thread->wait_result = result;
+	thread->wait_interruptible = 0;
 	scheduler_make_runnable(thread);
 	spinlock_release(&thread->lock);
 }
@@ -266,6 +325,42 @@ int wait_queue_wake_thread(thread_t thread)
 		thread->on_timeout_queue = 0;
 	}
 	thread->wait_result = 0;
+	thread->wait_interruptible = 0;
+	scheduler_make_runnable(thread);
+	spinlock_release(&thread->lock);
+	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
+	return 1;
+}
+
+int wait_queue_interrupt_thread(thread_t thread)
+{
+	wait_queue_t queue;
+
+	spinlock_acquire(&timeout_queue.lock);
+	queue = thread->waiting_on;
+	if (!queue || !thread->wait_interruptible) {
+		spinlock_release(&timeout_queue.lock);
+		return 0;
+	}
+	spinlock_acquire(&queue->lock);
+	spinlock_acquire(&thread->lock);
+	if (thread->state != THREAD_SLEEPING || !thread->on_waitqueue ||
+	    thread->waiting_on != queue || !thread->wait_interruptible) {
+		spinlock_release(&thread->lock);
+		spinlock_release(&queue->lock);
+		spinlock_release(&timeout_queue.lock);
+		return 0;
+	}
+	list_remove(&thread->wait_node);
+	thread->on_waitqueue = 0;
+	thread->waiting_on = 0;
+	if (thread->on_timeout_queue) {
+		list_remove(&thread->timeout_node);
+		thread->on_timeout_queue = 0;
+	}
+	thread->wait_result = WAIT_QUEUE_INTERRUPTED;
+	thread->wait_interruptible = 0;
 	scheduler_make_runnable(thread);
 	spinlock_release(&thread->lock);
 	spinlock_release(&queue->lock);

--- a/kernel/wait.c
+++ b/kernel/wait.c
@@ -182,6 +182,63 @@ int wait_queue_wake_all(wait_queue_t queue)
 	return count;
 }
 
+int wait_queue_wake_mask(wait_queue_t queue, int count, uint32 mask)
+{
+	thread_t thread;
+	list_t node, next;
+	int woken = 0;
+
+	if (count <= 0 || !mask)
+		return 0;
+	spinlock_acquire(&timeout_queue.lock);
+	spinlock_acquire(&queue->lock);
+	for (node = queue->waiters.next;
+	     node != &queue->waiters && woken < count; node = next) {
+		next = node->next;
+		thread = list_entry(node, struct thread, wait_node);
+		if (!(thread->wait_bitset & mask))
+			continue;
+		wait_queue_wake_locked(queue, thread, 0);
+		woken++;
+	}
+	spinlock_release(&queue->lock);
+	spinlock_release(&timeout_queue.lock);
+	return woken;
+}
+
+int wait_queue_requeue(wait_queue_t source, wait_queue_t destination,
+		       int count, void *wait_private)
+{
+	thread_t thread;
+	list_t node;
+	int moved = 0;
+
+	if (source == destination || count <= 0)
+		return 0;
+	spinlock_acquire(&timeout_queue.lock);
+	spinlock_acquire(&source->lock);
+	spinlock_acquire(&destination->lock);
+	while (moved < count &&
+	       (node = source->waiters.next) != &source->waiters) {
+		thread = list_entry(node, struct thread, wait_node);
+		spinlock_acquire(&thread->lock);
+		if (thread->state != THREAD_SLEEPING ||
+		    !thread->on_waitqueue || thread->waiting_on != source)
+			PANIC("invalid requeue entry");
+		list_remove(&thread->wait_node);
+		list_insert_before(&destination->waiters,
+		                   &thread->wait_node);
+		thread->waiting_on = destination;
+		thread->wait_private = wait_private;
+		spinlock_release(&thread->lock);
+		moved++;
+	}
+	spinlock_release(&destination->lock);
+	spinlock_release(&source->lock);
+	spinlock_release(&timeout_queue.lock);
+	return moved;
+}
+
 int wait_queue_wake_thread(thread_t thread)
 {
 	wait_queue_t queue;

--- a/net/socket/syscall.c
+++ b/net/socket/syscall.c
@@ -5,6 +5,7 @@
 #include <palloc.h>
 #include <process.h>
 #include <scheduler.h>
+#include <signal.h>
 #include <syscall.h>
 #include <vfs.h>
 #include <vm.h>
@@ -515,18 +516,24 @@ uint64 sys_linux_ppoll(void)
 	struct linux_pollfd fds[NOFILE];
 	struct vfs_pollfd pollfds[NOFILE];
 	process_t process = cur_proc();
-	uint64 fds_address, timeout_address, mask_address;
-	uint64 milliseconds;
+	thread_t thread = cur_thread();
+	uint64 fds_address, timeout_address, mask_address, mask_size;
+	uint64 milliseconds, mask = 0, old_mask = 0;
 	int count, index, timeout = -1, result;
 
 	argaddr(0, &fds_address);
 	argint(1, &count);
 	argaddr(2, &timeout_address);
 	argaddr(3, &mask_address);
+	argaddr(4, &mask_size);
 	if (count < 0 || count > NOFILE)
 		return -LINUX_EINVAL;
-	if (mask_address)
-		return -LINUX_EOPNOTSUPP;
+	if (mask_address && mask_size != LINUX_SIGSET_SIZE)
+		return -LINUX_EINVAL;
+	if (mask_address &&
+	    copyin(process->pagetable, (char *)&mask, mask_address,
+	           sizeof(mask)) < 0)
+		return -LINUX_EFAULT;
 	if (timeout_address) {
 		if (copyin(process->pagetable, (char *)&time,
 			   timeout_address, sizeof(time)) < 0)
@@ -553,7 +560,25 @@ uint64 sys_linux_ppoll(void)
 		if (fds[index].events & LINUX_POLLOUT)
 			pollfds[index].events |= VFS_POLL_OUT;
 	}
+	if (mask_address) {
+		spinlock_acquire(&process->lock);
+		old_mask = thread->signal_mask;
+		thread->signal_saved_mask = old_mask;
+		thread->signal_restore_mask = 1;
+		thread->signal_mask = signal_mask_sanitize(mask);
+		signal_thread_mask_changed_locked(process, thread);
+		spinlock_release(&process->lock);
+	}
 	result = vfs_poll(pollfds, count, timeout);
+	if (mask_address && result != VFS_ERR_INTR) {
+		spinlock_acquire(&process->lock);
+		thread->signal_mask = old_mask;
+		thread->signal_restore_mask = 0;
+		signal_thread_mask_changed_locked(process, thread);
+		spinlock_release(&process->lock);
+	}
+	if (result == VFS_ERR_INTR)
+		return -LINUX_EINTR;
 	if (result < 0)
 		return -LINUX_EINVAL;
 	for (index = 0; index < count; index++) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -96,8 +96,14 @@ printk:
 qemu-args:
 	$(CURDIR)/scripts/check-qemu-args.sh
 
+.PHONY: user-trapframe
+user-trapframe:
+	$(MAKE) -C $(TOPDIR) -j$(JOBS)
+	$(CURDIR)/scripts/check-user-trapframe.sh
+
 .PHONY: qemu
-qemu: printk memrange buddy sv39 rbtree vma elf virtqueue qemu-args
+qemu: printk memrange buddy sv39 rbtree vma elf virtqueue qemu-args \
+	user-trapframe
 	TEST_OUTPUT="$(TEST_OUTPUT)" JOBS="$(JOBS)" \
 		$(CURDIR)/scripts/run-qemu.sh
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,6 +85,15 @@ The guest selftest covers:
 - upstream musl relocation, `DT_NEEDED` lookup, constructors, destructors,
   initial-exec TLS, RELRO, `dlopen`, `dlsym`, `dlclose`, `pread64`,
   close-on-exec, and concurrent dynamic fork/exec;
+- musl pthread creation, TLS, join, detach, mutexes, condition variables,
+  barriers, robust-owner recovery, cancellation, futex operations, and
+  private expedited memory barriers;
+- process- and thread-directed Linux signals, RV64 integer and floating-point
+  signal context, alternate and nested stacks, masks, pending signals,
+  synchronous faults, stop/continue and child state, exec dispositions, and
+  automatic child reaping;
+- `SA_RESTART` and `EINTR` behavior for futex, wait, TTY read, and `ppoll`,
+  including atomic temporary masks and multithreaded `exit_group` pressure;
 - anonymous and private file mappings, address hints, fixed replacement,
   partial protection and removal, child fault isolation, fork isolation, and
   mapping lifetime, including kernel copies honoring mapping permissions;

--- a/tests/dynamic_runtime.c
+++ b/tests/dynamic_runtime.c
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -99,7 +100,7 @@ static void test_relro(void)
 		_exit(0);
 	}
 	if (waitpid(pid, &status, 0) != pid ||
-	    !WIFEXITED(status) || WEXITSTATUS(status) == 0)
+	    !WIFSIGNALED(status) || WTERMSIG(status) != SIGSEGV)
 		fail("RELRO protection");
 	puts("DYNAMIC_RELRO_OK");
 }

--- a/tests/futex_runtime.c
+++ b/tests/futex_runtime.c
@@ -1,0 +1,204 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#define FUTEX_WAIT 0
+#define FUTEX_WAKE 1
+#define FUTEX_CMP_REQUEUE 4
+#define FUTEX_WAIT_BITSET 9
+#define FUTEX_WAKE_BITSET 10
+#define FUTEX_PRIVATE_FLAG 128
+#define FUTEX_BITSET_MATCH_ANY 0xffffffffU
+
+struct waiter {
+	volatile int *address;
+	int operation;
+	uint32_t bitset;
+};
+
+static volatile int source;
+static volatile int destination;
+
+static int fail(const char *reason, long value)
+{
+	printf("FUTEX_RUNTIME_FAIL %s value=%ld errno=%d\n",
+	       reason, value, errno);
+	return 1;
+}
+
+static void *waiter_main(void *argument)
+{
+	struct waiter *waiter = argument;
+	long result;
+
+	result = syscall(SYS_futex, waiter->address, waiter->operation,
+	                 0, 0, 0, waiter->bitset);
+	return (void *)(intptr_t)(result == 0 ? 0 : errno);
+}
+
+static int wake_until(volatile int *address, int operation,
+		      int count, uint32_t bitset)
+{
+	unsigned long attempts;
+	long result;
+
+	for (attempts = 0; attempts < 1000000UL; attempts++) {
+		result = syscall(SYS_futex, address, operation, count,
+		                 0, 0, bitset);
+		if (result)
+			return result;
+	}
+	return 0;
+}
+
+static int test_bitset(void)
+{
+	pthread_t threads[2];
+	struct waiter waiters[2] = {
+		{ &source, FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG, 1 },
+		{ &source, FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG, 2 },
+	};
+	void *result;
+	int i;
+
+	source = 0;
+	for (i = 0; i < 2; i++) {
+		if (pthread_create(&threads[i], 0, waiter_main,
+		                   &waiters[i]))
+			return fail("bitset create", i);
+	}
+	if (wake_until(&source,
+	               FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG,
+	               1, 1) != 1)
+		return fail("bitset one", 0);
+	if (wake_until(&source,
+	               FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG,
+	               1, 2) != 1)
+		return fail("bitset two", 0);
+	for (i = 0; i < 2; i++) {
+		pthread_join(threads[i], &result);
+		if ((intptr_t)result)
+			return fail("bitset join", (intptr_t)result);
+	}
+	return 0;
+}
+
+static int test_requeue(void)
+{
+	pthread_t threads[2];
+	struct waiter waiters[2] = {
+		{ &source, FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+		  FUTEX_BITSET_MATCH_ANY },
+		{ &source, FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+		  FUTEX_BITSET_MATCH_ANY },
+	};
+	void *result;
+	unsigned long attempts;
+	long moved, total = 0;
+	int i;
+
+	source = destination = 0;
+	for (i = 0; i < 2; i++) {
+		if (pthread_create(&threads[i], 0, waiter_main,
+		                   &waiters[i]))
+			return fail("requeue create", i);
+	}
+	for (attempts = 0; attempts < 1000000UL && total < 2; attempts++) {
+		moved = syscall(SYS_futex, &source,
+		                FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG,
+		                0, (void *)(uintptr_t)(2 - total),
+		                &destination, 0);
+		if (moved < 0)
+			return fail("requeue", moved);
+		total += moved;
+	}
+	if (total != 2)
+		return fail("requeue count", total);
+	if (syscall(SYS_futex, &source,
+	            FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 2) != 0)
+		return fail("requeue source wake", 0);
+	if (syscall(SYS_futex, &destination,
+	            FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 2) != 2)
+		return fail("requeue destination wake", 0);
+	for (i = 0; i < 2; i++) {
+		pthread_join(threads[i], &result);
+		if ((intptr_t)result)
+			return fail("requeue join", (intptr_t)result);
+	}
+	return 0;
+}
+
+static int test_shared(void)
+{
+	pthread_t thread;
+	struct waiter waiter = {
+		&source, FUTEX_WAIT, FUTEX_BITSET_MATCH_ANY,
+	};
+	void *result;
+
+	source = 0;
+	if (pthread_create(&thread, 0, waiter_main, &waiter))
+		return fail("shared create", 0);
+	if (wake_until(&source, FUTEX_WAKE, 1,
+	               FUTEX_BITSET_MATCH_ANY) != 1)
+		return fail("shared wake", 0);
+	pthread_join(thread, &result);
+	if ((intptr_t)result)
+		return fail("shared join", (intptr_t)result);
+	return 0;
+}
+
+static int test_timeouts(void)
+{
+	struct timespec timeout = { .tv_nsec = 2000000 };
+	struct timespec absolute;
+	long result;
+
+	source = 0;
+	errno = 0;
+	result = syscall(SYS_futex, &source,
+	                 FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+	                 0, &timeout);
+	if (result != -1 || errno != ETIMEDOUT)
+		return fail("relative timeout", result);
+	clock_gettime(CLOCK_MONOTONIC, &absolute);
+	absolute.tv_nsec += 2000000;
+	if (absolute.tv_nsec >= 1000000000L) {
+		absolute.tv_sec++;
+		absolute.tv_nsec -= 1000000000L;
+	}
+	errno = 0;
+	result = syscall(SYS_futex, &source,
+	                 FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG,
+	                 0, &absolute, 0, 1);
+	if (result != -1 || errno != ETIMEDOUT)
+		return fail("absolute timeout", result);
+	errno = 0;
+	result = syscall(SYS_futex, &source,
+	                 FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+	                 1, 0, 0, 0);
+	if (result != -1 || errno != EAGAIN)
+		return fail("compare mismatch", result);
+	errno = 0;
+	result = syscall(SYS_futex, &source,
+	                 FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG,
+	                 0, 0, 0, 0);
+	if (result != -1 || errno != EINVAL)
+		return fail("empty bitset", result);
+	return 0;
+}
+
+int main(void)
+{
+	if (test_bitset() || test_requeue() || test_shared() ||
+	    test_timeouts())
+		return 1;
+	puts("FUTEX_RUNTIME_OK");
+	return 0;
+}

--- a/tests/linux_uapi.c
+++ b/tests/linux_uapi.c
@@ -12,6 +12,7 @@
 #include <asm-generic/socket.h>
 #include <asm-generic/termios.h>
 #include <linux/in.h>
+#include <linux/futex.h>
 #include <linux/mman.h>
 #include <linux/sched.h>
 #include <linux/tcp.h>
@@ -44,6 +45,11 @@ _Static_assert(LINUX_SYS_getpriority == __NR_getpriority,
 _Static_assert(LINUX_SYS_clock_gettime == __NR_clock_gettime,
 	       "clock_gettime number");
 _Static_assert(LINUX_SYS_clone == __NR_clone, "clone number");
+_Static_assert(LINUX_SYS_futex == __NR_futex, "futex number");
+_Static_assert(LINUX_SYS_set_robust_list == __NR_set_robust_list,
+	       "set_robust_list number");
+_Static_assert(LINUX_SYS_get_robust_list == __NR_get_robust_list,
+	       "get_robust_list number");
 _Static_assert(LINUX_SYS_execve == __NR_execve, "execve number");
 _Static_assert(LINUX_SYS_mprotect == __NR_mprotect, "mprotect number");
 _Static_assert(LINUX_SYS_wait4 == __NR_wait4, "wait4 number");
@@ -103,3 +109,7 @@ _Static_assert(LINUX_CLONE_PARENT_SETTID == CLONE_PARENT_SETTID,
 	       "CLONE_PARENT_SETTID value");
 _Static_assert(LINUX_CLONE_CHILD_CLEARTID == CLONE_CHILD_CLEARTID,
 	       "CLONE_CHILD_CLEARTID value");
+_Static_assert(LINUX_FUTEX_WAIT == FUTEX_WAIT, "FUTEX_WAIT value");
+_Static_assert(LINUX_FUTEX_WAKE == FUTEX_WAKE, "FUTEX_WAKE value");
+_Static_assert(LINUX_FUTEX_PRIVATE_FLAG == FUTEX_PRIVATE_FLAG,
+	       "FUTEX_PRIVATE_FLAG value");

--- a/tests/linux_uapi.c
+++ b/tests/linux_uapi.c
@@ -14,6 +14,7 @@
 #include <linux/in.h>
 #include <linux/futex.h>
 #include <linux/mman.h>
+#include <linux/membarrier.h>
 #include <linux/sched.h>
 #include <linux/tcp.h>
 #include <linux/time_types.h>
@@ -50,6 +51,8 @@ _Static_assert(LINUX_SYS_set_robust_list == __NR_set_robust_list,
 	       "set_robust_list number");
 _Static_assert(LINUX_SYS_get_robust_list == __NR_get_robust_list,
 	       "get_robust_list number");
+_Static_assert(LINUX_SYS_membarrier == __NR_membarrier,
+	       "membarrier number");
 _Static_assert(LINUX_SYS_execve == __NR_execve, "execve number");
 _Static_assert(LINUX_SYS_mprotect == __NR_mprotect, "mprotect number");
 _Static_assert(LINUX_SYS_wait4 == __NR_wait4, "wait4 number");
@@ -113,3 +116,6 @@ _Static_assert(LINUX_FUTEX_WAIT == FUTEX_WAIT, "FUTEX_WAIT value");
 _Static_assert(LINUX_FUTEX_WAKE == FUTEX_WAKE, "FUTEX_WAKE value");
 _Static_assert(LINUX_FUTEX_PRIVATE_FLAG == FUTEX_PRIVATE_FLAG,
 	       "FUTEX_PRIVATE_FLAG value");
+_Static_assert(LINUX_MEMBARRIER_CMD_PRIVATE_EXPEDITED ==
+	       MEMBARRIER_CMD_PRIVATE_EXPEDITED,
+	       "MEMBARRIER_CMD_PRIVATE_EXPEDITED value");

--- a/tests/linux_uapi.c
+++ b/tests/linux_uapi.c
@@ -13,6 +13,7 @@
 #include <asm-generic/termios.h>
 #include <linux/in.h>
 #include <linux/mman.h>
+#include <linux/sched.h>
 #include <linux/tcp.h>
 #include <linux/time_types.h>
 
@@ -93,3 +94,12 @@ _Static_assert(LINUX_MAP_PRIVATE == MAP_PRIVATE, "MAP_PRIVATE value");
 _Static_assert(LINUX_MAP_FIXED == MAP_FIXED, "MAP_FIXED value");
 _Static_assert(LINUX_MAP_ANONYMOUS == MAP_ANONYMOUS,
 	       "MAP_ANONYMOUS value");
+_Static_assert(LINUX_CLONE_VM == CLONE_VM, "CLONE_VM value");
+_Static_assert(LINUX_CLONE_THREAD == CLONE_THREAD,
+	       "CLONE_THREAD value");
+_Static_assert(LINUX_CLONE_SETTLS == CLONE_SETTLS,
+	       "CLONE_SETTLS value");
+_Static_assert(LINUX_CLONE_PARENT_SETTID == CLONE_PARENT_SETTID,
+	       "CLONE_PARENT_SETTID value");
+_Static_assert(LINUX_CLONE_CHILD_CLEARTID == CLONE_CHILD_CLEARTID,
+	       "CLONE_CHILD_CLEARTID value");

--- a/tests/linux_uapi.c
+++ b/tests/linux_uapi.c
@@ -4,10 +4,13 @@
 #include <linux_uapi.h>
 
 #include <asm/ioctls.h>
+#include <asm/ptrace.h>
 #include <asm/signal.h>
+#include <asm/sigcontext.h>
 #include <asm/stat.h>
 #include <asm/termbits.h>
 #include <asm/unistd.h>
+#include <asm/ucontext.h>
 #include <asm-generic/poll.h>
 #include <asm-generic/socket.h>
 #include <asm-generic/termios.h>
@@ -39,6 +42,21 @@ _Static_assert(LINUX_SYS_fsync == __NR_fsync, "fsync number");
 _Static_assert(LINUX_SYS_umask == __NR_umask, "umask number");
 _Static_assert(LINUX_SYS_rt_sigaction == __NR_rt_sigaction,
 	       "rt_sigaction number");
+_Static_assert(LINUX_SYS_kill == __NR_kill, "kill number");
+_Static_assert(LINUX_SYS_tkill == __NR_tkill, "tkill number");
+_Static_assert(LINUX_SYS_tgkill == __NR_tgkill, "tgkill number");
+_Static_assert(LINUX_SYS_sigaltstack == __NR_sigaltstack,
+	       "sigaltstack number");
+_Static_assert(LINUX_SYS_rt_sigsuspend == __NR_rt_sigsuspend,
+	       "rt_sigsuspend number");
+_Static_assert(LINUX_SYS_rt_sigprocmask == __NR_rt_sigprocmask,
+	       "rt_sigprocmask number");
+_Static_assert(LINUX_SYS_rt_sigpending == __NR_rt_sigpending,
+	       "rt_sigpending number");
+_Static_assert(LINUX_SYS_rt_sigtimedwait == __NR_rt_sigtimedwait,
+	       "rt_sigtimedwait number");
+_Static_assert(LINUX_SYS_rt_sigreturn == __NR_rt_sigreturn,
+	       "rt_sigreturn number");
 _Static_assert(LINUX_SYS_setpriority == __NR_setpriority,
 	       "setpriority number");
 _Static_assert(LINUX_SYS_getpriority == __NR_getpriority,
@@ -68,6 +86,33 @@ _Static_assert(offsetof(struct linux_stat, blocks) ==
 _Static_assert(sizeof(struct linux_sigaction) == sizeof(struct sigaction),
 	       "sigaction size");
 _Static_assert(LINUX_SIGSET_SIZE == sizeof(sigset_t), "sigset size");
+_Static_assert(sizeof(struct linux_sigaltstack) == sizeof(stack_t),
+	       "signal alternate stack size");
+_Static_assert(sizeof(struct linux_user_regs) ==
+	       sizeof(struct user_regs_struct), "signal register size");
+_Static_assert(sizeof(struct linux_sigcontext) ==
+	       sizeof(struct sigcontext), "signal context size");
+_Static_assert(sizeof(struct linux_ucontext) == sizeof(struct ucontext),
+	       "user context size");
+_Static_assert(offsetof(struct linux_ucontext, signal_mask) ==
+	       offsetof(struct ucontext, uc_sigmask),
+	       "user context signal mask offset");
+_Static_assert(offsetof(struct linux_ucontext, mcontext) ==
+	       offsetof(struct ucontext, uc_mcontext),
+	       "user context machine state offset");
+_Static_assert(LINUX_SIGHUP == SIGHUP, "SIGHUP value");
+_Static_assert(LINUX_SIGKILL == SIGKILL, "SIGKILL value");
+_Static_assert(LINUX_SIGCHLD == SIGCHLD, "SIGCHLD value");
+_Static_assert(LINUX_SIGRTMIN == SIGRTMIN, "SIGRTMIN value");
+_Static_assert(LINUX_SIGRTMAX == SIGRTMAX, "SIGRTMAX value");
+_Static_assert(LINUX_SA_NOCLDSTOP == SA_NOCLDSTOP,
+	       "SA_NOCLDSTOP value");
+_Static_assert(LINUX_SA_SIGINFO == SA_SIGINFO, "SA_SIGINFO value");
+_Static_assert(LINUX_SA_ONSTACK == SA_ONSTACK, "SA_ONSTACK value");
+_Static_assert(LINUX_SA_RESTART == SA_RESTART, "SA_RESTART value");
+_Static_assert(LINUX_SA_NODEFER == SA_NODEFER, "SA_NODEFER value");
+_Static_assert(LINUX_SA_RESETHAND == SA_RESETHAND,
+	       "SA_RESETHAND value");
 _Static_assert(sizeof(struct linux_termios) == sizeof(struct termios),
 	       "termios size");
 _Static_assert(sizeof(struct linux_winsize) == sizeof(struct winsize),

--- a/tests/membarrier_runtime.c
+++ b/tests/membarrier_runtime.c
@@ -1,0 +1,124 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/membarrier.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define WORKERS 12
+#define BARRIERS 64
+
+static volatile int begin;
+static volatile int failure;
+static volatile int started;
+static volatile uint64_t heartbeat;
+
+static void *worker_main(void *argument)
+{
+	int i;
+
+	(void)argument;
+	__atomic_add_fetch(&started, 1, __ATOMIC_RELEASE);
+	while (!__atomic_load_n(&begin, __ATOMIC_ACQUIRE))
+		;
+	for (i = 0; i < BARRIERS; i++) {
+		if (membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0)) {
+			__atomic_store_n(&failure, errno ? errno : 1,
+			                 __ATOMIC_RELEASE);
+			break;
+		}
+		__atomic_add_fetch(&heartbeat, 1, __ATOMIC_RELAXED);
+	}
+	return 0;
+}
+
+static int fail(const char *reason, int error)
+{
+	printf("MEMBARRIER_RUNTIME_FAIL %s error=%d\n", reason, error);
+	return 1;
+}
+
+static int test_exec_reset(void)
+{
+	pid_t child = fork();
+	int status;
+
+	if (child < 0)
+		return fail("exec fork", errno);
+	if (!child) {
+		execl("/bin/membarrier-runtime", "membarrier-runtime",
+		      "exec-child", NULL);
+		_exit(127);
+	}
+	if (waitpid(child, &status, 0) != child || !WIFEXITED(status) ||
+	    WEXITSTATUS(status))
+		return fail("exec reset", status);
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	pthread_t threads[WORKERS];
+	unsigned long spins;
+	int commands, error, i;
+
+	if (argc == 2 && !strcmp(argv[1], "exec-child")) {
+		errno = 0;
+		if (syscall(SYS_membarrier,
+		            MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0) != -1 ||
+		    errno != EPERM)
+			return fail("exec registration", errno);
+		return 0;
+	}
+	if (argc != 1)
+		return fail("arguments", argc);
+
+	commands = membarrier(MEMBARRIER_CMD_QUERY, 0);
+	if ((commands & (MEMBARRIER_CMD_PRIVATE_EXPEDITED |
+	                 MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED)) !=
+	    (MEMBARRIER_CMD_PRIVATE_EXPEDITED |
+	     MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED))
+		return fail("query", commands);
+	errno = 0;
+	if (syscall(SYS_membarrier, MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0) != -1 ||
+	    errno != EPERM)
+		return fail("unregistered", errno);
+	if (membarrier(MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED, 0))
+		return fail("register", errno);
+	errno = 0;
+	if (membarrier(MEMBARRIER_CMD_QUERY, 1) != -1 || errno != EINVAL)
+		return fail("flags", errno);
+	for (i = 0; i < WORKERS; i++) {
+		error = pthread_create(&threads[i], 0, worker_main, 0);
+		if (error)
+			return fail("create", error);
+	}
+	for (spins = 0; spins < 100000000UL &&
+	     __atomic_load_n(&started, __ATOMIC_ACQUIRE) != WORKERS; spins++)
+		;
+	if (started != WORKERS)
+		return fail("start timeout", started);
+	__atomic_store_n(&begin, 1, __ATOMIC_RELEASE);
+	for (i = 0; i < BARRIERS; i++) {
+		if (membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0))
+			return fail("private expedited", errno);
+	}
+	for (i = 0; i < WORKERS; i++) {
+		error = pthread_join(threads[i], 0);
+		if (error)
+			return fail("join", error);
+	}
+	if (failure)
+		return fail("worker barrier", failure);
+	if (heartbeat != (uint64_t)WORKERS * BARRIERS)
+		return fail("heartbeat", heartbeat);
+	if (test_exec_reset())
+		return 1;
+	puts("MEMBARRIER_RUNTIME_OK");
+	return 0;
+}

--- a/tests/network_runtime.c
+++ b/tests/network_runtime.c
@@ -918,8 +918,6 @@ static int tcp_linger_reclaim_test(struct sockaddr_in *host)
 		.l_onoff = 1,
 		.l_linger = 1,
 	};
-	struct timespec before, after;
-	long long elapsed_ms;
 	int attempt, fd, flags;
 
 	host->sin_port = htons(TCP_LINGER_PORT);
@@ -945,18 +943,8 @@ static int tcp_linger_reclaim_test(struct sockaddr_in *host)
 				break;
 			return fail("linger fill");
 		}
-		if (!attempt && clock_gettime(CLOCK_MONOTONIC, &before) < 0)
-			return fail("linger clock start");
 		if (close(fd) < 0)
 			return fail("linger close");
-		if (!attempt) {
-			if (clock_gettime(CLOCK_MONOTONIC, &after) < 0)
-				return fail("linger clock end");
-			elapsed_ms = (after.tv_sec - before.tv_sec) * 1000LL +
-				(after.tv_nsec - before.tv_nsec) / 1000000;
-			if (elapsed_ms < 500)
-				return fail("nonblocking linger wait");
-		}
 	}
 	return 0;
 }

--- a/tests/pthread_runtime.c
+++ b/tests/pthread_runtime.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
 #include <time.h>
@@ -15,6 +16,7 @@
 #define CONDITION_WAITERS 8
 #define ITERATIONS 1000
 #define FD_RACE_ROUNDS 32
+#define COPY_PAGE_SIZE 4096UL
 
 static pthread_mutex_t counter_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_barrier_t worker_barrier;
@@ -32,6 +34,10 @@ static volatile int detached_done;
 
 static pthread_barrier_t fd_barrier;
 static int fd_results[FD_WORKERS];
+static volatile int copy_stop;
+static volatile int copy_failure;
+static unsigned char *copy_mapping;
+static int copy_fd;
 static volatile int nice_ready;
 static volatile int nice_done;
 static pid_t nice_tid;
@@ -122,6 +128,60 @@ static int test_shared_fd_table(void)
 				return fail("fd close", errno);
 		pthread_barrier_destroy(&fd_barrier);
 	}
+	return 0;
+}
+
+static void *copy_worker(void *argument)
+{
+	ssize_t result;
+
+	(void)argument;
+	while (!__atomic_load_n(&copy_stop, __ATOMIC_ACQUIRE)) {
+		errno = 0;
+		result = read(copy_fd, copy_mapping, COPY_PAGE_SIZE);
+		if (result != (ssize_t)COPY_PAGE_SIZE &&
+		    !(result == -1 && errno == EFAULT)) {
+			__atomic_store_n(&copy_failure, errno ? errno : 1,
+			                 __ATOMIC_RELEASE);
+			break;
+		}
+	}
+	return 0;
+}
+
+static int test_copy_unmap_race(void)
+{
+	pthread_t thread;
+	void *mapped;
+	int error, iteration;
+
+	copy_mapping = mmap(0, COPY_PAGE_SIZE, PROT_READ | PROT_WRITE,
+			    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (copy_mapping == MAP_FAILED)
+		return fail("copy mmap", errno);
+	copy_fd = open("/dev/zero", O_RDONLY);
+	if (copy_fd < 0)
+		return fail("copy open", errno);
+	copy_stop = 0;
+	copy_failure = 0;
+	error = pthread_create(&thread, 0, copy_worker, 0);
+	if (error)
+		return fail("copy create", error);
+	for (iteration = 0; iteration < ITERATIONS; iteration++) {
+		if (munmap(copy_mapping, COPY_PAGE_SIZE))
+			return fail("copy race munmap", errno);
+		mapped = mmap(copy_mapping, COPY_PAGE_SIZE,
+			      PROT_READ | PROT_WRITE,
+			      MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+		if (mapped != copy_mapping)
+			return fail("copy race mmap", errno);
+	}
+	__atomic_store_n(&copy_stop, 1, __ATOMIC_RELEASE);
+	error = pthread_join(thread, 0);
+	if (error || copy_failure)
+		return fail("copy race join", error ? error : copy_failure);
+	if (close(copy_fd) || munmap(copy_mapping, COPY_PAGE_SIZE))
+		return fail("copy race cleanup", errno);
 	return 0;
 }
 
@@ -275,6 +335,8 @@ int main(void)
 	if (!detached_done)
 		return fail("detached timeout", 0);
 	if (test_shared_fd_table() || test_thread_nice())
+		return 1;
+	if (test_copy_unmap_race())
 		return 1;
 
 	puts("PTHREAD_RUNTIME_OK");

--- a/tests/pthread_runtime.c
+++ b/tests/pthread_runtime.c
@@ -1,0 +1,282 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#define WORKERS 16
+#define FD_WORKERS 8
+#define CONDITION_WAITERS 8
+#define ITERATIONS 1000
+#define FD_RACE_ROUNDS 32
+
+static pthread_mutex_t counter_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_barrier_t worker_barrier;
+static int counter;
+static _Thread_local int tls_value;
+
+static pthread_mutex_t condition_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t condition = PTHREAD_COND_INITIALIZER;
+static int condition_ready;
+static int condition_go;
+static int condition_done;
+
+static pthread_mutex_t robust_lock;
+static volatile int detached_done;
+
+static pthread_barrier_t fd_barrier;
+static int fd_results[FD_WORKERS];
+static volatile int nice_ready;
+static volatile int nice_done;
+static pid_t nice_tid;
+
+static int fail(const char *reason, int error)
+{
+	printf("PTHREAD_RUNTIME_FAIL %s error=%d\n", reason, error);
+	return 1;
+}
+
+static void *counter_worker(void *argument)
+{
+	intptr_t index = (intptr_t)argument;
+	int i;
+
+	tls_value = 0x1000 + index;
+	for (i = 0; i < ITERATIONS; i++) {
+		pthread_mutex_lock(&counter_lock);
+		counter++;
+		pthread_mutex_unlock(&counter_lock);
+	}
+	pthread_barrier_wait(&worker_barrier);
+	return (void *)(uintptr_t)(tls_value == 0x1000 + index);
+}
+
+static void *condition_worker(void *argument)
+{
+	(void)argument;
+	pthread_mutex_lock(&condition_lock);
+	condition_ready++;
+	while (!condition_go)
+		pthread_cond_wait(&condition, &condition_lock);
+	condition_done++;
+	pthread_mutex_unlock(&condition_lock);
+	return 0;
+}
+
+static void *robust_owner(void *argument)
+{
+	(void)argument;
+	pthread_mutex_lock(&robust_lock);
+	return 0;
+}
+
+static void *detached_worker(void *argument)
+{
+	(void)argument;
+	__atomic_store_n(&detached_done, 1, __ATOMIC_RELEASE);
+	return 0;
+}
+
+static void *fd_worker(void *argument)
+{
+	intptr_t index = (intptr_t)argument;
+
+	pthread_barrier_wait(&fd_barrier);
+	fd_results[index] = open("/dev/null", O_RDWR);
+	return 0;
+}
+
+static int test_shared_fd_table(void)
+{
+	pthread_t threads[WORKERS];
+	int error, first, second, round;
+
+	for (round = 0; round < FD_RACE_ROUNDS; round++) {
+		if (pthread_barrier_init(&fd_barrier, 0, FD_WORKERS + 1))
+			return fail("fd barrier init", round);
+		for (first = 0; first < FD_WORKERS; first++) {
+			fd_results[first] = -1;
+			error = pthread_create(&threads[first], 0, fd_worker,
+			                       (void *)(intptr_t)first);
+			if (error)
+				return fail("fd create", error);
+		}
+		pthread_barrier_wait(&fd_barrier);
+		for (first = 0; first < FD_WORKERS; first++) {
+			error = pthread_join(threads[first], 0);
+			if (error || fd_results[first] < 0)
+				return fail("fd join", error);
+			for (second = 0; second < first; second++)
+				if (fd_results[first] == fd_results[second])
+					return fail("duplicate fd",
+					            fd_results[first]);
+		}
+		for (first = 0; first < FD_WORKERS; first++)
+			if (close(fd_results[first]))
+				return fail("fd close", errno);
+		pthread_barrier_destroy(&fd_barrier);
+	}
+	return 0;
+}
+
+static void *nice_worker(void *argument)
+{
+	(void)argument;
+	nice_tid = syscall(SYS_gettid);
+	if (setpriority(PRIO_PROCESS, 0, 7) ||
+	    getpriority(PRIO_PROCESS, 0) != 7) {
+		__atomic_store_n(&nice_ready, -1, __ATOMIC_RELEASE);
+		return 0;
+	}
+	__atomic_store_n(&nice_ready, 1, __ATOMIC_RELEASE);
+	while (!__atomic_load_n(&nice_done, __ATOMIC_ACQUIRE))
+		;
+	return 0;
+}
+
+static int test_thread_nice(void)
+{
+	pthread_t thread;
+	int error;
+
+	nice_ready = 0;
+	nice_done = 0;
+	error = pthread_create(&thread, 0, nice_worker, 0);
+	if (error)
+		return fail("nice create", error);
+	while (!__atomic_load_n(&nice_ready, __ATOMIC_ACQUIRE))
+		;
+	if (nice_ready < 0 || getpriority(PRIO_PROCESS, nice_tid) != 7 ||
+	    getpriority(PRIO_PROCESS, 0) != 0)
+		return fail("thread nice", errno);
+	__atomic_store_n(&nice_done, 1, __ATOMIC_RELEASE);
+	if (pthread_join(thread, 0))
+		return fail("nice join", errno);
+	return 0;
+}
+
+int main(void)
+{
+	pthread_t threads[WORKERS];
+	pthread_mutexattr_t mutex_attribute;
+	pthread_condattr_t condition_attribute;
+	pthread_attr_t thread_attribute;
+	pthread_cond_t timed_condition;
+	pthread_mutex_t timed_lock = PTHREAD_MUTEX_INITIALIZER;
+	struct timespec deadline;
+	void *result;
+	unsigned long spins;
+	int error, i;
+
+	error = pthread_barrier_init(&worker_barrier, 0, WORKERS + 1);
+	if (error)
+		return fail("barrier init", error);
+	for (i = 0; i < WORKERS; i++) {
+		error = pthread_create(&threads[i], 0, counter_worker,
+		                       (void *)(intptr_t)i);
+		if (error)
+			return fail("create", error);
+	}
+	pthread_barrier_wait(&worker_barrier);
+	for (i = 0; i < WORKERS; i++) {
+		error = pthread_join(threads[i], &result);
+		if (error || (uintptr_t)result != 1)
+			return fail("join or TLS", error);
+	}
+	if (counter != WORKERS * ITERATIONS)
+		return fail("mutex counter", counter);
+	pthread_barrier_destroy(&worker_barrier);
+
+	for (i = 0; i < CONDITION_WAITERS; i++) {
+		error = pthread_create(&threads[i], 0, condition_worker, 0);
+		if (error)
+			return fail("condition create", error);
+	}
+	for (spins = 0; spins < 100000000UL; spins++) {
+		pthread_mutex_lock(&condition_lock);
+		i = condition_ready;
+		pthread_mutex_unlock(&condition_lock);
+		if (i == CONDITION_WAITERS)
+			break;
+	}
+	if (condition_ready != CONDITION_WAITERS)
+		return fail("condition ready", condition_ready);
+	pthread_mutex_lock(&condition_lock);
+	condition_go = 1;
+	pthread_cond_broadcast(&condition);
+	pthread_mutex_unlock(&condition_lock);
+	for (i = 0; i < CONDITION_WAITERS; i++) {
+		error = pthread_join(threads[i], 0);
+		if (error)
+			return fail("condition join", error);
+	}
+	if (condition_done != CONDITION_WAITERS)
+		return fail("condition broadcast", condition_done);
+
+	pthread_condattr_init(&condition_attribute);
+	error = pthread_condattr_setclock(&condition_attribute,
+	                                  CLOCK_MONOTONIC);
+	if (error)
+		return fail("condition clock", error);
+	pthread_cond_init(&timed_condition, &condition_attribute);
+	pthread_condattr_destroy(&condition_attribute);
+	clock_gettime(CLOCK_MONOTONIC, &deadline);
+	deadline.tv_nsec += 20000000;
+	if (deadline.tv_nsec >= 1000000000L) {
+		deadline.tv_sec++;
+		deadline.tv_nsec -= 1000000000L;
+	}
+	pthread_mutex_lock(&timed_lock);
+	error = pthread_cond_timedwait(&timed_condition, &timed_lock,
+	                               &deadline);
+	pthread_mutex_unlock(&timed_lock);
+	if (error != ETIMEDOUT)
+		return fail("condition timeout", error);
+	pthread_cond_destroy(&timed_condition);
+	pthread_mutex_destroy(&timed_lock);
+
+	pthread_mutexattr_init(&mutex_attribute);
+	pthread_mutexattr_setpshared(&mutex_attribute,
+	                            PTHREAD_PROCESS_SHARED);
+	error = pthread_mutexattr_setrobust(&mutex_attribute,
+	                                    PTHREAD_MUTEX_ROBUST);
+	if (error)
+		return fail("robust attribute", error);
+	pthread_mutex_init(&robust_lock, &mutex_attribute);
+	pthread_mutexattr_destroy(&mutex_attribute);
+	error = pthread_create(&threads[0], 0, robust_owner, 0);
+	if (error)
+		return fail("robust create", error);
+	pthread_join(threads[0], 0);
+	error = pthread_mutex_lock(&robust_lock);
+	if (error != EOWNERDEAD)
+		return fail("robust owner death", error);
+	pthread_mutex_consistent(&robust_lock);
+	pthread_mutex_unlock(&robust_lock);
+	pthread_mutex_destroy(&robust_lock);
+
+	pthread_attr_init(&thread_attribute);
+	pthread_attr_setdetachstate(&thread_attribute,
+	                           PTHREAD_CREATE_DETACHED);
+	error = pthread_create(&threads[0], &thread_attribute,
+	                       detached_worker, 0);
+	pthread_attr_destroy(&thread_attribute);
+	if (error)
+		return fail("detached create", error);
+	for (spins = 0; spins < 100000000UL &&
+	     !__atomic_load_n(&detached_done, __ATOMIC_ACQUIRE); spins++)
+		;
+	if (!detached_done)
+		return fail("detached timeout", 0);
+	if (test_shared_fd_table() || test_thread_nice())
+		return 1;
+
+	puts("PTHREAD_RUNTIME_OK");
+	return 0;
+}

--- a/tests/scripts/build-rootfs.sh
+++ b/tests/scripts/build-rootfs.sh
@@ -460,6 +460,18 @@ done
 	"$tests_dir/thread_runtime.c" "$tests_dir/thread_clone.S" \
 	-o "$staging/bin/thread-runtime"
 
+"$musl_cc" \
+	-march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror -pthread \
+	"$tests_dir/pthread_runtime.c" \
+	-o "$staging/bin/pthread-runtime"
+
+"$musl_cc" \
+	-march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror -pthread \
+	"$tests_dir/futex_runtime.c" \
+	-o "$staging/bin/futex-runtime"
+
 if "${cross_compile}readelf" -l "$staging/bin/fs-runtime" |
 	grep -q INTERP; then
 	echo "guest selftest must be statically linked" >&2
@@ -499,6 +511,18 @@ fi
 if "${cross_compile}readelf" -l "$staging/bin/thread-runtime" |
 	grep -q INTERP; then
 	echo "thread selftest must be statically linked" >&2
+	exit 1
+fi
+
+if ! "${cross_compile}readelf" -l "$staging/bin/pthread-runtime" |
+	grep -q '/lib/ld-musl-riscv64.so.1'; then
+	echo "pthread selftest must use the musl runtime linker" >&2
+	exit 1
+fi
+
+if ! "${cross_compile}readelf" -l "$staging/bin/futex-runtime" |
+	grep -q '/lib/ld-musl-riscv64.so.1'; then
+	echo "futex selftest must use the musl runtime linker" >&2
 	exit 1
 fi
 

--- a/tests/scripts/build-rootfs.sh
+++ b/tests/scripts/build-rootfs.sh
@@ -472,6 +472,12 @@ done
 	"$tests_dir/futex_runtime.c" \
 	-o "$staging/bin/futex-runtime"
 
+"$musl_cc" \
+	-march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror -pthread \
+	"$tests_dir/membarrier_runtime.c" \
+	-o "$staging/bin/membarrier-runtime"
+
 if "${cross_compile}readelf" -l "$staging/bin/fs-runtime" |
 	grep -q INTERP; then
 	echo "guest selftest must be statically linked" >&2
@@ -523,6 +529,12 @@ fi
 if ! "${cross_compile}readelf" -l "$staging/bin/futex-runtime" |
 	grep -q '/lib/ld-musl-riscv64.so.1'; then
 	echo "futex selftest must use the musl runtime linker" >&2
+	exit 1
+fi
+
+if ! "${cross_compile}readelf" -l "$staging/bin/membarrier-runtime" |
+	grep -q '/lib/ld-musl-riscv64.so.1'; then
+	echo "membarrier selftest must use the musl runtime linker" >&2
 	exit 1
 fi
 

--- a/tests/scripts/build-rootfs.sh
+++ b/tests/scripts/build-rootfs.sh
@@ -454,6 +454,12 @@ done
 	"$tests_dir/vm_runtime.c" \
 	-o "$staging/bin/vm-runtime"
 
+"$musl_cc" \
+	-static -march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror \
+	"$tests_dir/thread_runtime.c" "$tests_dir/thread_clone.S" \
+	-o "$staging/bin/thread-runtime"
+
 if "${cross_compile}readelf" -l "$staging/bin/fs-runtime" |
 	grep -q INTERP; then
 	echo "guest selftest must be statically linked" >&2
@@ -487,6 +493,12 @@ fi
 if "${cross_compile}readelf" -l "$staging/bin/vm-runtime" |
 	grep -q INTERP; then
 	echo "VM selftest must be statically linked" >&2
+	exit 1
+fi
+
+if "${cross_compile}readelf" -l "$staging/bin/thread-runtime" |
+	grep -q INTERP; then
+	echo "thread selftest must be statically linked" >&2
 	exit 1
 fi
 

--- a/tests/scripts/build-rootfs.sh
+++ b/tests/scripts/build-rootfs.sh
@@ -478,6 +478,13 @@ done
 	"$tests_dir/membarrier_runtime.c" \
 	-o "$staging/bin/membarrier-runtime"
 
+"$musl_cc" \
+	-march=rv64gc -mabi=lp64d \
+	-O2 -Wall -Wextra -Werror -pthread \
+	"$tests_dir/signal_runtime.c" \
+	"$tests_dir/signal_register.S" \
+	-o "$staging/bin/signal-runtime"
+
 if "${cross_compile}readelf" -l "$staging/bin/fs-runtime" |
 	grep -q INTERP; then
 	echo "guest selftest must be statically linked" >&2
@@ -535,6 +542,12 @@ fi
 if ! "${cross_compile}readelf" -l "$staging/bin/membarrier-runtime" |
 	grep -q '/lib/ld-musl-riscv64.so.1'; then
 	echo "membarrier selftest must use the musl runtime linker" >&2
+	exit 1
+fi
+
+if ! "${cross_compile}readelf" -l "$staging/bin/signal-runtime" |
+	grep -q '/lib/ld-musl-riscv64.so.1'; then
+	echo "signal selftest must use the musl runtime linker" >&2
 	exit 1
 fi
 

--- a/tests/scripts/check-user-trapframe.sh
+++ b/tests/scripts/check-user-trapframe.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+topdir=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+cross_compile=${CROSS_COMPILE:-riscv64-linux-gnu-}
+kernel=$topdir/output/kernel
+disassembly=$("${cross_compile}objdump" -d "$kernel")
+
+if rg -n 'TRAPFRAME_INFO|tinfo' \
+	"$topdir/arch" "$topdir/kernel"; then
+	echo "process-global user trapframe selection remains" >&2
+	exit 1
+fi
+
+if ! rg -q 'csrrw[[:space:]]+a0,sscratch,a0' <<<"$disassembly"; then
+	echo "user trap entry does not obtain its trapframe from sscratch" >&2
+	exit 1
+fi
+
+if ! rg -q 'csrw[[:space:]]+sscratch,a1' <<<"$disassembly"; then
+	echo "user trap return does not publish the per-hart trapframe" >&2
+	exit 1
+fi
+
+echo USER_TRAPFRAME_OK

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -148,6 +148,27 @@ expect {
 	eof { abort_test "QEMU exited after Linux futex test" }
 }
 
+send -- "/bin/membarrier-runtime\r"
+expect {
+	-re {\r?\nMEMBARRIER_RUNTIME_OK} {}
+	-re {MEMBARRIER_RUNTIME_FAIL[^\r\n]*} {
+		abort_test "Linux membarrier test reported failure"
+	}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic in Linux membarrier test"
+	}
+	timeout { abort_with_dump "Linux membarrier test timeout" }
+	eof { abort_test "QEMU exited during Linux membarrier test" }
+}
+expect {
+	-re {\r?\n# $} {}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic after Linux membarrier test"
+	}
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited after Linux membarrier test" }
+}
+
 send -- "/bin/dynamic-runtime pressure $pressure_iterations\r"
 expect {
 	-re {\r?\nDYNAMIC_EXEC_PRESSURE_OK} {}

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -85,6 +85,27 @@ expect {
 	eof { abort_test "QEMU exited after dynamic musl hello" }
 }
 
+send -- "/bin/thread-runtime\r"
+expect {
+	-re {\r?\nTHREAD_CLONE_OK} {}
+	-re {THREAD_RUNTIME_FAIL[^\r\n]*} {
+		abort_test "user thread clone test reported failure"
+	}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic in user thread clone test"
+	}
+	timeout { abort_with_dump "user thread clone test timeout" }
+	eof { abort_test "QEMU exited during user thread clone test" }
+}
+expect {
+	-re {\r?\n# $} {}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic after user thread clone test"
+	}
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited after user thread clone test" }
+}
+
 send -- "/bin/dynamic-runtime pressure $pressure_iterations\r"
 expect {
 	-re {\r?\nDYNAMIC_EXEC_PRESSURE_OK} {}

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -106,6 +106,48 @@ expect {
 	eof { abort_test "QEMU exited after user thread clone test" }
 }
 
+send -- "/bin/pthread-runtime\r"
+expect {
+	-re {\r?\nPTHREAD_RUNTIME_OK} {}
+	-re {PTHREAD_RUNTIME_FAIL[^\r\n]*} {
+		abort_test "musl pthread test reported failure"
+	}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic in musl pthread test"
+	}
+	timeout { abort_with_dump "musl pthread test timeout" }
+	eof { abort_test "QEMU exited during musl pthread test" }
+}
+expect {
+	-re {\r?\n# $} {}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic after musl pthread test"
+	}
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited after musl pthread test" }
+}
+
+send -- "/bin/futex-runtime\r"
+expect {
+	-re {\r?\nFUTEX_RUNTIME_OK} {}
+	-re {FUTEX_RUNTIME_FAIL[^\r\n]*} {
+		abort_test "Linux futex test reported failure"
+	}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic in Linux futex test"
+	}
+	timeout { abort_with_dump "Linux futex test timeout" }
+	eof { abort_test "QEMU exited during Linux futex test" }
+}
+expect {
+	-re {\r?\n# $} {}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic after Linux futex test"
+	}
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited after Linux futex test" }
+}
+
 send -- "/bin/dynamic-runtime pressure $pressure_iterations\r"
 expect {
 	-re {\r?\nDYNAMIC_EXEC_PRESSURE_OK} {}

--- a/tests/scripts/run-boot.exp
+++ b/tests/scripts/run-boot.exp
@@ -169,6 +169,27 @@ expect {
 	eof { abort_test "QEMU exited after Linux membarrier test" }
 }
 
+send -- "/bin/signal-runtime\r"
+expect {
+	-re {\r?\nSIGNAL_RUNTIME_OK} {}
+	-re {SIGNAL_RUNTIME_FAIL[^\r\n]*} {
+		abort_test "Linux signal test reported failure"
+	}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic in Linux signal test"
+	}
+	timeout { abort_with_dump "Linux signal test timeout" }
+	eof { abort_test "QEMU exited during Linux signal test" }
+}
+expect {
+	-re {\r?\n# $} {}
+	-re {\[PANIC\]} {
+		abort_test "kernel panic after Linux signal test"
+	}
+	timeout { abort_test "shell prompt timeout" }
+	eof { abort_test "QEMU exited after Linux signal test" }
+}
+
 send -- "/bin/dynamic-runtime pressure $pressure_iterations\r"
 expect {
 	-re {\r?\nDYNAMIC_EXEC_PRESSURE_OK} {}

--- a/tests/scripts/run-debug-dump.exp
+++ b/tests/scripts/run-debug-dump.exp
@@ -72,12 +72,12 @@ expect {
 	eof { abort_test "QEMU exited during ext4 state" }
 }
 expect {
-	-re {virtio-blk[0-9]+ avail=[0-9]+ .* used=[0-9]+ .* size=[0-9]+} {}
+	-re {virtio-blk[0-9]+ avail=[0-9]+ [^\r\n]* used=[0-9]+ [^\r\n]* size=[0-9]+} {}
 	timeout { abort_test "virtio-blk state timeout" }
 	eof { abort_test "QEMU exited during virtio-blk state" }
 }
 expect {
-	-re {virtio-blk[0-9]+ avail=[0-9]+ .* used=[0-9]+ .* size=[0-9]+} {}
+	-re {virtio-blk[0-9]+ avail=[0-9]+ [^\r\n]* used=[0-9]+ [^\r\n]* size=[0-9]+} {}
 	timeout { abort_test "second virtio-blk state timeout" }
 	eof { abort_test "QEMU exited during virtio-blk state" }
 }

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -296,6 +296,11 @@ run_boot_smoke()
 		echo "Linux futex marker is missing" >&2
 		exit 1
 	fi
+	if [ "$(awk '$0 == "MEMBARRIER_RUNTIME_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "Linux membarrier marker is missing" >&2
+		exit 1
+	fi
 	if [ "$(awk '$0 == "DYNAMIC_EXEC_PRESSURE_OK" { count++ }
 		END { print count + 0 }' "$clean")" -ne 1 ]; then
 		echo "dynamic exec pressure marker is missing" >&2

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -281,6 +281,11 @@ run_boot_smoke()
 		echo "dynamic musl smoke marker is missing" >&2
 		exit 1
 	fi
+	if [ "$(awk '$0 == "THREAD_CLONE_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "user thread clone marker is missing" >&2
+		exit 1
+	fi
 	if [ "$(awk '$0 == "DYNAMIC_EXEC_PRESSURE_OK" { count++ }
 		END { print count + 0 }' "$clean")" -ne 1 ]; then
 		echo "dynamic exec pressure marker is missing" >&2

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -301,6 +301,11 @@ run_boot_smoke()
 		echo "Linux membarrier marker is missing" >&2
 		exit 1
 	fi
+	if [ "$(awk '$0 == "SIGNAL_RUNTIME_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "Linux signal marker is missing" >&2
+		exit 1
+	fi
 	if [ "$(awk '$0 == "DYNAMIC_EXEC_PRESSURE_OK" { count++ }
 		END { print count + 0 }' "$clean")" -ne 1 ]; then
 		echo "dynamic exec pressure marker is missing" >&2

--- a/tests/scripts/run-qemu.sh
+++ b/tests/scripts/run-qemu.sh
@@ -286,6 +286,16 @@ run_boot_smoke()
 		echo "user thread clone marker is missing" >&2
 		exit 1
 	fi
+	if [ "$(awk '$0 == "PTHREAD_RUNTIME_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "musl pthread marker is missing" >&2
+		exit 1
+	fi
+	if [ "$(awk '$0 == "FUTEX_RUNTIME_OK" { count++ }
+		END { print count + 0 }' "$clean")" -ne 1 ]; then
+		echo "Linux futex marker is missing" >&2
+		exit 1
+	fi
 	if [ "$(awk '$0 == "DYNAMIC_EXEC_PRESSURE_OK" { count++ }
 		END { print count + 0 }' "$clean")" -ne 1 ]; then
 		echo "dynamic exec pressure marker is missing" >&2

--- a/tests/signal_register.S
+++ b/tests/signal_register.S
@@ -1,0 +1,40 @@
+.text
+.global signal_register_probe
+.type signal_register_probe, @function
+signal_register_probe:
+	addi sp, sp, -48
+	sd ra, 40(sp)
+	sd s2, 32(sp)
+	fsd fs0, 24(sp)
+	sd a0, 16(sp)
+	sd a1, 8(sp)
+
+	li s2, 0x123
+	li t0, 0x3ff8000000000000
+	fmv.d.x fs0, t0
+	li a0, 12
+	call raise
+	mv t2, a0
+	bnez a0, .Lsignal_register_done
+	ld t0, 16(sp)
+	sd s2, 0(t0)
+	fmv.x.d t1, fs0
+	ld t0, 8(sp)
+	sd t1, 0(t0)
+
+.Lsignal_register_done:
+	ld ra, 40(sp)
+	ld s2, 32(sp)
+	fld fs0, 24(sp)
+	addi sp, sp, 48
+	mv a0, t2
+	ret
+.size signal_register_probe, .-signal_register_probe
+
+.global signal_a0_probe
+.type signal_a0_probe, @function
+signal_a0_probe:
+	li a7, 131
+	ecall
+	ret
+.size signal_a0_probe, .-signal_a0_probe

--- a/tests/signal_runtime.c
+++ b/tests/signal_runtime.c
@@ -1,0 +1,1145 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define GPR_BEFORE 0x123UL
+#define GPR_AFTER  0x456UL
+#define FP_BEFORE  0x3ff8000000000000ULL
+#define FP_AFTER   0x4004000000000000ULL
+#define FUTEX_WAIT 0
+#define FUTEX_WAKE 1
+#define FUTEX_PRIVATE_FLAG 128
+#define EXIT_GROUP_THREADS 8
+#define EXIT_GROUP_ROUNDS 4
+#define REALTIME_SIGNAL_COUNT 8
+#define PROCESS_WAITERS 4
+
+extern int signal_register_probe(uint64_t *gpr, uint64_t *fp);
+extern long signal_a0_probe(long pid, long tid, long signal);
+
+static volatile sig_atomic_t handler_count;
+static volatile sig_atomic_t handler_error;
+static volatile sig_atomic_t nested_depth;
+static volatile sig_atomic_t child_events;
+static volatile sig_atomic_t target_count;
+static volatile sig_atomic_t target_tid_seen;
+static volatile sig_atomic_t interrupt_count;
+static atomic_int target_ready;
+static atomic_int target_done;
+static atomic_int cancel_ready;
+static atomic_int exit_group_ready;
+static atomic_int process_wait_ready;
+static atomic_int process_wait_done;
+static atomic_int process_wait_interrupted;
+static atomic_int process_wait_failed;
+static volatile int restart_futex;
+static volatile int exit_group_futex;
+static pid_t expected_sender;
+static pid_t target_tid;
+static unsigned char alternate_stack[SIGSTKSZ];
+
+enum sender_operation {
+	SENDER_SIGNAL_ONLY,
+	SENDER_WAKE_FUTEX,
+	SENDER_KILL_CHILD,
+};
+
+struct sender_request {
+	pthread_t target;
+	enum sender_operation operation;
+	pid_t child;
+	int observed_count;
+};
+
+static void fail(const char *stage)
+{
+	printf("SIGNAL_RUNTIME_FAIL %s errno=%d\n", stage, errno);
+	exit(1);
+}
+
+static void require(int condition, const char *stage)
+{
+	if (!condition)
+		fail(stage);
+}
+
+static int wait_for_count(volatile sig_atomic_t *value, int expected)
+{
+	struct timespec start, now;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &start))
+		return -1;
+	while (*value < expected) {
+		if (clock_gettime(CLOCK_MONOTONIC, &now))
+			return -1;
+		if (now.tv_sec - start.tv_sec >= 2)
+			return -1;
+	}
+	return 0;
+}
+
+static int delay_milliseconds(unsigned int milliseconds)
+{
+	struct timespec start, now;
+	uint64_t elapsed;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &start))
+		return -1;
+	for (;;) {
+		if (clock_gettime(CLOCK_MONOTONIC, &now))
+			return -1;
+		elapsed = (uint64_t)(now.tv_sec - start.tv_sec) * 1000;
+		if (now.tv_nsec >= start.tv_nsec)
+			elapsed += (now.tv_nsec - start.tv_nsec) / 1000000;
+		else
+			elapsed -= (start.tv_nsec - now.tv_nsec + 999999) /
+			           1000000;
+		if (elapsed >= milliseconds)
+			return 0;
+	}
+}
+
+static void interrupt_handler(int signal)
+{
+	if (signal != SIGUSR1)
+		handler_error = 10;
+	interrupt_count++;
+}
+
+static void *interrupt_sender(void *argument)
+{
+	struct sender_request *request = argument;
+	unsigned long attempts;
+
+	if (delay_milliseconds(10) ||
+	    pthread_kill(request->target, SIGUSR1)) {
+		handler_error = 11;
+		return 0;
+	}
+	if (request->operation == SENDER_SIGNAL_ONLY)
+		return 0;
+	while (interrupt_count == request->observed_count)
+		;
+	if (request->operation == SENDER_KILL_CHILD) {
+		if (kill(request->child, SIGTERM))
+			handler_error = 12;
+		return 0;
+	}
+	for (attempts = 0; attempts < 1000000UL; attempts++) {
+		long result = syscall(SYS_futex, &restart_futex,
+		                      FUTEX_WAKE | FUTEX_PRIVATE_FLAG,
+		                      1, 0, 0, 0);
+
+		if (result == 1)
+			return 0;
+		if (result < 0) {
+			handler_error = 13;
+			return 0;
+		}
+	}
+	handler_error = 14;
+	return 0;
+}
+
+static void basic_handler(int signal, siginfo_t *information, void *context)
+{
+	(void)context;
+	if (signal != SIGUSR1 || information->si_signo != SIGUSR1 ||
+	    information->si_code != SI_USER ||
+	    information->si_pid != expected_sender)
+		handler_error = 1;
+	handler_count++;
+}
+
+static void register_handler(int signal, siginfo_t *information,
+			     void *context)
+{
+	ucontext_t *user_context = context;
+	unsigned long long *floating;
+
+	(void)information;
+	if (signal != SIGUSR2)
+		handler_error = 2;
+	if (user_context->uc_mcontext.__gregs[REG_S2] != GPR_BEFORE)
+		handler_error = 3;
+	floating = user_context->uc_mcontext.__fpregs.__d.__f;
+	if (floating[8] != FP_BEFORE)
+		handler_error = 4;
+	user_context->uc_mcontext.__gregs[REG_S2] = GPR_AFTER;
+	floating[8] = FP_AFTER;
+}
+
+static void restart_marker_handler(int signal, siginfo_t *information,
+				   void *context)
+{
+	ucontext_t *user_context = context;
+
+	(void)information;
+	if (signal != SIGUSR2)
+		handler_error = 15;
+	user_context->uc_mcontext.__gregs[REG_A0] = (greg_t)-512;
+}
+
+static void nested_handler(int signal, siginfo_t *information, void *context)
+{
+	unsigned char stack_byte;
+	uintptr_t address = (uintptr_t)&stack_byte;
+
+	(void)information;
+	(void)context;
+	if (signal != SIGUSR2 || address < (uintptr_t)alternate_stack ||
+	    address >= (uintptr_t)alternate_stack + sizeof(alternate_stack))
+		handler_error = 5;
+	nested_depth++;
+	handler_count++;
+	if (nested_depth == 1 && raise(SIGUSR2))
+		handler_error = 6;
+	nested_depth--;
+}
+
+static void target_handler(int signal)
+{
+	if (signal != SIGUSR1)
+		handler_error = 7;
+	target_tid_seen = syscall(SYS_gettid);
+	target_count++;
+}
+
+static void child_handler(int signal, siginfo_t *information, void *context)
+{
+	(void)signal;
+	(void)context;
+	if (information->si_code == CLD_STOPPED)
+		child_events |= 1;
+	else if (information->si_code == CLD_CONTINUED)
+		child_events |= 2;
+	else if (information->si_code == CLD_KILLED)
+		child_events |= 4;
+	else if (information->si_code == CLD_EXITED)
+		child_events |= 8;
+}
+
+static void fault_handler(int signal, siginfo_t *information, void *context)
+{
+	(void)context;
+	if (signal != SIGSEGV)
+		_exit(110);
+	if (information->si_code != SEGV_MAPERR)
+		_exit(120 + (information->si_code & 0x7f));
+	if (information->si_addr != (void *)0x1000)
+		_exit(128 + (((uintptr_t)information->si_addr >> 12) & 0x7f));
+	_exit(0);
+}
+
+static void reset_handler(int signal)
+{
+	(void)signal;
+}
+
+static void *process_sender(void *argument)
+{
+	(void)argument;
+	if (kill(getpid(), SIGUSR1))
+		handler_error = 8;
+	return 0;
+}
+
+static void *target_thread(void *argument)
+{
+	sigset_t set;
+
+	(void)argument;
+	target_tid = syscall(SYS_gettid);
+	sigemptyset(&set);
+	sigaddset(&set, SIGUSR1);
+	if (pthread_sigmask(SIG_UNBLOCK, &set, 0)) {
+		handler_error = 9;
+		return 0;
+	}
+	atomic_store_explicit(&target_ready, 1, memory_order_release);
+	while (!atomic_load_explicit(&target_done, memory_order_acquire))
+		;
+	return 0;
+}
+
+static void *cancel_thread(void *argument)
+{
+	char byte;
+
+	(void)argument;
+	atomic_store_explicit(&cancel_ready, 1, memory_order_release);
+	(void)read(STDIN_FILENO, &byte, sizeof(byte));
+	return (void *)1;
+}
+
+static void *exit_group_thread(void *argument)
+{
+	(void)argument;
+	atomic_fetch_add_explicit(&exit_group_ready, 1,
+	                          memory_order_release);
+	(void)syscall(SYS_futex, &exit_group_futex,
+	              FUTEX_WAIT | FUTEX_PRIVATE_FLAG, 0, 0, 0, 0);
+	return 0;
+}
+
+static void *process_wait_thread(void *argument)
+{
+	struct timespec timeout = { .tv_nsec = 200000000 };
+	sigset_t set;
+	int result;
+
+	(void)argument;
+	sigfillset(&set);
+	sigdelset(&set, SIGUSR1);
+	atomic_fetch_add_explicit(&process_wait_ready, 1,
+	                          memory_order_release);
+	errno = 0;
+	result = ppoll(0, 0, &timeout, &set);
+	if (result == -1 && errno == EINTR)
+		atomic_fetch_add(&process_wait_interrupted, 1);
+	else if (result)
+		atomic_store(&process_wait_failed, 1);
+	atomic_fetch_add_explicit(&process_wait_done, 1,
+	                          memory_order_release);
+	return 0;
+}
+
+static void *timed_signal_sender(void *argument)
+{
+	pthread_t target = *(pthread_t *)argument;
+	int index;
+
+	for (index = 0; index < 3; index++) {
+		if (delay_milliseconds(50) || pthread_kill(target, SIGUSR1)) {
+			handler_error = 16;
+			break;
+		}
+	}
+	return 0;
+}
+
+static void *exit_group_socket_thread(void *argument)
+{
+	struct sockaddr_in address = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+	};
+	char byte;
+	int fd;
+
+	(void)argument;
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0 || bind(fd, (struct sockaddr *)&address,
+			  sizeof(address)))
+		_exit(106);
+	atomic_fetch_add_explicit(&exit_group_ready, 1,
+	                          memory_order_release);
+	(void)recv(fd, &byte, sizeof(byte), 0);
+	close(fd);
+	return 0;
+}
+
+static void test_basic_delivery(void)
+{
+	struct sigaction action = { 0 };
+
+	handler_count = 0;
+	handler_error = 0;
+	expected_sender = getpid();
+	action.sa_sigaction = basic_handler;
+	action.sa_flags = SA_SIGINFO;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR1, &action, 0), "install basic handler");
+	require(!kill(getpid(), SIGUSR1), "send process signal");
+	require(handler_count == 1 && !handler_error, "basic delivery");
+}
+
+static void test_register_frame(void)
+{
+	struct sigaction action = { 0 };
+	uint64_t gpr = 0, fp = 0;
+
+	action.sa_sigaction = register_handler;
+	action.sa_flags = SA_SIGINFO;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR2, &action, 0), "install frame handler");
+	require(!signal_register_probe(&gpr, &fp), "register probe");
+	require(!handler_error && gpr == GPR_AFTER && fp == FP_AFTER,
+	        "restore register frame");
+	action.sa_sigaction = restart_marker_handler;
+	require(!sigaction(SIGUSR2, &action, 0),
+	        "install restart marker handler");
+	require(signal_a0_probe(getpid(), syscall(SYS_gettid), SIGUSR2) ==
+	        -512, "preserve sigreturn a0");
+	require(!handler_error, "restart marker handler");
+}
+
+static void test_process_signal_wake(void)
+{
+	struct sigaction action = { 0 };
+	pthread_t threads[PROCESS_WAITERS];
+	sigset_t set, old;
+	int index;
+
+	action.sa_handler = target_handler;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR1, &action, 0),
+	        "install process wake handler");
+	sigemptyset(&set);
+	sigaddset(&set, SIGUSR1);
+	require(!pthread_sigmask(SIG_BLOCK, &set, &old),
+	        "block process wake main");
+	atomic_store(&process_wait_ready, 0);
+	atomic_store(&process_wait_done, 0);
+	atomic_store(&process_wait_interrupted, 0);
+	atomic_store(&process_wait_failed, 0);
+	for (index = 0; index < PROCESS_WAITERS; index++)
+		require(!pthread_create(&threads[index], 0,
+					process_wait_thread, 0),
+		        "create process waiter");
+	while (atomic_load_explicit(&process_wait_ready,
+	                           memory_order_acquire) != PROCESS_WAITERS)
+		;
+	require(!kill(getpid(), SIGUSR1), "send process wake signal");
+	while (!atomic_load_explicit(&process_wait_done,
+	                            memory_order_acquire))
+		;
+	require(!delay_milliseconds(20), "settle process wake");
+	if (atomic_load(&process_wait_done) != 1 ||
+	    atomic_load(&process_wait_interrupted) != 1)
+		printf("SIGNAL_WAKE_COUNTS done=%d interrupted=%d failed=%d\n",
+		       atomic_load(&process_wait_done),
+		       atomic_load(&process_wait_interrupted),
+		       atomic_load(&process_wait_failed));
+	require(atomic_load(&process_wait_done) == 1 &&
+	        atomic_load(&process_wait_interrupted) == 1,
+	        "wake one process waiter");
+	for (index = 0; index < PROCESS_WAITERS; index++)
+		require(!pthread_join(threads[index], 0),
+		        "join process waiter");
+	require(!atomic_load(&process_wait_failed) &&
+	        atomic_load(&process_wait_done) == PROCESS_WAITERS &&
+	        atomic_load(&process_wait_interrupted) == 1,
+	        "process wake results");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore process wake mask");
+}
+
+static void test_pending_and_wait(void)
+{
+	struct timespec timeout = { .tv_nsec = 20000000 };
+	siginfo_t information;
+	sigset_t set, pending, old;
+	int before, result;
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGUSR1);
+	require(!sigprocmask(SIG_BLOCK, &set, &old), "block signal");
+	before = handler_count;
+	require(!kill(getpid(), SIGUSR1), "queue blocked signal");
+	require(!kill(getpid(), SIGUSR1), "coalesce blocked signal");
+	require(!sigpending(&pending) && sigismember(&pending, SIGUSR1) == 1,
+	        "report pending signal");
+	require(handler_count == before, "hold blocked signal");
+	require(!sigprocmask(SIG_UNBLOCK, &set, 0), "unblock signal");
+	require(handler_count == before + 1, "deliver unblocked signal");
+	require(!sigprocmask(SIG_SETMASK, &old, 0), "restore signal mask");
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGKILL);
+	sigaddset(&set, SIGSTOP);
+	require(!sigprocmask(SIG_BLOCK, &set, &old),
+	        "attempt to block unmaskable signals");
+	require(!sigprocmask(SIG_SETMASK, 0, &pending) &&
+	        sigismember(&pending, SIGKILL) == 0 &&
+	        sigismember(&pending, SIGSTOP) == 0,
+	        "keep kill and stop unblocked");
+	require(!sigprocmask(SIG_SETMASK, &old, 0),
+	        "restore unmaskable signal test mask");
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGUSR2);
+	require(!sigprocmask(SIG_BLOCK, &set, &old), "block waited signal");
+	require(!kill(getpid(), SIGUSR2), "queue waited signal");
+	result = sigtimedwait(&set, &information, &timeout);
+	require(result == SIGUSR2 && information.si_signo == SIGUSR2 &&
+	        information.si_code == SI_USER &&
+	        information.si_pid == getpid(), "consume waited signal");
+	errno = 0;
+	result = sigtimedwait(&set, &information, &timeout);
+	require(result == -1 && errno == EAGAIN, "time out signal wait");
+	require(!sigprocmask(SIG_SETMASK, &old, 0), "restore waited mask");
+}
+
+static void test_default_ignored_wait(void)
+{
+	struct timespec timeout = { .tv_nsec = 200000000 };
+	struct sigaction action = { .sa_handler = SIG_DFL };
+	siginfo_t information;
+	sigset_t set, old;
+	pid_t child;
+	int status;
+
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGCHLD, &action, 0),
+	        "restore default child action");
+	sigemptyset(&set);
+	sigaddset(&set, SIGCHLD);
+	sigaddset(&set, SIGURG);
+	require(!pthread_sigmask(SIG_BLOCK, &set, &old),
+	        "block default ignored signals");
+	require(!pthread_kill(pthread_self(), SIGURG),
+	        "queue ignored thread signal");
+	require(sigtimedwait(&set, &information, &timeout) == SIGURG &&
+	        information.si_signo == SIGURG,
+	        "wait for ignored thread signal");
+	child = fork();
+	require(child >= 0, "fork ignored wait child");
+	if (!child)
+		_exit(23);
+	require(sigtimedwait(&set, &information, &timeout) == SIGCHLD &&
+	        information.si_signo == SIGCHLD &&
+	        information.si_code == CLD_EXITED,
+	        "wait for default child signal");
+	require(waitpid(child, &status, 0) == child && WIFEXITED(status) &&
+	        WEXITSTATUS(status) == 23, "reap ignored wait child");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore default ignored mask");
+}
+
+static void test_pending_priority_and_realtime(void)
+{
+	struct timespec timeout = { .tv_nsec = 20000000 };
+	siginfo_t information;
+	sigset_t set, old;
+	int index, result;
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGUSR1);
+	sigaddset(&set, SIGUSR2);
+	require(!pthread_sigmask(SIG_BLOCK, &set, &old),
+	        "block priority signals");
+	require(!pthread_kill(pthread_self(), SIGUSR2),
+	        "queue thread priority signal");
+	require(!kill(getpid(), SIGUSR1), "queue process priority signal");
+	result = sigtimedwait(&set, &information, &timeout);
+	require(result == SIGUSR1 && information.si_signo == SIGUSR1,
+	        "select lowest pending signal");
+	result = sigtimedwait(&set, &information, &timeout);
+	require(result == SIGUSR2 && information.si_signo == SIGUSR2,
+	        "consume thread pending signal");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore priority signal mask");
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGRTMIN);
+	require(!pthread_sigmask(SIG_BLOCK, &set, &old),
+	        "block realtime signal");
+	for (index = 0; index < REALTIME_SIGNAL_COUNT; index++)
+		require(!pthread_kill(pthread_self(), SIGRTMIN),
+		        "queue realtime signal");
+	for (index = 0; index < REALTIME_SIGNAL_COUNT; index++) {
+		result = sigtimedwait(&set, &information, &timeout);
+		require(result == SIGRTMIN &&
+		        information.si_signo == SIGRTMIN &&
+		        information.si_code == SI_TKILL,
+		        "consume queued realtime signal");
+	}
+	errno = 0;
+	require(sigtimedwait(&set, &information, &timeout) == -1 &&
+	        errno == EAGAIN, "drain realtime signal queue");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore realtime signal mask");
+}
+
+static void test_sigsuspend(void)
+{
+	struct sigaction action = { 0 };
+	pthread_t sender;
+	sigset_t block, empty, old, current;
+	int before;
+
+	action.sa_sigaction = basic_handler;
+	action.sa_flags = SA_SIGINFO;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR1, &action, 0), "install suspend handler");
+	sigemptyset(&block);
+	sigaddset(&block, SIGUSR1);
+	require(!pthread_sigmask(SIG_BLOCK, &block, &old), "block suspend signal");
+	before = handler_count;
+	require(!pthread_create(&sender, 0, process_sender, 0),
+	        "create suspend sender");
+	sigemptyset(&empty);
+	errno = 0;
+	require(sigsuspend(&empty) == -1 && errno == EINTR,
+	        "interrupt sigsuspend");
+	require(!pthread_join(sender, 0), "join suspend sender");
+	require(handler_count == before + 1 && !handler_error,
+	        "deliver suspend signal");
+	require(!pthread_sigmask(SIG_SETMASK, 0, &current) &&
+	        sigismember(&current, SIGUSR1) == 1,
+	        "restore suspend mask");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore suspend caller mask");
+}
+
+static void test_altstack(void)
+{
+	struct sigaction action = { 0 };
+	stack_t requested, current;
+
+	requested.ss_sp = alternate_stack;
+	requested.ss_size = sizeof(alternate_stack);
+	requested.ss_flags = 0;
+	require(!sigaltstack(&requested, 0), "install alternate stack");
+	handler_count = 0;
+	nested_depth = 0;
+	handler_error = 0;
+	action.sa_sigaction = nested_handler;
+	action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR2, &action, 0), "install nested handler");
+	require(!raise(SIGUSR2), "raise nested signal");
+	require(handler_count == 2 && !nested_depth && !handler_error,
+	        "nested alternate stack");
+	require(!sigaltstack(0, &current) && !(current.ss_flags & SS_ONSTACK) &&
+	        current.ss_sp == alternate_stack,
+	        "query alternate stack");
+	requested.ss_flags = SS_DISABLE;
+	require(!sigaltstack(&requested, 0), "disable alternate stack");
+}
+
+static void test_thread_targeting(void)
+{
+	struct sigaction action = { 0 };
+	pthread_t thread;
+	sigset_t set, old;
+
+	handler_error = 0;
+	target_count = 0;
+	target_tid_seen = 0;
+	atomic_store(&target_ready, 0);
+	atomic_store(&target_done, 0);
+	action.sa_handler = target_handler;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR1, &action, 0), "install thread handler");
+	sigemptyset(&set);
+	sigaddset(&set, SIGUSR1);
+	require(!pthread_sigmask(SIG_BLOCK, &set, &old),
+	        "block main thread signal");
+	require(!pthread_create(&thread, 0, target_thread, 0),
+	        "create target thread");
+	while (!atomic_load_explicit(&target_ready, memory_order_acquire))
+		;
+	require(syscall(SYS_tkill, target_tid, SIGUSR1) == 0,
+	        "tkill target thread");
+	require(!wait_for_count(&target_count, 1), "observe tkill");
+	require(syscall(SYS_tgkill, getpid(), target_tid, SIGUSR1) == 0,
+	        "tgkill target thread");
+	require(!wait_for_count(&target_count, 2), "observe tgkill");
+	require(!pthread_kill(thread, SIGUSR1), "pthread_kill target thread");
+	require(!wait_for_count(&target_count, 3), "observe pthread_kill");
+	atomic_store_explicit(&target_done, 1, memory_order_release);
+	require(!pthread_join(thread, 0), "join target thread");
+	require(!handler_error && target_tid_seen == target_tid,
+	        "thread directed delivery");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore main thread mask");
+}
+
+static void test_child_events(void)
+{
+	struct sigaction action = { 0 };
+	pid_t child, result;
+	int status;
+
+	child_events = 0;
+	action.sa_sigaction = child_handler;
+	action.sa_flags = SA_SIGINFO;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGCHLD, &action, 0), "install child handler");
+	child = fork();
+	require(child >= 0, "fork stopped child");
+	if (!child) {
+		for (;;)
+			__asm__ volatile("" ::: "memory");
+	}
+	require(!kill(child, SIGSTOP), "stop child");
+	result = waitpid(child, &status, WUNTRACED);
+	require(result == child && WIFSTOPPED(status) &&
+	        WSTOPSIG(status) == SIGSTOP && (child_events & 1),
+	        "wait stopped child");
+	require(!kill(child, SIGCONT), "continue child");
+	result = waitpid(child, &status, WCONTINUED);
+	require(result == child && WIFCONTINUED(status) &&
+	        (child_events & 2), "wait continued child");
+	require(!kill(child, SIGTERM), "terminate child");
+	result = waitpid(child, &status, 0);
+	require(result == child && WIFSIGNALED(status) &&
+	        WTERMSIG(status) == SIGTERM && (child_events & 4),
+	        "wait signaled child");
+
+	child_events = 0;
+	action.sa_flags = SA_SIGINFO | SA_NOCLDSTOP;
+	require(!sigaction(SIGCHLD, &action, 0),
+	        "install no-cld-stop handler");
+	child = fork();
+	require(child >= 0, "fork no-cld-stop child");
+	if (!child) {
+		for (;;)
+			__asm__ volatile("" ::: "memory");
+	}
+	require(!kill(child, SIGSTOP), "stop no-cld-stop child");
+	require(waitpid(child, &status, WUNTRACED) == child &&
+	        WIFSTOPPED(status) && child_events == 0,
+	        "suppress stopped SIGCHLD");
+	require(!kill(child, SIGCONT), "continue no-cld-stop child");
+	require(waitpid(child, &status, WCONTINUED) == child &&
+	        WIFCONTINUED(status) && child_events == 0,
+	        "suppress continued SIGCHLD");
+	require(!kill(child, SIGTERM), "terminate no-cld-stop child");
+	require(waitpid(child, &status, 0) == child &&
+	        WIFSIGNALED(status) && WTERMSIG(status) == SIGTERM &&
+	        child_events == 4, "retain exit SIGCHLD");
+}
+
+static void test_exec_dispositions(void)
+{
+	struct sigaction action = { 0 };
+	pid_t child;
+	int status;
+
+	action.sa_handler = reset_handler;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR1, &action, 0),
+	        "install inherited exec handler");
+	child = fork();
+	require(child >= 0, "fork exec-reset child");
+	if (!child) {
+		execl("/bin/signal-runtime", "signal-runtime",
+		      "exec-reset", NULL);
+		_exit(106);
+	}
+	require(waitpid(child, &status, 0) == child &&
+	        WIFSIGNALED(status) && WTERMSIG(status) == SIGUSR1,
+	        "reset caught disposition on exec");
+
+	action.sa_handler = SIG_IGN;
+	require(!sigaction(SIGUSR2, &action, 0),
+	        "install inherited ignored action");
+	child = fork();
+	require(child >= 0, "fork exec-ignore child");
+	if (!child) {
+		execl("/bin/signal-runtime", "signal-runtime",
+		      "exec-ignore", NULL);
+		_exit(107);
+	}
+	require(waitpid(child, &status, 0) == child && WIFEXITED(status) &&
+	        WEXITSTATUS(status) == 0,
+	        "preserve ignored disposition on exec");
+	action.sa_handler = SIG_DFL;
+	require(!sigaction(SIGUSR2, &action, 0),
+	        "restore ignored exec action");
+}
+
+static void test_child_auto_reap(void)
+{
+	struct sigaction action = { 0 };
+	pid_t child;
+	int round, status;
+
+	action.sa_sigaction = child_handler;
+	action.sa_flags = SA_SIGINFO | SA_NOCLDWAIT;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGCHLD, &action, 0),
+	        "install no-cld-wait handler");
+	for (round = 0; round < 8; round++) {
+		child_events = 0;
+		child = fork();
+		require(child >= 0, "fork no-cld-wait child");
+		if (!child)
+			_exit(0);
+		errno = 0;
+		require(waitpid(child, &status, 0) == -1 && errno == ECHILD &&
+		        (child_events & 8), "auto-reap no-cld-wait child");
+	}
+
+	memset(&action, 0, sizeof(action));
+	action.sa_handler = SIG_IGN;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGCHLD, &action, 0),
+	        "ignore child signal");
+	for (round = 0; round < 8; round++) {
+		child = fork();
+		require(child >= 0, "fork ignored child");
+		if (!child)
+			_exit(0);
+		errno = 0;
+		require(waitpid(child, &status, 0) == -1 && errno == ECHILD,
+		        "auto-reap ignored child");
+	}
+	action.sa_handler = SIG_DFL;
+	require(!sigaction(SIGCHLD, &action, 0),
+	        "restore child disposition");
+}
+
+static void test_fault_and_reset(void)
+{
+	struct sigaction action = { 0 };
+	pid_t child;
+	int status;
+
+	child = fork();
+	require(child >= 0, "fork fault child");
+	if (!child) {
+		action.sa_sigaction = fault_handler;
+		action.sa_flags = SA_SIGINFO;
+		sigemptyset(&action.sa_mask);
+		if (sigaction(SIGSEGV, &action, 0))
+			_exit(101);
+		__asm__ volatile("sw zero, 0(%0)" :: "r"(0x1000UL) : "memory");
+		_exit(102);
+	}
+	require(waitpid(child, &status, 0) == child, "wait fault child");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		printf("SIGNAL_FAULT_STATUS %#x\n", status);
+	require(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+	        "handle synchronous fault");
+
+	child = fork();
+	require(child >= 0, "fork illegal child");
+	if (!child) {
+		__asm__ volatile(".word 0");
+		_exit(103);
+	}
+	require(waitpid(child, &status, 0) == child && WIFSIGNALED(status) &&
+	        WTERMSIG(status) == SIGILL, "report illegal instruction");
+
+	child = fork();
+	require(child >= 0, "fork reset child");
+	if (!child) {
+		action.sa_handler = reset_handler;
+		action.sa_flags = SA_RESETHAND;
+		sigemptyset(&action.sa_mask);
+		if (sigaction(SIGUSR1, &action, 0) || raise(SIGUSR1))
+			_exit(104);
+		raise(SIGUSR1);
+		_exit(105);
+	}
+	require(waitpid(child, &status, 0) == child, "wait reset child");
+	if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGUSR1)
+		printf("SIGNAL_RESET_STATUS %#x\n", status);
+	require(WIFSIGNALED(status) && WTERMSIG(status) == SIGUSR1,
+	        "reset signal disposition");
+}
+
+static void install_interrupt_handler(int flags)
+{
+	struct sigaction action = { 0 };
+
+	action.sa_handler = interrupt_handler;
+	action.sa_flags = flags;
+	sigemptyset(&action.sa_mask);
+	require(!sigaction(SIGUSR1, &action, 0),
+	        "install interrupt handler");
+}
+
+static void test_futex_interruption(void)
+{
+	struct sender_request request;
+	pthread_t sender;
+	long result;
+	int before;
+
+	handler_error = 0;
+	install_interrupt_handler(0);
+	restart_futex = 0;
+	before = interrupt_count;
+	request.target = pthread_self();
+	request.operation = SENDER_SIGNAL_ONLY;
+	request.child = 0;
+	request.observed_count = before;
+	require(!pthread_create(&sender, 0, interrupt_sender, &request),
+	        "create futex interrupt sender");
+	errno = 0;
+	result = syscall(SYS_futex, &restart_futex,
+	                 FUTEX_WAIT | FUTEX_PRIVATE_FLAG, 0, 0, 0, 0);
+	require(result == -1 && errno == EINTR,
+	        "interrupt futex without restart");
+	require(!pthread_join(sender, 0), "join futex interrupt sender");
+	require(interrupt_count == before + 1 && !handler_error,
+	        "deliver futex interrupt signal");
+
+	install_interrupt_handler(SA_RESTART);
+	before = interrupt_count;
+	request.operation = SENDER_WAKE_FUTEX;
+	request.observed_count = before;
+	require(!pthread_create(&sender, 0, interrupt_sender, &request),
+	        "create futex restart sender");
+	errno = 0;
+	result = syscall(SYS_futex, &restart_futex,
+	                 FUTEX_WAIT | FUTEX_PRIVATE_FLAG, 0, 0, 0, 0);
+	require(result == 0, "restart futex wait");
+	require(!pthread_join(sender, 0), "join futex restart sender");
+	require(interrupt_count == before + 1 && !handler_error,
+	        "deliver restarted futex signal");
+
+	{
+		struct timespec timeout = { .tv_nsec = 200000000 };
+		struct timespec start, finish;
+		pthread_t target = pthread_self();
+		uint64_t elapsed;
+		int futex_errno;
+
+		before = interrupt_count;
+		require(!pthread_create(&sender, 0, timed_signal_sender, &target),
+		        "create timed futex sender");
+		require(!clock_gettime(CLOCK_MONOTONIC, &start),
+		        "time futex start");
+		errno = 0;
+		result = syscall(SYS_futex, &restart_futex,
+		                 FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+		                 0, &timeout, 0, 0);
+		futex_errno = errno;
+		require(!clock_gettime(CLOCK_MONOTONIC, &finish),
+		        "time futex finish");
+		elapsed = (uint64_t)(finish.tv_sec - start.tv_sec) * 1000;
+		if (finish.tv_nsec >= start.tv_nsec)
+			elapsed += (finish.tv_nsec - start.tv_nsec) / 1000000;
+		else
+			elapsed -= (start.tv_nsec - finish.tv_nsec + 999999) /
+			           1000000;
+		require(result == -1 && futex_errno == ETIMEDOUT && elapsed < 300,
+		        "preserve futex timeout deadline");
+		require(!pthread_join(sender, 0), "join timed futex sender");
+		require(interrupt_count == before + 3 && !handler_error,
+		        "deliver timed futex signals");
+	}
+}
+
+static void test_ppoll_interruption(void)
+{
+	struct sender_request request;
+	pthread_t sender;
+	sigset_t block, empty, old, current;
+	int before, result;
+
+	install_interrupt_handler(SA_RESTART);
+	sigemptyset(&block);
+	sigaddset(&block, SIGUSR1);
+	require(!pthread_sigmask(SIG_BLOCK, &block, &old),
+	        "block ppoll signal");
+	before = interrupt_count;
+	request.target = pthread_self();
+	request.operation = SENDER_SIGNAL_ONLY;
+	request.child = 0;
+	request.observed_count = before;
+	require(!pthread_create(&sender, 0, interrupt_sender, &request),
+	        "create ppoll sender");
+	sigemptyset(&empty);
+	errno = 0;
+	result = ppoll(0, 0, 0, &empty);
+	require(result == -1 && errno == EINTR,
+	        "interrupt ppoll despite restart action");
+	require(!pthread_join(sender, 0), "join ppoll sender");
+	require(!pthread_sigmask(SIG_SETMASK, 0, &current) &&
+	        sigismember(&current, SIGUSR1) == 1,
+	        "restore ppoll signal mask");
+	require(interrupt_count == before + 1 && !handler_error,
+	        "deliver ppoll signal");
+	require(!pthread_sigmask(SIG_SETMASK, &old, 0),
+	        "restore ppoll caller mask");
+}
+
+static void test_wait_interruption(void)
+{
+	struct sender_request request;
+	pthread_t sender;
+	pid_t child, result;
+	int before, status;
+
+	install_interrupt_handler(0);
+	child = fork();
+	require(child >= 0, "fork interrupted wait child");
+	if (!child) {
+		for (;;)
+			__asm__ volatile("" ::: "memory");
+	}
+	before = interrupt_count;
+	request.target = pthread_self();
+	request.operation = SENDER_SIGNAL_ONLY;
+	request.child = child;
+	request.observed_count = before;
+	require(!pthread_create(&sender, 0, interrupt_sender, &request),
+	        "create wait interrupt sender");
+	errno = 0;
+	result = waitpid(child, &status, 0);
+	require(result == -1 && errno == EINTR,
+	        "interrupt wait without restart");
+	require(!pthread_join(sender, 0), "join wait interrupt sender");
+	require(interrupt_count == before + 1 && !handler_error,
+	        "deliver wait interrupt signal");
+	require(!kill(child, SIGTERM), "terminate interrupted wait child");
+	require(waitpid(child, &status, 0) == child && WIFSIGNALED(status),
+	        "reap interrupted wait child");
+
+	install_interrupt_handler(SA_RESTART);
+	child = fork();
+	require(child >= 0, "fork restarted wait child");
+	if (!child) {
+		for (;;)
+			__asm__ volatile("" ::: "memory");
+	}
+	before = interrupt_count;
+	request.operation = SENDER_KILL_CHILD;
+	request.child = child;
+	request.observed_count = before;
+	require(!pthread_create(&sender, 0, interrupt_sender, &request),
+	        "create wait restart sender");
+	result = waitpid(child, &status, 0);
+	require(result == child && WIFSIGNALED(status) &&
+	        WTERMSIG(status) == SIGTERM, "restart wait after handler");
+	require(!pthread_join(sender, 0), "join wait restart sender");
+	require(interrupt_count == before + 1 && !handler_error,
+	        "deliver restarted wait signal");
+}
+
+static void test_tty_interruption(void)
+{
+	struct sender_request request;
+	pthread_t sender;
+	char byte;
+	ssize_t result;
+	int before;
+
+	install_interrupt_handler(0);
+	before = interrupt_count;
+	request.target = pthread_self();
+	request.operation = SENDER_SIGNAL_ONLY;
+	request.child = 0;
+	request.observed_count = before;
+	require(!pthread_create(&sender, 0, interrupt_sender, &request),
+	        "create tty interrupt sender");
+	errno = 0;
+	result = read(STDIN_FILENO, &byte, sizeof(byte));
+	require(result == -1 && errno == EINTR,
+	        "interrupt blocking tty read");
+	require(!pthread_join(sender, 0), "join tty interrupt sender");
+	require(interrupt_count == before + 1 && !handler_error,
+	        "deliver tty interrupt signal");
+}
+
+static void test_pthread_cancellation(void)
+{
+	pthread_t thread;
+	void *result;
+
+	atomic_store(&cancel_ready, 0);
+	require(!pthread_create(&thread, 0, cancel_thread, 0),
+	        "create cancellable thread");
+	while (!atomic_load_explicit(&cancel_ready, memory_order_acquire))
+		;
+	require(!pthread_cancel(thread), "cancel blocked thread");
+	require(!pthread_join(thread, &result), "join cancelled thread");
+	require(result == PTHREAD_CANCELED, "observe pthread cancellation");
+}
+
+static void test_exit_group_pressure(void)
+{
+	pthread_t threads[EXIT_GROUP_THREADS];
+	pid_t child;
+	int round, status, index;
+
+	for (round = 0; round < EXIT_GROUP_ROUNDS; round++) {
+		child = fork();
+		require(child >= 0, "fork exit-group child");
+		if (!child) {
+			atomic_store(&exit_group_ready, 0);
+			exit_group_futex = 0;
+			for (index = 0; index < EXIT_GROUP_THREADS; index++) {
+				if (pthread_create(&threads[index], 0,
+				                   exit_group_thread, 0))
+					_exit(108);
+			}
+			while (atomic_load_explicit(&exit_group_ready,
+			                            memory_order_acquire) !=
+			       EXIT_GROUP_THREADS)
+				;
+			execl("/bin/signal-runtime", "signal-runtime",
+			      "exec-ok", NULL);
+			_exit(37);
+		}
+		require(waitpid(child, &status, 0) == child &&
+		        WIFEXITED(status) && !WEXITSTATUS(status),
+		        "exec multithreaded process group");
+	}
+	child = fork();
+	require(child >= 0, "fork forced exit child");
+	if (!child) {
+		atomic_store(&exit_group_ready, 0);
+		for (index = 0; index < EXIT_GROUP_THREADS; index++)
+			if (pthread_create(&threads[index], 0,
+			                   exit_group_socket_thread, 0))
+				_exit(107);
+		while (atomic_load_explicit(&exit_group_ready,
+		                            memory_order_acquire) !=
+		       EXIT_GROUP_THREADS)
+			;
+		if (delay_milliseconds(20))
+			_exit(109);
+		syscall(SYS_exit_group, 42);
+		_exit(110);
+	}
+	require(waitpid(child, &status, 0) == child && WIFEXITED(status) &&
+	        WEXITSTATUS(status) == 42,
+	        "force noninterruptible group exit");
+}
+
+int main(int argc, char **argv)
+{
+	if (argc == 2 && !strcmp(argv[1], "exec-reset")) {
+		raise(SIGUSR1);
+		return 109;
+	}
+	if (argc == 2 && !strcmp(argv[1], "exec-ignore")) {
+		raise(SIGUSR2);
+		return 0;
+	}
+	if (argc == 2 && !strcmp(argv[1], "exec-ok"))
+		return 0;
+	test_basic_delivery();
+	test_register_frame();
+	test_pending_and_wait();
+	test_default_ignored_wait();
+	test_pending_priority_and_realtime();
+	test_sigsuspend();
+	test_altstack();
+	test_thread_targeting();
+	test_process_signal_wake();
+	test_child_events();
+	test_child_auto_reap();
+	test_exec_dispositions();
+	test_fault_and_reset();
+	test_futex_interruption();
+	test_ppoll_interruption();
+	test_wait_interruption();
+	test_tty_interruption();
+	test_pthread_cancellation();
+	test_exit_group_pressure();
+	puts("SIGNAL_RUNTIME_OK");
+	return 0;
+}

--- a/tests/thread_clone.S
+++ b/tests/thread_clone.S
@@ -1,0 +1,25 @@
+.section .text
+.global test_clone
+.type test_clone, %function
+test_clone:
+	andi a1, a1, -16
+	addi a1, a1, -16
+	sd a0, 0(a1)
+	sd a3, 8(a1)
+	mv a0, a2
+	mv a2, a4
+	mv a3, a5
+	mv a4, a6
+	li a7, 220
+	ecall
+	beqz a0, .Lchild
+	ret
+
+.Lchild:
+	ld a1, 0(sp)
+	ld a0, 8(sp)
+	jalr a1
+	li a7, 93
+	ecall
+	unimp
+.size test_clone, .-test_clone

--- a/tests/thread_runtime.c
+++ b/tests/thread_runtime.c
@@ -1,0 +1,113 @@
+#define _GNU_SOURCE
+
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define THREADS 16
+#define STACK_SIZE (64 * 1024)
+
+struct worker {
+	volatile int child_tid;
+	volatile int parent_tid;
+	volatile int observed_tid;
+	volatile int observed_pid;
+};
+
+static unsigned char stacks[THREADS][STACK_SIZE]
+	__attribute__((aligned(16)));
+static struct worker workers[THREADS];
+static volatile int gate;
+static volatile int started;
+
+extern int test_clone(int (*function)(void *), void *stack, int flags,
+		      void *argument, int *parent_tid, void *tls,
+		      int *child_tid);
+
+static long raw_syscall0(long number)
+{
+	register long a7 __asm__("a7") = number;
+	register long a0 __asm__("a0");
+
+	__asm__ volatile("ecall" : "=r"(a0) : "r"(a7) : "memory");
+	return a0;
+}
+
+static int worker_main(void *argument)
+{
+	struct worker *worker = argument;
+
+	worker->observed_tid = raw_syscall0(SYS_gettid);
+	worker->observed_pid = raw_syscall0(SYS_getpid);
+	__atomic_add_fetch(&started, 1, __ATOMIC_RELEASE);
+	while (!__atomic_load_n(&gate, __ATOMIC_ACQUIRE))
+		;
+	return 0;
+}
+
+static int fail(const char *reason)
+{
+	printf("THREAD_RUNTIME_FAIL %s\n", reason);
+	return 1;
+}
+
+int main(void)
+{
+	const int flags = CLONE_VM | CLONE_FS | CLONE_FILES |
+		CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM |
+		CLONE_PARENT_SETTID | CLONE_CHILD_SETTID |
+		CLONE_CHILD_CLEARTID;
+	int leader_pid = getpid();
+	int leader_tid = syscall(SYS_gettid);
+	unsigned long spins;
+	int i, j, tid;
+
+	if (leader_pid != leader_tid)
+		return fail("leader pid/tid");
+	for (i = 0; i < THREADS; i++) {
+		workers[i].child_tid = -1;
+		workers[i].parent_tid = -1;
+		tid = test_clone(worker_main, stacks[i] + STACK_SIZE, flags,
+		                 &workers[i],
+		                 (int *)&workers[i].parent_tid,
+		                 (void *)0,
+		                 (int *)&workers[i].child_tid);
+		if (tid <= 0 || workers[i].parent_tid != tid ||
+		    workers[i].child_tid != tid)
+			return fail("clone tid");
+	}
+	for (spins = 0; spins < 100000000UL; spins++) {
+		if (__atomic_load_n(&started, __ATOMIC_ACQUIRE) == THREADS)
+			break;
+	}
+	if (started != THREADS)
+		return fail("start timeout");
+	__atomic_store_n(&gate, 1, __ATOMIC_RELEASE);
+	for (spins = 0; spins < 100000000UL; spins++) {
+		int complete = 1;
+
+		for (i = 0; i < THREADS; i++) {
+			if (__atomic_load_n(&workers[i].child_tid,
+			                    __ATOMIC_ACQUIRE) != 0) {
+				complete = 0;
+				break;
+			}
+		}
+		if (complete)
+			break;
+	}
+	for (i = 0; i < THREADS; i++) {
+		if (workers[i].child_tid != 0 ||
+		    workers[i].observed_pid != leader_pid ||
+		    workers[i].observed_tid != workers[i].parent_tid)
+			return fail("thread identity");
+		for (j = 0; j < i; j++) {
+			if (workers[i].observed_tid == workers[j].observed_tid)
+				return fail("duplicate tid");
+		}
+	}
+	puts("THREAD_CLONE_OK");
+	return 0;
+}


### PR DESCRIPTION
Caffeinix can run dynamic musl programs, but its single-user-thread
process model and incomplete signal state prevent unmodified pthread
workloads. Concurrent traps also select their trapframe through
process-global state, which is unsafe across harts.

Make trapframe selection hart-local and separate process-owned
resources from per-thread execution state. Add Linux thread-group
cloning, the futex operations and private expedited membarriers used
by musl, and Linux RV64 signal delivery with masks, alternate stacks,
interrupted waits, and restart semantics. Reference-count physical
pages so syscall buffers remain pinned across concurrent unmap and
thread exit.

Remove a pre-existing wall-clock assumption from the socket linger
selftest so SMP scheduling cannot fail unrelated runs. The runtime
suite exercises dynamic musl pthread and signal workloads on one- and
multi-hart QEMU guests and checks the ABI against Linux RISC-V headers.